### PR TITLE
Fix tagging SQL over binary protocol

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -507,6 +507,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         self,
         rpc.CompilationRequest query_req,
         uint64_t allow_capabilities,
+        tag=None,
     ) -> dbview.CompiledQuery:
         cdef dbview.DatabaseConnectionView dbv
         dbv = self.get_dbview()
@@ -546,6 +547,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
                             query_req,
                             allow_capabilities=allow_capabilities,
                             pgcon=pg_conn,
+                            tag=tag,
                         )
                 else:
                     return await dbv.parse(
@@ -957,7 +959,9 @@ cdef class EdgeConnection(frontend.FrontendConnection):
                 if self.debug:
                     self.debug_print('EXECUTE /CACHE MISS', query_req.source.text())
 
-                compiled = await self._parse(query_req, allow_capabilities)
+                compiled = await self._parse(
+                    query_req, allow_capabilities, tag
+                )
                 query_unit_group = compiled.query_unit_group
                 if self._cancelled:
                     raise ConnectionAbortedError

--- a/edb/testbase/connection.py
+++ b/edb/testbase/connection.py
@@ -367,6 +367,9 @@ class Connection(options._OptionsMixin, abstract.AsyncIOExecutor):
     def _get_state(self):
         return self._options.state
 
+    def _get_annotations(self) -> typing.Dict[str, str]:
+        return self._options.annotations
+
     def _warning_handler(self, warnings, res):
         if self._capture_warnings is not None:
             self._capture_warnings.extend(warnings)


### PR DESCRIPTION
SQL over binary protocol will `Parse` first for `_amend_typedesc_in_sql()`, where we didn't send tags and the edb_stat_statements remembered that for all future commands of the same query.