### PR TITLE
Increase recursion limit in compiler worker processes

### DIFF
--- a/edb/edgeql/compiler/config_desc.py
+++ b/edb/edgeql/compiler/config_desc.py
@@ -51,7 +51,9 @@ def compile_describe_config(
         ctx.env.schema, scope, ctx.env.options.testmode)
     config_ast = qlparser.parse_fragment(config_edgeql)
 
-    return dispatch.compile(config_ast, ctx=ctx)
+    with ctx.new() as subctx:
+        subctx.allow_factoring()
+        return dispatch.compile(config_ast, ctx=subctx)
 
 
 def _describe_config(

--- a/edb/server/compiler_pool/worker_proc.py
+++ b/edb/server/compiler_pool/worker_proc.py
@@ -116,7 +116,7 @@ def main(get_handler):
     parser.add_argument("--version-serial", type=int)
     args = parser.parse_args()
 
-    sys.setrecursionlimit(10000)
+    sys.setrecursionlimit(2000)
 
     ql_parser.preload_spec()
     gc.freeze()

--- a/edb/server/compiler_pool/worker_proc.py
+++ b/edb/server/compiler_pool/worker_proc.py
@@ -22,6 +22,7 @@ import gc
 import os
 import pickle
 import signal
+import sys
 import time
 import traceback
 
@@ -114,6 +115,8 @@ def main(get_handler):
     parser.add_argument("--numproc")
     parser.add_argument("--version-serial", type=int)
     args = parser.parse_args()
+
+    sys.setrecursionlimit(10000)
 
     ql_parser.preload_spec()
     gc.freeze()

--- a/tests/test_edgeql_userddl.py
+++ b/tests/test_edgeql_userddl.py
@@ -447,6 +447,13 @@ class TestEdgeQLUserDDL(tb.DDLTestCase):
             COMMIT MIGRATION;
         """)
 
+        await self.con.query("""
+            describe current database config as ddl
+        """)
+        await self.con.query("""
+            describe instance config as ddl
+        """)
+
         await self.con.execute(f"""
             START MIGRATION TO {{
                 {ext_commands}


### PR DESCRIPTION
I've been threatening to do this for a while and it is finally time, I
think. Compiling the (complex!) query for `DESCRIBE INSTANCE CONFIG AS
DDL` as part of `dump --all` has been failing.