### PR TITLE
Schema diagnostics in language server

### DIFF
--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -220,6 +220,10 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def pgext_code(self):
         return self._pgext_code
 
+    @property
+    def filename(self):
+        return self._attrs.get(FIELD_FILENAME, None)
+
 
 @contextlib.contextmanager
 def ensure_span(span: Optional[edb_span.Span]) -> Iterator[None]:

--- a/edb/language_server/__init__.py
+++ b/edb/language_server/__init__.py
@@ -24,7 +24,11 @@ T = TypeVar('T', covariant=True)
 E = TypeVar('E', covariant=True)
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
+@dataclasses.dataclass(kw_only=True, slots=True, frozen=True)
 class Result(Generic[T, E]):
     ok: Optional[T] = None
     err: Optional[E] = None
+
+
+def is_schema_file(path: str) -> bool:
+    return path.endswith(('.esdl', '.gel'))

--- a/edb/language_server/__init__.py
+++ b/edb/language_server/__init__.py
@@ -15,3 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import dataclasses
+from typing import Generic, Optional, TypeVar
+
+
+T = TypeVar('T', covariant=True)
+E = TypeVar('E', covariant=True)
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class Result(Generic[T, E]):
+    ok: Optional[T] = None
+    err: Optional[E] = None

--- a/edb/language_server/main.py
+++ b/edb/language_server/main.py
@@ -26,6 +26,7 @@ from edb.edgeql import parser as qlparser
 
 from . import parsing as ls_parsing
 from . import server as ls_server
+from . import is_schema_file
 
 
 @click.command()
@@ -92,7 +93,7 @@ def document_updated(ls: ls_server.GelLanguageServer, doc_uri: str):
     diagnostic_set: ls_server.DiagnosticsSet
 
     try:
-        if doc_uri.endswith('.esdl') or doc_uri.endswith('.gel'):
+        if is_schema_file(doc_uri):
             # schema file
 
             ls_server.update_schema_doc(ls, document)

--- a/edb/language_server/main.py
+++ b/edb/language_server/main.py
@@ -37,7 +37,7 @@ from . import server as ls_server
 )
 def main(*, version: bool, stdio: bool):
     if version:
-        print(f"edgedb-ls, version {buildmeta.get_version()}")
+        print(f"gel-ls, version {buildmeta.get_version()}")
         sys.exit(0)
 
     ls = init()
@@ -48,8 +48,8 @@ def main(*, version: bool, stdio: bool):
         print("Error: no LSP transport enabled. Use --stdio.")
 
 
-def init() -> ls_server.EdgeDBLanguageServer:
-    ls = ls_server.EdgeDBLanguageServer()
+def init() -> ls_server.GelLanguageServer:
+    ls = ls_server.GelLanguageServer()
 
     @ls.feature(
         lsp_types.INITIALIZE,
@@ -84,29 +84,46 @@ def init() -> ls_server.EdgeDBLanguageServer:
     return ls
 
 
-def document_updated(ls: ls_server.EdgeDBLanguageServer, doc_uri: str):
+def document_updated(ls: ls_server.GelLanguageServer, doc_uri: str):
     # each call to this function should yield in exactly one publish_diagnostics
     # for this document
 
     document = ls.workspace.get_text_document(doc_uri)
-    ql_ast = ls_parsing.parse(document, ls)
-    if diagnostics := ql_ast.error:
-        ls.publish_diagnostics(document.uri, diagnostics, document.version)
-        return
-    assert ql_ast.ok
+    diagnostic_set: ls_server.DiagnosticsSet
 
     try:
-        if isinstance(ql_ast.ok, list):
-            diagnostics = ls_server.compile(ls, ql_ast.ok)
-            ls.publish_diagnostics(document.uri, diagnostics, document.version)
+        if doc_uri.endswith('.esdl') or doc_uri.endswith('.gel'):
+            # schema file
+
+            ls_server.update_schema_doc(ls, document)
+
+            # recompile schema
+            ls.state.schema = None
+            _schema, diagnostic_set = ls_server.get_schema(ls)
         else:
-            ls.publish_diagnostics(document.uri, [], document.version)
+            # query file
+            ql_ast_res = ls_parsing.parse(document, ls)
+            if diag := ql_ast_res.err:
+                ls.publish_diagnostics(document.uri, diag, document.version)
+                return
+            assert ql_ast_res.ok
+            ql_ast = ql_ast_res.ok
+
+            if isinstance(ql_ast, list):
+                diagnostic_set = ls_server.compile(ls, document, ql_ast)
+            else:
+                # SDL in query files?
+                ls.publish_diagnostics(document.uri, [], document.version)
+                diagnostic_set = ls_server.DiagnosticsSet()
+
+        for doc, diags in diagnostic_set.by_doc.items():
+            ls.publish_diagnostics(doc.uri, diags, doc.version)
     except BaseException as e:
         send_internal_error(ls, e)
         ls.publish_diagnostics(document.uri, [], document.version)
 
 
-def send_internal_error(ls: ls_server.EdgeDBLanguageServer, e: BaseException):
+def send_internal_error(ls: ls_server.GelLanguageServer, e: BaseException):
     text = edb_traceback.format_exception(e)
     ls.show_message_log(f'Internal error: {text}')
 

--- a/edb/language_server/parsing.py
+++ b/edb/language_server/parsing.py
@@ -29,17 +29,13 @@ from edb.edgeql import parser as qlparser
 from edb.edgeql.parser.grammar import tokens as qltokens
 import edb._edgeql_parser as rust_parser
 
-from . import Result
+from . import Result, is_schema_file
 
 
 def parse(
     doc: TextDocument, ls: LanguageServer
 ) -> Result[List[qlast.Base] | qlast.Schema, List[lsp_types.Diagnostic]]:
-    sdl = (
-        doc.filename.endswith('.esdl') or doc.filename.endswith('.gel')
-        if doc.filename
-        else False
-    )
+    sdl = is_schema_file(doc.filename) if doc.filename else False
 
     source, result, productions = _parse_inner(doc.source, sdl)
 

--- a/edb/language_server/parsing.py
+++ b/edb/language_server/parsing.py
@@ -16,8 +16,7 @@
 # limitations under the License.
 #
 
-from typing import Any, List, Tuple, Optional, TypeVar, Generic
-from dataclasses import dataclass
+from typing import Any, List, Tuple, Optional
 
 from pygls.server import LanguageServer
 from pygls.workspace import TextDocument
@@ -30,21 +29,17 @@ from edb.edgeql import parser as qlparser
 from edb.edgeql.parser.grammar import tokens as qltokens
 import edb._edgeql_parser as rust_parser
 
-
-T = TypeVar('T', covariant=True)
-E = TypeVar('E', covariant=True)
-
-
-@dataclass(kw_only=True, slots=True)
-class Result(Generic[T, E]):
-    ok: Optional[T] = None
-    error: Optional[E] = None
+from . import Result
 
 
 def parse(
     doc: TextDocument, ls: LanguageServer
 ) -> Result[List[qlast.Base] | qlast.Schema, List[lsp_types.Diagnostic]]:
-    sdl = doc.filename.endswith('.esdl') if doc.filename else False
+    sdl = (
+        doc.filename.endswith('.esdl') or doc.filename.endswith('.gel')
+        if doc.filename
+        else False
+    )
 
     source, result, productions = _parse_inner(doc.source, sdl)
 
@@ -77,7 +72,7 @@ def parse(
                 )
             )
 
-        return Result(error=diagnostics)
+        return Result(err=diagnostics)
 
     # parsing successful
     assert isinstance(result.out, rust_parser.CSTNode)

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -38,6 +38,7 @@ from edb.schema import ddl as s_ddl
 import pygls.workspace
 
 from . import parsing as ls_parsing
+from . import is_schema_file
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -188,7 +189,7 @@ def _load_schema_docs(ls: GelLanguageServer):
 
     # read .esdl files
     for entry in os.listdir(workspace_path / schema_dir):
-        if not (entry.endswith('.esdl') or entry.endswith('.gel')):
+        if not is_schema_file(entry):
             continue
         doc = ls.workspace.get_text_document(
             str(workspace_path / schema_dir / entry)

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -16,13 +16,14 @@
 # limitations under the License.
 #
 
-from typing import Optional, List
+from typing import Dict, Mapping, Optional, List, Tuple
 import dataclasses
 import pathlib
 import os
 
 from pygls.server import LanguageServer
 from pygls import uris as pygls_uris
+import pygls
 from lsprotocol import types as lsp_types
 
 
@@ -34,18 +35,23 @@ from edb.edgeql import compiler as qlcompiler
 from edb.schema import schema as s_schema
 from edb.schema import std as s_std
 from edb.schema import ddl as s_ddl
+import pygls.workspace
 
 from . import parsing as ls_parsing
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class State:
+    schema_docs: List[pygls.workspace.TextDocument] = dataclasses.field(
+        default_factory=lambda: []
+    )
+
     schema: Optional[s_schema.Schema] = None
 
     std_schema: Optional[s_schema.Schema] = None
 
 
-class EdgeDBLanguageServer(LanguageServer):
+class GelLanguageServer(LanguageServer):
     state: State
 
     def __init__(self):
@@ -53,35 +59,50 @@ class EdgeDBLanguageServer(LanguageServer):
         self.state = State()
 
 
+@dataclasses.dataclass(kw_only=True, slots=True)
+class DiagnosticsSet:
+    by_doc: Dict[pygls.workspace.TextDocument, List[lsp_types.Diagnostic]] = (
+        dataclasses.field(default_factory=lambda: {})
+    )
+
+
 def compile(
-    ls: EdgeDBLanguageServer, stmts: List[qlast.Base]
-) -> List[lsp_types.Diagnostic]:
-    diagnostics: List[lsp_types.Diagnostic] = []
-
+    ls: GelLanguageServer,
+    doc: pygls.workspace.TextDocument,
+    stmts: List[qlast.Base],
+) -> DiagnosticsSet:
     if not stmts:
-        return diagnostics
+        return DiagnosticsSet(by_doc={doc: []})
 
-    schema = _get_schema(ls)
+    schema, diagnostics_set = get_schema(ls)
     if not schema:
-        return diagnostics
+        return diagnostics_set
 
+    diagnostics: List[lsp_types.Diagnostic] = []
+    modaliases: Mapping[Optional[str], str] = {None: 'default'}
     for ql_stmt in stmts:
 
         try:
             if isinstance(ql_stmt, qlast.DDLCommand):
                 schema, _delta = s_ddl.delta_and_schema_from_ddl(
-                    ql_stmt, schema=schema, modaliases={None: 'default'}
+                    ql_stmt, schema=schema, modaliases=modaliases
                 )
 
-            elif isinstance(ql_stmt, (qlast.Command, qlast.Query)):
-                ir_stmt = qlcompiler.compile_ast_to_ir(ql_stmt, schema)
-                ls.show_message_log(f'IR: {ir_stmt}')
-
+            elif isinstance(ql_stmt, (qlast.Command, qlast.Expr)):
+                options = qlcompiler.CompilerOptions(modaliases=modaliases)
+                ir_stmt = qlcompiler.compile_ast_to_ir(
+                    ql_stmt, schema, options=options
+                )
+                ls.show_message_log(
+                    f'IR: {ir_stmt}', msg_type=lsp_types.MessageType.Debug
+                )
             else:
                 ls.show_message_log(f'skip compile of {ql_stmt}')
         except errors.EdgeDBError as error:
             diagnostics.append(_convert_error(error))
-    return diagnostics
+
+    diagnostics_set.by_doc[doc] = diagnostics
+    return diagnostics_set
 
 
 def _convert_error(error: errors.EdgeDBError) -> lsp_types.Diagnostic:
@@ -101,11 +122,42 @@ def _convert_error(error: errors.EdgeDBError) -> lsp_types.Diagnostic:
     )
 
 
-def _get_schema(ls: EdgeDBLanguageServer) -> Optional[s_schema.Schema]:
-
+def get_schema(
+    ls: GelLanguageServer,
+) -> Tuple[Optional[s_schema.Schema], DiagnosticsSet]:
     if ls.state.schema:
-        return ls.state.schema
+        return (ls.state.schema, DiagnosticsSet())
 
+    if len(ls.state.schema_docs) == 0:
+        _load_schema_docs(ls)
+
+    return _compile_schema(ls)
+
+
+def update_schema_doc(ls: GelLanguageServer, doc: pygls.workspace.TextDocument):
+    # TODO: check that this doc in actually in dbschema dir
+
+    if len(ls.state.schema_docs) == 0:
+        _load_schema_docs(ls)
+
+    existing = next(
+        (i for i, d in enumerate(ls.state.schema_docs) if d.path == doc.path),
+        None,
+    )
+    if existing is not None:
+        # update
+        ls.state.schema_docs[existing] = doc
+    else:
+        # insert
+        ls.show_message_log("new schema file added: " + doc.path)
+        ls.show_message_log("existing files: ")
+        for d in ls.state.schema_docs:
+            ls.show_message_log("- " + d.path)
+
+        ls.state.schema_docs.append(doc)
+
+
+def _load_schema_docs(ls: GelLanguageServer):
     # discover dbschema/ folders
     if len(ls.workspace.folders) != 1:
 
@@ -116,40 +168,76 @@ def _get_schema(ls: EdgeDBLanguageServer) -> Optional[s_schema.Schema]:
             )
         return None
 
+    # discard all existing docs
+    ls.state.schema_docs.clear()
+
     workspace: lsp_types.WorkspaceFolder = next(
         iter(ls.workspace.folders.values())
     )
     workspace_path = pathlib.Path(pygls_uris.to_fs_path(workspace.uri))
 
-    dbschema = workspace_path / 'dbschema'
+    # TODO: read gel.toml and use [project.schema-dir]
+    schema_dir = 'dbschema'
 
-    # read and parse .esdl files
-    sdl = qlast.Schema(declarations=[])
-    for entry in os.listdir(dbschema):
-        if not entry.endswith('.esdl'):
+    # read .esdl files
+    for entry in os.listdir(workspace_path / schema_dir):
+        if not (entry.endswith('.esdl') or entry.endswith('.gel')):
             continue
-        doc = ls.workspace.get_text_document(f'dbschema/{entry}')
+        doc = ls.workspace.get_text_document(
+            str(workspace_path / schema_dir / entry)
+        )
+        ls.state.schema_docs.append(doc)
 
+
+def _compile_schema(
+    ls: GelLanguageServer,
+) -> Tuple[Optional[s_schema.Schema], DiagnosticsSet]:
+    # parse
+    sdl = qlast.Schema(declarations=[])
+    diagnostics = DiagnosticsSet()
+    for doc in ls.state.schema_docs:
         res = ls_parsing.parse(doc, ls)
-        if diagnostics := res.error:
-            ls.publish_diagnostics(doc.uri, diagnostics, doc.version)
+        if d := res.err:
+            diagnostics.by_doc[doc] = d
         else:
+            diagnostics.by_doc[doc] = []
             if isinstance(res.ok, qlast.Schema):
                 sdl.declarations.extend(res.ok.declarations)
             else:
                 # TODO: complain that .esdl contains non-SDL syntax
                 pass
 
-    # apply SDL to std schema
     std_schema = _load_std_schema(ls.state)
-    schema, _warnings = s_ddl.apply_sdl(
-        sdl,
-        base_schema=std_schema,
-        current_schema=std_schema,
-    )
+
+    # apply SDL to std schema
+    ls.show_message_log('compiling schema ..')
+    try:
+        schema, _warnings = s_ddl.apply_sdl(
+            sdl,
+            base_schema=std_schema,
+            current_schema=std_schema,
+        )
+        ls.show_message_log('.. done')
+    except errors.EdgeDBError as error:
+        schema = None
+
+        # find doc
+        do = next(
+            (d for d in ls.state.schema_docs if error.filename == d.filename),
+            None,
+        )
+        if do is None:
+            ls.show_message_log(
+                f'cannot find original doc of the error ({error.filename}), '
+                'using first schema file'
+            )
+            do = ls.state.schema_docs[0]
+
+        # convert error
+        diagnostics.by_doc[doc].append(_convert_error(error))
 
     ls.state.schema = schema
-    return ls.state.schema
+    return (schema, diagnostics)
 
 
 def _load_std_schema(state: State) -> s_schema.Schema:

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -107,15 +107,22 @@ def compile(
 
 def _convert_error(error: errors.EdgeDBError) -> lsp_types.Diagnostic:
     return lsp_types.Diagnostic(
-        range=lsp_types.Range(
-            start=lsp_types.Position(
-                line=error.line - 1,
-                character=error.col - 1,
-            ),
-            end=lsp_types.Position(
-                line=error.line_end - 1,
-                character=error.col_end - 1,
-            ),
+        range=(
+            lsp_types.Range(
+                start=lsp_types.Position(
+                    line=error.line - 1,
+                    character=error.col - 1,
+                ),
+                end=lsp_types.Position(
+                    line=error.line_end - 1,
+                    character=error.col_end - 1,
+                ),
+            )
+            if error.line >= 0
+            else lsp_types.Range(
+                start=lsp_types.Position(line=0, character=0),
+                end=lsp_types.Position(line=0, character=0),
+            )
         ),
         severity=lsp_types.DiagnosticSeverity.Error,
         message=error.args[0],
@@ -234,7 +241,7 @@ def _compile_schema(
             do = ls.state.schema_docs[0]
 
         # convert error
-        diagnostics.by_doc[doc].append(_convert_error(error))
+        diagnostics.by_doc[do].append(_convert_error(error))
 
     ls.state.schema = schema
     return (schema, diagnostics)

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -88,5 +88,6 @@ from . import ast_inheritance_graph  # noqa
 from . import parser_demo  # noqa
 from . import ls_forbidden_functions  # noqa
 from . import redo_metaschema  # noqa
+from . import ls  # noqa
 from .profiling import cli as prof_cli  # noqa
 from .experimental_interpreter import edb_entry # noqa

--- a/edb/tools/ls.py
+++ b/edb/tools/ls.py
@@ -1,0 +1,46 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2020-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import sys
+import click
+
+from edb import buildmeta
+from edb.tools.edb import edbcommands
+from edb.language_server import main as ls_main
+
+
+@edbcommands.command("ls")
+@click.option('--version', is_flag=True, help="Show the version and exit.")
+@click.option(
+    '--stdio',
+    is_flag=True,
+    help="Use stdio for LSP. This is currently the only transport.",
+)
+def main(*, version: bool, stdio: bool):
+    if version:
+        print(f"gel-ls, version {buildmeta.get_version()}")
+        sys.exit(0)
+
+    ls = ls_main.init()
+
+    if stdio:
+        ls.start_io()
+    else:
+        print("Error: no LSP transport enabled. Use --stdio.")

--- a/rust/gel-jwt/benches/bench-jwcrypto.py
+++ b/rust/gel-jwt/benches/bench-jwcrypto.py
@@ -2,6 +2,7 @@ from jwcrypto import jwt, jwk
 import time
 import statistics
 
+
 def generate_key(key_type):
     if key_type == "ES256":
         return jwk.JWK.generate(kty='EC', crv='P-256')
@@ -11,15 +12,16 @@ def generate_key(key_type):
         return jwk.JWK.generate(kty='oct', size=256)
     raise ValueError(f"Unsupported key type: {key_type}")
 
+
 def benchmark_encode(key_type, iterations=100):
     # Generate key outside the loop
     key = generate_key(key_type)
-    
+
     # Benchmark full encoding process including claims creation
     times = []
     for _ in range(iterations):
         start = time.perf_counter_ns()
-        
+
         # Create claims and sign in the timed section
         claims = {"sub": "test"}
         token = jwt.JWT(
@@ -27,37 +29,39 @@ def benchmark_encode(key_type, iterations=100):
             claims=claims
         )
         token.make_signed_token(key)
-        
+
         end = time.perf_counter_ns()
         times.append(end - start)
-    
+
     mean = statistics.mean(times) / 1000  # Convert to microseconds
     median = statistics.median(times) / 1000
     return mean, median
+
 
 def benchmark_signing(key_type, iterations=100):
     # Generate key outside the loop
     key = generate_key(key_type)
     claims = {"sub": "test"}
-    
+
     # Benchmark signing
     times = []
     for _ in range(iterations):
         start = time.perf_counter_ns()
-        
+
         # Signing
         token = jwt.JWT(
             header={"alg": key_type},
             claims=claims
         )
         token.make_signed_token(key)
-        
+
         end = time.perf_counter_ns()
         times.append(end - start)
-    
+
     mean = statistics.mean(times) / 1000
     median = statistics.median(times) / 1000
     return mean, median
+
 
 def benchmark_validation(key_type, iterations=100):
     # Generate key and token outside the loop
@@ -68,48 +72,50 @@ def benchmark_validation(key_type, iterations=100):
     )
     token.make_signed_token(key)
     token_string = token.serialize()
-    
+
     # Benchmark validation
     times = []
     for _ in range(iterations):
         start = time.perf_counter_ns()
-        
+
         # Validation
         jwt.JWT(jwt=token_string, key=key)
-        
+
         end = time.perf_counter_ns()
         times.append(end - start)
-    
+
     mean = statistics.mean(times) / 1000
     median = statistics.median(times) / 1000
     return mean, median
 
+
 def main():
     key_types = ["ES256", "RS256", "HS256"]
     iterations = 100
-    
+
     print(f"Running {iterations} iterations for each algorithm")
-    
+
     print("\nFull encode benchmarks (including claims creation):")
     print(f"{'Algorithm':<10} | {'Mean (µs)':<12} | {'Median (µs)':<12}")
     print("-" * 38)
     for key_type in key_types:
         mean, median = benchmark_encode(key_type, iterations)
         print(f"{key_type:<10} | {mean:12.2f} | {median:12.2f}")
-    
+
     print("\nSigning benchmarks (pre-created claims):")
     print(f"{'Algorithm':<10} | {'Mean (µs)':<12} | {'Median (µs)':<12}")
     print("-" * 38)
     for key_type in key_types:
         mean, median = benchmark_signing(key_type, iterations)
         print(f"{key_type:<10} | {mean:12.2f} | {median:12.2f}")
-        
+
     print("\nValidation benchmarks:")
     print(f"{'Algorithm':<10} | {'Mean (µs)':<12} | {'Median (µs)':<12}")
     print("-" * 38)
     for key_type in key_types:
         mean, median = benchmark_validation(key_type, iterations)
         print(f"{key_type:<10} | {mean:12.2f} | {median:12.2f}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Ref #7411

- adds `edb ls` sub command, which can be invoked from the vscode extension directly, which makes development much easier,
- treats both `.esdl` and `.gel` files as schema files,
- keeps track of modified `dbschema/` files (even those that have not been saved to fs yet),
- reports compilation errors from schema (we have previously done that for .edgeql files only)

