### PR TITLE
[Docs] Align EdgeQL/TypeScript examples

### DIFF
--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -412,15 +412,15 @@ Every new set of curly braces introduces a new scope. You can add ``filter``,
 
   .. code-tab:: typescript
 
-    e.select(e.Movie, movie => ({
+    const query = e.select(e.Movie, movie => ({
       title: true,
-      characters: c => ({
+      actors: actor => ({
         name: true,
-        filter: e.op(c.name, "ilike", "chris%"),
+        filter: e.op(actor.name, "ilike", "chris%"),
       }),
       filter: e.op(movie.title, "ilike", "%avengers%"),
     }));
-    // => { characters: { name: string; }[]; title: string; }[]
+    // => { actors: { name: string; }[]; title: string; }[]
 
     const result = await query.run(client);
     // {id: string; title: number}[]

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -684,9 +684,9 @@ executing a query.
     client = edgedb.create_async_client()
 
     async def main():
-
-        result = await client.query("select <str>$param", param="Play it, Sam.")
-        # => "Play it, Sam"
+        query = "select <str>$param"
+        result = await client.query(query, param="Play it, Sam.")
+        # => "Play it, Sam."
 
   .. code-tab:: go
 

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -855,13 +855,16 @@ groupings of objects.
       const release_year = movie.release_year;
       return {
         title: true,
+        actors: {
+          name: true
+        },
         by: {release_year},
       };
     });
     /* {
       grouping: string[];
       key: { release_year: number | null };
-      elements: { title: string; }[];
+      elements: { title: string, actors: {name: string}[];
     }[] */
 
 See :ref:`Docs > EdgeQL > Group <ref_eql_group>`.

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -611,6 +611,7 @@ The ``delete`` statement can contain ``filter``, ``order by``, ``offset``, and
 
     const query = e.delete(e.Movie, (movie) => ({
       filter: e.op(movie.title, 'ilike', "the avengers%"),
+      limit: 3
     }));
 
     const result = await query.run(client);

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -874,7 +874,7 @@ groupings of objects.
     /* {
       grouping: string[];
       key: { release_year: number | null };
-      elements: { title: string, actors: {name: string}[];
+      elements: { title: string; actors: {name: string}[] }[];
     }[] */
 
 See :ref:`Docs > EdgeQL > Group <ref_eql_group>`.

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -231,7 +231,7 @@ Similarly, it provides a comprehensive set of built-in operators.
     // boolean
     e.op(e.int64(2), "+", e.int64(2));
     // number
-    e.op(e.str("Hello "), "++", e.str("World!"));
+    e.op(e.str("Hello"), "++", e.str(" world!"));
     // string
     e.op(e.str("😄"), "if", e.bool(true), "else", e.str("😢"));
     // string

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -741,7 +741,7 @@ useful, for instance, when performing nested mutations.
     }));
 
     // select actors
-    const actors = e.select(e.Person, person => ({
+    const benedicts = e.select(e.Person, person => ({
       filter: e.op(person.name, 'in', e.set(
         'Benedict Cumberbatch',
         'Benedict Wong'
@@ -750,7 +750,7 @@ useful, for instance, when performing nested mutations.
 
     // add actors to cast of drStrange
     const query = e.update(drStrange, ()=>({
-      actors: { "+=": actors }
+      actors: { "+=": benedicts }
     }));
 
 We can also use subqueries to fetch properties of an object we just inserted.

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -678,7 +678,7 @@ executing a query.
 
     async def main():
 
-        result = await client.query("select <str>$param", param="Play it, Sam")
+        result = await client.query("select <str>$param", param="Play it, Sam.")
         # => "Play it, Sam"
 
   .. code-tab:: go

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -354,7 +354,7 @@ Fetch linked objects with a nested shape.
     }));
 
     const result = await query.run(client);
-    // {id: string; title: string, actors: {name: string}[]}[]
+    // {id: string; title: string; actors: {name: string}[]}[]
 
 See :ref:`Docs > EdgeQL > Select > Shapes <ref_eql_shapes>`.
 
@@ -503,11 +503,13 @@ Selection shapes can contain computed properties.
 
   .. code-tab:: typescript
 
-    e.select(e.Movie, movie => ({
+    const query = e.select(e.Movie, movie => ({
       title: true,
       title_upper: e.str_upper(movie.title),
       cast_size: e.count(movie.actors)
-    }))
+    }));
+
+    const result = await query.run(client);
     // {title: string; title_upper: string; cast_size: number}[]
 
 A common use for computed properties is to query a link in reverse; this is
@@ -526,13 +528,15 @@ known as a *backlink* and it has special syntax.
 
   .. code-tab:: typescript
 
-    e.select(e.Person, person => ({
+    const query = e.select(e.Person, person => ({
       name: true,
       acted_in: e.select(person["<actors[is Content]"], () => ({
         title: true,
       })),
     }));
-    // {name: string; acted_in: {title: string}[];}[]
+
+    const result = await query.run(client);
+    // {name: string; acted_in: {title: string}[]}[]
 
 See :ref:`Docs > EdgeQL > Select > Computed <ref_eql_select>` and
 :ref:`Docs > EdgeQL > Select > Backlinks <ref_eql_select>`.
@@ -580,7 +584,7 @@ subtracted from with ``-=``, or overridden with ``:=``.
 
   .. code-tab:: typescript
 
-    e.update(e.Movie, (movie) => ({
+    const query = e.update(e.Movie, (movie) => ({
       filter: e.op(movie.title, '=', 'Doctor Strange 2'),
       set: {
         actors: {
@@ -590,6 +594,9 @@ subtracted from with ``-=``, or overridden with ``:=``.
         }
       },
     }));
+
+    const result = await query.run(client);
+    // {id: string}
 
 See :ref:`Docs > EdgeQL > Update <ref_eql_update>`.
 
@@ -752,6 +759,9 @@ useful, for instance, when performing nested mutations.
     const query = e.update(drStrange, ()=>({
       actors: { "+=": benedicts }
     }));
+    
+    const result = await query.run(client);
+    // {id: string}
 
 We can also use subqueries to fetch properties of an object we just inserted.
 

--- a/docs/intro/edgeql.rst
+++ b/docs/intro/edgeql.rst
@@ -824,13 +824,13 @@ properties from known subtypes.
 
     const query = e.select(e.Content, (content) => ({
       title: true,
-      ...e.is(e.Movie, {release_year: true}),
       ...e.is(e.TVShow, {num_seasons: true}),
+      ...e.is(e.Movie, {release_year: true}),
     }));
     /* {
       title: string;
-      release_year: number | null;
       num_seasons: number | null;
+      release_year: number | null;
     }[] */
 
 See :ref:`Docs > EdgeQL > Select > Polymorphic queries


### PR DESCRIPTION
I spotted a few places where the EdgeQL and TypeScript variants were inconsistent with each other.
I also added in the results of `query.run` to all the TypeScript variants that were missing them to make them consistent.