### PR TITLE
Allow directly nested arrays of arrays

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -338,13 +338,6 @@ def compile_Tuple(expr: qlast.Tuple, *, ctx: context.ContextLevel) -> irast.Set:
 @dispatch.compile.register(qlast.Array)
 def compile_Array(expr: qlast.Array, *, ctx: context.ContextLevel) -> irast.Set:
     elements = [dispatch.compile(e, ctx=ctx) for e in expr.elements]
-    # check that none of the elements are themselves arrays
-    for el, expr_el in zip(elements, expr.elements):
-        if isinstance(setgen.get_set_type(el, ctx=ctx), s_abc.Array):
-            raise errors.QueryError(
-                f'nested arrays are not supported',
-                span=expr_el.span)
-
     return setgen.new_array_set(elements, ctx=ctx, span=expr.span)
 
 

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -400,6 +400,7 @@ def compile_FunctionCall(
         is_singleton_set_of=func.get_is_singleton_set_of(env.schema),
         global_args=global_args,
         span=expr.span,
+        return_polymorphism=matched_call.return_polymorphism,
     )
 
     # Apply special function handling
@@ -922,6 +923,7 @@ def compile_operator(
         prefer_subquery_args=oper.get_prefer_subquery_args(env.schema),
         is_singleton_set_of=is_singleton_set_of,
         span=qlexpr.span,
+        return_polymorphism=matched_call.return_polymorphism,
     )
 
     _check_free_shape_op(node, ctx=ctx)
@@ -1203,8 +1205,13 @@ def finalize_args(
             if ctx.path_scope.is_optional(orig_arg_val.path_id):
                 pathctx.register_set_in_scope(arg_val, optional=True, ctx=ctx)
 
-        arg = irast.CallArg(expr=arg_val, expr_type_path_id=arg_type_path_id,
-            is_default=barg.is_default, param_typemod=param_mod)
+        arg = irast.CallArg(
+            expr=arg_val,
+            expr_type_path_id=arg_type_path_id,
+            is_default=barg.is_default,
+            param_typemod=param_mod,
+            polymorphism=barg.polymorphism,
+        )
         param_shortname = param.get_parameter_name(ctx.env.schema)
         if param_kind is ft.ParameterKind.NamedOnlyParam:
             args[param_shortname] = arg

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -633,13 +633,7 @@ def try_bind_call_args(
 
     return_polymorphism = ft.Polymorphism.NotUsed
     if return_type.is_polymorphic(schema):
-        return_polymorphism = (
-            ft.Polymorphism.Simple
-            if not return_type.is_collection() else
-            ft.Polymorphism.Array
-            if return_type.is_array() else
-            ft.Polymorphism.Collection
-        )
+        return_polymorphism = ft.Polymorphism.from_schema_type(return_type)
 
         if resolved_poly_base_type is not None:
             ctx.env.schema, return_type = return_type.to_nonpolymorphic(
@@ -654,13 +648,7 @@ def try_bind_call_args(
             if barg.param_type.is_polymorphic(schema):
                 ctx.env.schema, ptype = barg.param_type.to_nonpolymorphic(
                     ctx.env.schema, resolved_poly_base_type)
-                polymorphism = (
-                    ft.Polymorphism.Simple
-                    if not barg.param_type.is_collection() else
-                    ft.Polymorphism.Array
-                    if barg.param_type.is_array() else
-                    ft.Polymorphism.Collection
-                )
+                polymorphism = ft.Polymorphism.from_schema_type(barg.param_type)
                 bound_param_args[i] = BoundArg(
                     barg.param,
                     ptype,

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -69,6 +69,7 @@ class BoundArg(NamedTuple):
     cast_distance: int
     arg_id: Optional[int | str]
     is_default: bool = False
+    polymorphism: ft.Polymorphism = ft.Polymorphism.NotUsed
 
 
 class MissingArg(NamedTuple):
@@ -85,6 +86,7 @@ class BoundCall(NamedTuple):
     return_type: s_types.Type
     variadic_arg_id: Optional[int]
     variadic_arg_count: Optional[int]
+    return_polymorphism: ft.Polymorphism = ft.Polymorphism.NotUsed
 
     server_param_conversions: Optional[dict[
         str,
@@ -629,7 +631,16 @@ def try_bind_call_args(
         bound_param_args.insert(
             0, BoundArg(None, bytes_t, bm_set, bytes_t, 0, None))
 
+    return_polymorphism = ft.Polymorphism.NotUsed
     if return_type.is_polymorphic(schema):
+        return_polymorphism = (
+            ft.Polymorphism.Simple
+            if not return_type.is_collection() else
+            ft.Polymorphism.Array
+            if return_type.is_array() else
+            ft.Polymorphism.Collection
+        )
+
         if resolved_poly_base_type is not None:
             ctx.env.schema, return_type = return_type.to_nonpolymorphic(
                 ctx.env.schema, resolved_poly_base_type)
@@ -643,6 +654,13 @@ def try_bind_call_args(
             if barg.param_type.is_polymorphic(schema):
                 ctx.env.schema, ptype = barg.param_type.to_nonpolymorphic(
                     ctx.env.schema, resolved_poly_base_type)
+                polymorphism = (
+                    ft.Polymorphism.Simple
+                    if not barg.param_type.is_collection() else
+                    ft.Polymorphism.Array
+                    if barg.param_type.is_array() else
+                    ft.Polymorphism.Collection
+                )
                 bound_param_args[i] = BoundArg(
                     barg.param,
                     ptype,
@@ -650,6 +668,7 @@ def try_bind_call_args(
                     barg.valtype,
                     barg.cast_distance,
                     barg.arg_id,
+                    polymorphism=polymorphism
                 )
 
     return BoundCall(
@@ -659,6 +678,7 @@ def try_bind_call_args(
         return_type,
         variadic_arg_id,
         variadic_arg_count,
+        return_polymorphism=return_polymorphism,
         server_param_conversions=server_param_conversions,
     )
 

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -57,6 +57,13 @@ class TypeModifier(s_enum.StrEnum):
             return ''
 
 
+class Polymorphism(s_enum.StrEnum):
+    NotUsed = 'NotUsed'
+    Simple = 'Simple'
+    Array = 'Array'
+    Collection = 'Collection'
+
+
 class OperatorKind(s_enum.StrEnum):
     Infix = 'Infix'
     Postfix = 'Postfix'

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -28,6 +28,8 @@ from edb.common import enum as s_enum
 if TYPE_CHECKING:
     T = TypeVar("T", covariant=True)
 
+    from edb.schema import types as s_types
+
 
 class ParameterKind(s_enum.StrEnum):
     VariadicParam = 'VariadicParam'
@@ -62,6 +64,16 @@ class Polymorphism(s_enum.StrEnum):
     Simple = 'Simple'
     Array = 'Array'
     Collection = 'Collection'
+
+    @staticmethod
+    def from_schema_type(type: s_types.Type) -> Polymorphism:
+        return (
+            Polymorphism.Simple
+            if not type.is_collection() else
+            Polymorphism.Array
+            if type.is_array() else
+            Polymorphism.Collection
+        )
 
 
 class OperatorKind(s_enum.StrEnum):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -953,6 +953,7 @@ class CallArg(ImmutableBase):
     multiplicity: qltypes.Multiplicity = qltypes.Multiplicity.UNKNOWN
     is_default: bool = False
     param_typemod: qltypes.TypeModifier
+    polymorphism: qltypes.Polymorphism = qltypes.Polymorphism.NotUsed
 
 
 class Call(ImmutableExpr):
@@ -1003,6 +1004,11 @@ class Call(ImmutableExpr):
 
     # If this is a set of call but is allowed in singleton expressions.
     is_singleton_set_of: typing.Optional[bool] = None
+
+    # The polymorphism of the return type
+    # This is used to identify cases where polymorphism needs to be handled in
+    # a specialized way (eg. arrays of arrays).
+    return_polymorphism: qltypes.Polymorphism = qltypes.Polymorphism.NotUsed
 
 
 class FunctionCall(Call):

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -129,6 +129,40 @@ def tuple_getattr(
     return set_expr
 
 
+def array_get_inner_array(
+    wrapped_array: pgast.BaseExpr,
+    array_typeref: irast.TypeRef,
+) -> pgast.BaseExpr:
+    # Nested arrays wrap their inner arrays in a tuple
+    return pgast.SelectStmt(
+        target_list=[
+            pgast.ResTarget(val=pgast.ColumnRef(name=['0'])),
+        ],
+        from_clause=[
+            pgast.RangeFunction(
+                functions=[
+                    pgast.FuncCall(
+                        name=('unnest',),
+                        args=[
+                            pgast.ArrayExpr(
+                                elements=[wrapped_array],
+                            )
+                        ],
+                        coldeflist=[
+                            pgast.ColumnDef(
+                                name='0',
+                                typename=pgast.TypeName(
+                                    name=pg_types.pg_type_from_ir_typeref(array_typeref)
+                                )
+                            )
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+
 def is_null_const(expr: pgast.BaseExpr) -> bool:
     if isinstance(expr, pgast.TypeCast):
         expr = expr.arg

--- a/edb/pgsql/compiler/astutils.py
+++ b/edb/pgsql/compiler/astutils.py
@@ -133,7 +133,63 @@ def array_get_inner_array(
     wrapped_array: pgast.BaseExpr,
     array_typeref: irast.TypeRef,
 ) -> pgast.BaseExpr:
-    # Nested arrays wrap their inner arrays in a tuple
+    """Unwrap and get the inner array of a formerly nested array.
+
+    Since array<array<...>> is implemented as array<tuple<array<...>>>, when
+    an element is accessed, it needs to be unwrapped.
+
+    Essentially, this function takes tuple<array<...>> and returns array<...>
+
+    Postgres does not support arbitrarily accessing fields out of unnamed
+    composites and so we need to do an extra unnest(array[]) to be able to
+    specify the name and type our resulting array.
+
+    For example, the query: `select [[1]][0];` will produce the following SQL:
+
+    SELECT
+            "expr-6~2"."array_value~4" AS "array_serialized~1"
+        FROM
+            LATERAL
+            (SELECT
+                    "expr-5~2"."array_value~3" AS "array_value~4"
+                FROM
+                    LATERAL
+                    (SELECT
+                            (SELECT
+                                    "0"
+                                FROM
+                                    -- EXTRA unnest(array[])
+                                    unnest(ARRAY[
+                                        -- INDEX INDIRECTION
+                                        edgedb_v7_2f26206480._index(
+                                            "expr-3~2"."array_value~2",
+                                            ($2)::int8,
+                                            'ERROR MESSAGE'
+                                        )
+                                    ]) AS ("0" int8[])
+                            ) AS "array_value~3"
+                        FROM
+                            LATERAL
+                            -- INITAL ARRAY [[1]]
+                            (SELECT
+                                    ARRAY[ROW("expr-2~2"."array_value~1")]
+                                    AS "array_value~2"
+                                FROM
+                                    LATERAL
+                                    (SELECT
+                                            ARRAY[($1)::int8]
+                                            AS "array_value~1"
+                                    ) AS "expr-2~2"
+                            ) AS "expr-3~2"
+                    ) AS "expr-5~2"
+            ) AS "expr-6~2"
+        WHERE
+            ("expr-6~2"."array_value~4" IS NOT NULL)
+        LIMIT
+        (SELECT
+                (101)::int8 AS "expr~7_value~1"
+        )
+    """
     return pgast.SelectStmt(
         target_list=[
             pgast.ResTarget(val=pgast.ColumnRef(name=['0'])),

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -199,12 +199,12 @@ def array_as_json_object(
                     )
 
             json_func = 'build_object' if is_named else 'build_array'
-            serialized_inner_array = _build_json(json_func, json_args, env=env)
+            agg_arg = _build_json(json_func, json_args, env=env)
 
             needs_unnest = bool(el_type.subtypes)
         else:
             val = pgast.ColumnRef(name=[out_alias])
-            serialized_inner_array = serialize_expr_to_json(
+            agg_arg = serialize_expr_to_json(
                 val, styperef=el_type, nested=True, env=env)
             needs_unnest = True
 
@@ -215,7 +215,7 @@ def array_as_json_object(
                         args=[
                             pgast.FuncCall(
                                 name=_get_json_func('agg', env=env),
-                                args=[serialized_inner_array],
+                                args=[agg_arg],
                             ),
                             pgast.StringConstant(val='[]'),
                         ]

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -239,6 +239,14 @@ def array_as_json_object(
         )
     elif irtyputils.is_array(el_type):
         # array<array<...>> implemented as array<tuple<array<...>>>
+        #
+        # If we serialize without any special handling, the tuple will be
+        # included, with the key 'f1'
+        #
+        # eg. [[1, 2, 3], [4, 5]] -> [{'f1': [1,2,3]}, {'f1': [4,5]}]
+        #
+        # To prevent this, we need to explicitly serialize the inner arrays then
+        # aggregate them.
         el_name = 'f1'
         coldeflist = [
             pgast.ColumnDef(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -2308,11 +2308,26 @@ def process_set_as_const_set(
 def process_set_as_oper_expr(
     ir_set: irast.SetE[irast.OperatorCall], *, ctx: context.CompilerContextLevel
 ) -> SetRVars:
+    has_array_polymorphic_arg = any(
+        ir_arg.polymorphism == qltypes.Polymorphism.Array
+        for ir_arg in ir_set.expr.args.values()
+    )
+    unwrap_array_return = (
+        has_array_polymorphic_arg
+        and ir_set.expr.return_polymorphism == qltypes.Polymorphism.Simple
+        and irtyputils.is_array(ir_set.expr.typeref)
+    )
+
     # XXX: do we need a subrel?
     with ctx.new() as newctx:
         newctx.expr_exposed = False
         args = _compile_call_args(ir_set, ctx=newctx)
         oper_expr = exprcomp.compile_operator(ir_set.expr, args, ctx=newctx)
+
+        if unwrap_array_return:
+            oper_expr = astutils.array_get_inner_array(
+                oper_expr, ir_set.expr.typeref
+            )
 
     pathctx.put_path_value_var_if_not_exists(
         ctx.rel, ir_set.path_id, oper_expr
@@ -3243,10 +3258,13 @@ def _process_set_func_with_ordinality(
 
 
 def _process_set_func(
-        ir_set: irast.Set, *,
-        func_name: tuple[str, ...],
-        args: list[pgast.BaseExpr],
-        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
+    ir_set: irast.Set,
+    *,
+    func_name: tuple[str, ...],
+    args: list[pgast.BaseExpr],
+    ctx: context.CompilerContextLevel,
+    unwrap_array_return: bool,
+) -> pgast.BaseExpr:
     expr = ir_set.expr
     assert isinstance(expr, irast.FunctionCall)
 
@@ -3272,6 +3290,16 @@ def _process_set_func(
         colnames = list(subtypes)
     else:
         colnames = [ctx.env.aliases.get('v')]
+
+        if unwrap_array_return:
+            coldeflist = [
+                pgast.ColumnDef(
+                    name='v',
+                    typename=pgast.TypeName(
+                        name=pg_types.pg_type_from_ir_typeref(expr.typeref)
+                    )
+                )
+            ]
 
     if (
         # SQL functions declared with OUT params or returning
@@ -3415,6 +3443,15 @@ def _compile_call_args(
     expr = ir_set.expr
     assert isinstance(expr, irast.Call)
 
+    has_array_polymorphic_arg = any(
+        ir_arg.polymorphism == qltypes.Polymorphism.Array
+        for ir_arg in expr.args.values()
+    )
+    wrap_single_polymorphic_args = (
+        has_array_polymorphic_arg
+        or expr.return_polymorphism == qltypes.Polymorphism.Array
+    )
+
     args = []
 
     if isinstance(expr, irast.FunctionCall) and expr.global_args:
@@ -3451,6 +3488,14 @@ def _compile_call_args(
         else:
             arg_ref = dispatch.compile(ir_arg.expr, ctx=ctx)
             arg_ref = output.output_as_value(arg_ref, env=ctx.env)
+
+        if (
+            wrap_single_polymorphic_args
+            and ir_arg.polymorphism == qltypes.Polymorphism.Simple
+            and irtyputils.is_array(ir_arg.expr.typeref)
+        ):
+            arg_ref = pgast.RowExpr(args=[arg_ref])
+
         args.append(arg_ref)
         _compile_arg_null_check(expr, ir_arg, arg_ref, typemod, ctx=ctx)
 
@@ -3634,6 +3679,16 @@ def process_set_as_func_expr(
     expr = ir_set.expr
     assert isinstance(expr, irast.FunctionCall)
 
+    has_array_polymorphic_arg = any(
+        ir_arg.polymorphism == qltypes.Polymorphism.Array
+        for ir_arg in expr.args.values()
+    )
+    unwrap_array_return = (
+        has_array_polymorphic_arg
+        and expr.return_polymorphism == qltypes.Polymorphism.Simple
+        and irtyputils.is_array(expr.typeref)
+    )
+
     with ctx.subrel() as newctx:
         newctx.expr_exposed = False
 
@@ -3648,6 +3703,11 @@ def process_set_as_func_expr(
                 newctx.rel, ir_set.path_id, expr.body.path_id
             )
 
+            if unwrap_array_return:
+                set_expr = astutils.array_get_inner_array(
+                    set_expr, expr.typeref
+                )
+
         else:
             args = _compile_call_args(ir_set, ctx=newctx)
 
@@ -3655,9 +3715,20 @@ def process_set_as_func_expr(
 
             if expr.typemod is qltypes.TypeModifier.SetOfType:
                 set_expr = _process_set_func(
-                    ir_set, func_name=name, args=args, ctx=newctx)
+                    ir_set,
+                    func_name=name,
+                    args=args,
+                    ctx=newctx,
+                    unwrap_array_return=unwrap_array_return,
+                )
+
             else:
                 set_expr = pgast.FuncCall(name=name, args=args)
+
+                if unwrap_array_return:
+                    set_expr = astutils.array_get_inner_array(
+                        set_expr, expr.typeref
+                    )
 
         if expr.error_on_null_result:
             set_expr = pgast.FuncCall(
@@ -3706,6 +3777,20 @@ def process_set_as_agg_expr_inner(
     expr = ir_set.expr
     assert isinstance(expr, irast.FunctionCall)
     stmt = ctx.rel
+
+    has_array_polymorphic_arg = any(
+        ir_arg.polymorphism == qltypes.Polymorphism.Array
+        for ir_arg in expr.args.values()
+    )
+    wrap_single_polymorphic_args = (
+        has_array_polymorphic_arg
+        or expr.return_polymorphism == qltypes.Polymorphism.Array
+    )
+    unwrap_array_return = (
+        has_array_polymorphic_arg
+        and expr.return_polymorphism == qltypes.Polymorphism.Simple
+        and irtyputils.is_array(expr.typeref)
+    )
 
     set_expr: pgast.BaseExpr
 
@@ -3828,6 +3913,14 @@ def process_set_as_agg_expr_inner(
 
                         query.sort_clause = []
 
+                if (
+                    wrap_single_polymorphic_args
+                    and ir_call_arg.polymorphism == qltypes.Polymorphism.Simple
+                    and irtyputils.is_array(ir_arg.expr.typeref)
+                ):
+                    # Wrap aggregated arrays in a tuple
+                    arg_ref = pgast.RowExpr(args=[arg_ref])
+
                 args.append(arg_ref)
 
         name = exprcomp.get_func_call_backend_name(expr, ctx=newctx)
@@ -3835,6 +3928,11 @@ def process_set_as_agg_expr_inner(
         set_expr = pgast.FuncCall(
             name=name, args=args, agg_order=agg_sort, agg_filter=agg_filter,
             ser_safe=serialization_safe and all(x.ser_safe for x in args))
+
+        if unwrap_array_return:
+            set_expr = astutils.array_get_inner_array(
+                set_expr, expr.typeref
+            )
 
         if for_group_by and not expr.impl_is_strict:
             # If we are doing this for a GROUP BY, and the function is not

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3213,7 +3213,7 @@ def _process_nested_array_set_func_with_ordinality(
     ir_set: irast.Set,
     *,
     outer_func_set: irast.Set,
-    args: List[pgast.BaseExpr],
+    args: list[pgast.BaseExpr],
     ctx: context.CompilerContextLevel
 ) -> _FuncWithOrdinalityInfo:
     # array<array<...>> is implemented as array<tuple<array<...>>>
@@ -3328,8 +3328,8 @@ def _process_set_func_with_ordinality(
     ir_set: irast.Set,
     *,
     outer_func_set: irast.Set,
-    func_name: Tuple[str, ...],
-    args: List[pgast.BaseExpr],
+    func_name: tuple[str, ...],
+    args: list[pgast.BaseExpr],
     ctx: context.CompilerContextLevel
 ) -> pgast.BaseExpr:
     expr = ir_set.expr

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3205,7 +3205,7 @@ def _process_typical_set_func_with_ordinality(
         colnames=colnames,
         inner_expr=inner_expr,
         arg_is_tuple=arg_is_tuple,
-        nullable=fexpr.nullable,
+        nullable=bool(fexpr.nullable),
     )
 
 
@@ -3244,7 +3244,7 @@ def _process_nested_array_set_func_with_ordinality(
                 val=pgast.ColumnRef(name=[colname]),
                 name=colname
             )
-            for colname in alias.colnames
+            for colname in colnames
         ],
         from_clause=[
             pgast.RangeFunction(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -4088,6 +4088,9 @@ def process_set_as_array_expr(
 
     for ir_element in expr.elements:
         element = dispatch.compile(ir_element, ctx=ctx)
+        if irtyputils.is_array(ir_element.typeref):
+            # Wrap nested arrays in a tuple
+            element = pgast.RowExpr(args=[element])
         elements.append(element)
 
         if serializing:

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -382,6 +382,8 @@ def pg_type_from_ir_typeref(
                 or (irtyputils.is_abstract(ir_typeref.subtypes[0])
                     and irtyputils.is_scalar(ir_typeref.subtypes[0]))):
             return ('anyarray',)
+        elif (irtyputils.is_array(ir_typeref.subtypes[0])):
+            return ('record[]',)
         else:
             tp = pg_type_from_ir_typeref(
                 ir_typeref.subtypes[0],

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -382,7 +382,7 @@ def pg_type_from_ir_typeref(
                 or (irtyputils.is_abstract(ir_typeref.subtypes[0])
                     and irtyputils.is_scalar(ir_typeref.subtypes[0]))):
             return ('anyarray',)
-        elif (irtyputils.is_array(ir_typeref.subtypes[0])):
+        elif irtyputils.is_array(ir_typeref.subtypes[0]):
             return ('record[]',)
         else:
             tp = pg_type_from_ir_typeref(

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -288,6 +288,9 @@ class Type(
     def is_sequence(self, schema: s_schema.Schema) -> bool:
         return False
 
+    def is_array_of_arrays(self, schema: s_schema.Schema) -> bool:
+        return False
+
     def is_array_of_tuples(self, schema: s_schema.Schema) -> bool:
         return False
 
@@ -321,6 +324,10 @@ class Type(
 
     def find_array(self, schema: s_schema.Schema) -> Optional[Type]:
         return self.find_predicate(lambda x: x.is_array(), schema)
+
+    def contains_array_of_array(self, schema: s_schema.Schema) -> bool:
+        return self.contains_predicate(
+            lambda x: x.is_array_of_arrays(schema), schema)
 
     def contains_array_of_tuples(self, schema: s_schema.Schema) -> bool:
         return self.contains_predicate(
@@ -1293,6 +1300,9 @@ class Array(
         return type(self).generate_name(
             self.get_element_type(schema).get_name(schema),
         )
+
+    def is_array_of_arrays(self, schema: s_schema.Schema) -> bool:
+        return self.get_element_type(schema).is_array()
 
     def is_array_of_tuples(self, schema: s_schema.Schema) -> bool:
         return self.get_element_type(schema).is_tuple(schema)

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1452,10 +1452,6 @@ class Array(
                 f'unexpected number of subtypes, expecting 1: {subtypes!r}')
         stype = subtypes[0]
 
-        if isinstance(stype, Array):
-            raise errors.UnsupportedFeatureError(
-                f'nested arrays are not supported')
-
         # One-dimensional unbounded array.
         dimensions = [-1]
 

--- a/tests/schemas/cards.esdl
+++ b/tests/schemas/cards.esdl
@@ -170,3 +170,19 @@ global HighestCost := (
 global CardsWithText := (
     SELECT Card FILTER exists(.text)
 );
+
+alias AliasArrayOfArrayOfScalar := [[1, 2, 3], [4, 5, 6]];
+global GlobalArrayOfArrayOfScalar := [[1, 2, 3], [4, 5, 6]];
+
+alias AliasCardsByCost := array_agg((
+    for cost in range_unpack(range(0, max(Card.cost) + 1))
+        select array_agg(
+            (select Card filter .cost = cost)
+        )
+));
+global GlobalCardsByCost := array_agg((
+    for cost in range_unpack(range(0, max(Card.cost) + 1))
+        select array_agg(
+            (select Card filter .cost = cost)
+        )
+));

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -1303,3 +1303,36 @@ class TestEdgeQLExprAliases(tb.QueryTestCase):
             ''',
             []
         )
+
+    async def test_edgeql_aliases_array_of_array_01(self):
+        await self.assert_query_result(
+            r"""
+                select AliasArrayOfArrayOfScalar;
+            """,
+            [
+                [[1, 2, 3], [4, 5, 6]],
+            ],
+        )
+
+    async def test_edgeql_aliases_array_of_array_02(self):
+        await self.assert_query_result(
+            r"""
+                select array_agg((
+                    for card_group in array_unpack(AliasCardsByCost)
+                        select array_agg((
+                            for card in array_unpack(card_group)
+                                select card.name
+                        ))
+                ))
+            """,
+            [
+                [
+                    tb.bag([]),
+                    tb.bag(['Imp', 'Dwarf', 'Sprite']),
+                    tb.bag(['Bog monster', 'Giant eagle']),
+                    tb.bag(['Giant turtle', 'Golem']),
+                    tb.bag(['Djinn']),
+                    tb.bag(['Dragon']),
+                ],
+            ],
+        )

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -3426,32 +3426,202 @@ class TestExpressions(tb.QueryTestCase):
         )
 
     async def test_edgeql_expr_array_10(self):
-        with self.assertRaisesRegex(edgedb.QueryError, 'nested array'):
-            await self.con.execute(r'''
+        # Basic arrays of arrays
+        await self.assert_query_result(
+            'select <array<array<int64>>>{}',
+            [],
+        )
+        await self.assert_query_result(
+            'select <array<array<int64>>>[]',
+            [[]],
+        )
+        await self.assert_query_result(
+            'select [[1]]',
+            [[[1]]],
+        )
+        await self.assert_query_result(
+            'select [[[1]]]',
+            [[[[1]]]],
+        )
+        await self.assert_query_result(
+            'select [[[[1]]]]',
+            [[[[[1]]]]],
+        )
+        await self.assert_query_result(
+            'select [[1], [2, 3], [4, 5, 6, 7]]',
+            [[[1], [2, 3], [4, 5, 6, 7]]],
+        )
+
+        # Index
+        await self.assert_query_result(
+            'select [[1, 2], [3, 4], [5, 6]][1]',
+            [[3, 4]],
+        )
+        await self.assert_query_result(
+            '''
+            select {
+                [[11, 12], [13, 14, 15], [16]],
+                [[21, 22], [23, 24, 25], [26]],
+            }[1][2]
+            ''',
+            [15, 25],
+        )
+
+        # Slice
+        await self.assert_query_result(
+            'select [[1], [2], [3], [4], [5]][1:4]',
+            [[[2], [3], [4]]],
+        )
+
+        # ++ operator
+        await self.assert_query_result(
+            'select [[1], [2]] ++ {[[3]], [[4], [5]]}',
+            [[[1], [2], [3]], [[1], [2], [4], [5]]],
+        )
+
+        # array agg
+        await self.assert_query_result(
+            r'''
                 SELECT [[1, 2], [3, 4]];
-            ''')
+            ''',
+            [[[1, 2], [3, 4]]],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT [array_agg({1, 2})];
+            ''',
+            [[[1, 2]]],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT array_agg([1, 2, 3]);
+            ''',
+            [[[1, 2, 3]]],
+        )
+
+        await self.assert_query_result(
+            r'''
+                SELECT array_agg(array_agg({1, 2 ,3}));
+            ''',
+            [[[1, 2, 3]]],
+        )
 
     async def test_edgeql_expr_array_11(self):
-        with self.assertRaisesRegex(edgedb.QueryError, 'nested array'):
-            await self.con.execute(r'''
-                SELECT [array_agg({1, 2})];
-            ''')
+        # Nested array of array and tuple
+
+        # tuple<array<array<int64>>, array<array<array<int64>>>>
+        await self.assert_query_result(
+            '''
+            select (
+                [[1, 1], [1, 2]],
+                [[[2, 1, 1], [2, 1, 2]], [[2, 2, 1]]],
+            )
+            ''',
+            [(
+                [[1, 1], [1, 2]],
+                [[[2, 1, 1], [2, 1, 2]], [[2, 2, 1]]],
+            )],
+        )
+
+        await self.assert_query_result(
+            '''
+            select (
+                [[1, 1], [1, 2]],
+                [[[2, 1, 1], [2, 1, 2]], [[2, 2, 1]]],
+            ).0
+            ''',
+            [[[1, 1], [1, 2]]],
+        )
+        await self.assert_query_result(
+            '''
+            select (
+                [[1, 1], [1, 2]],
+                [[[2, 1, 1], [2, 1, 2]], [[2, 2, 1]]],
+            ).1[0][0]
+            ''',
+            [[2, 1, 1]],
+        )
 
     async def test_edgeql_expr_array_12(self):
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                r"nested arrays are not supported"):
-            await self.con.execute(r'''
-                SELECT array_agg([1, 2, 3]);
-            ''')
+        # array<array<tuple<int64>>>
+        await self.assert_query_result(
+            '''
+            select [
+                [(1, 'A'), (1, 'B')],
+                [(2, 'C'), (2, 'D')],
+                [(3, 'E'), (3, 'F'), (3, 'G')],
+            ]
+            ''',
+            [[
+                [(1, 'A'), (1, 'B')],
+                [(2, 'C'), (2, 'D')],
+                [(3, 'E'), (3, 'F'), (3, 'G')],
+            ]],
+        )
+
+        await self.assert_query_result(
+            '''
+            select [
+                [(1, 'A'), (1, 'B')],
+                [(2, 'C'), (2, 'D')],
+                [(3, 'E'), (3, 'F'), (3, 'G')],
+            ][2][1]
+            ''',
+            [(3, 'F')],
+        )
 
     async def test_edgeql_expr_array_13(self):
-        with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                r"nested arrays are not supported"):
-            await self.con.execute(r'''
-                SELECT array_agg(array_agg({1, 2 ,3}));
-            ''')
+        # array<array<tuple<array<array>>>>
+        await self.assert_query_result(
+            '''
+            select [
+                [
+                    (
+                        [[1, 1, 1, 1], [1, 1, 1, 2]],
+                        [['A', 'A', 'B', 'A'], ['A', 'A', 'B', 'B']],
+                    ),
+                    (
+                        [[1, 2, 1, 1], [1, 2, 1, 2]],
+                        [['A', 'B', 'B', 'A'], ['A', 'B', 'B', 'B']],
+                    ),
+                ],
+                [
+                    (
+                        [[2, 1, 1, 1], [2, 1, 1, 2]],
+                        [['B', 'A', 'B', 'A'], ['B', 'A', 'B', 'B']],
+                    ),
+                    (
+                        [[2, 2, 1, 1], [2, 2, 1, 2]],
+                        [['B', 'B', 'B', 'A'], ['B', 'B', 'B', 'B']],
+                    ),
+                ],
+            ]
+            ''',
+            [[
+                [
+                    (
+                        [[1, 1, 1, 1], [1, 1, 1, 2]],
+                        [['A', 'A', 'B', 'A'], ['A', 'A', 'B', 'B']],
+                    ),
+                    (
+                        [[1, 2, 1, 1], [1, 2, 1, 2]],
+                        [['A', 'B', 'B', 'A'], ['A', 'B', 'B', 'B']],
+                    ),
+                ],
+                [
+                    (
+                        [[2, 1, 1, 1], [2, 1, 1, 2]],
+                        [['B', 'A', 'B', 'A'], ['B', 'A', 'B', 'B']],
+                    ),
+                    (
+                        [[2, 2, 1, 1], [2, 2, 1, 2]],
+                        [['B', 'B', 'B', 'A'], ['B', 'B', 'B', 'B']],
+                    ),
+                ],
+            ]],
+        )
 
     async def test_edgeql_expr_array_14(self):
         await self.assert_query_result(

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -462,6 +462,35 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
                 ''',
             )
 
+    async def test_edgeql_globals_16(self):
+        await self.assert_query_result(
+            r'''select global GlobalArrayOfArrayOfScalar''',
+            [[[1, 2, 3], [4, 5, 6]]],
+        )
+
+    async def test_edgeql_globals_17(self):
+        await self.assert_query_result(
+            r"""
+                select array_agg((
+                    for card_group in array_unpack(global GlobalCardsByCost)
+                        select array_agg((
+                            for card in array_unpack(card_group)
+                                select card.name
+                        ))
+                ))
+            """,
+            [
+                [
+                    tb.bag([]),
+                    tb.bag(['Imp', 'Dwarf', 'Sprite']),
+                    tb.bag(['Bog monster', 'Giant eagle']),
+                    tb.bag(['Giant turtle', 'Golem']),
+                    tb.bag(['Djinn']),
+                    tb.bag(['Dragon']),
+                ],
+            ],
+        )
+
     async def test_edgeql_globals_client_01(self):
         con = edgedb.create_async_client(
             **self.get_connect_args(database=self.con.dbname)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3734,6 +3734,83 @@ class TestSchema(tb.BaseSchemaLoadTest):
             "abs' does not exist",
         )
 
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "nested arrays are not supported",
+    )
+    def test_schema_array_of_array_01(self):
+        """
+        global foo: array<array<int64>>;
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "nested arrays are not supported",
+    )
+    def test_schema_array_of_array_02(self):
+        """
+        type Foo;
+        global foo: array<array<Foo>>;
+        """
+
+    def test_schema_array_of_array_03(self):
+        """
+        global foo := [[1]];
+        """
+
+    def test_schema_array_of_array_04(self):
+        """
+        alias foo := [[1]];
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "nested arrays are not supported",
+    )
+    def test_schema_array_of_array_05(self):
+        """
+        type Foo {
+            foo: array<array<int64>>;
+        }
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "nested arrays are not supported",
+    )
+    def test_schema_array_of_array_06(self):
+        """
+        type Foo {
+            foo: array<array<Foo>>;
+        }
+        """
+
+    def test_schema_array_of_array_07(self):
+        """
+        type Foo {
+            foo := [[1]];
+        };
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "nested arrays are not supported",
+    )
+    def test_schema_array_of_array_08(self):
+        """
+        function foo(x: array<array<int64>>) -> int64 using (1);
+        """
+
+    @tb.must_fail(
+        errors.UnsupportedFeatureError,
+        "nested arrays are not supported",
+    )
+    def test_schema_array_of_array_09(self):
+        """
+        type Foo;
+        function foo(x: array<array<Foo>>) -> int64 using (1);
+        """
+
 
 class TestGetMigration(tb.BaseSchemaLoadTest):
     """Test migration deparse consistency.


### PR DESCRIPTION
related #4309


Allows directly nested arrays within queries and schema expressions.

The query `select ([[1],[2]]++[[3]])[1:3][0];` returns `[2]`.

The query `select find(array_replace([[1],[2],[3]],[2],[4]),[1]);` returns `0`.