### PR TITLE
Add hint to partial path errors if anchor is available.

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -2609,7 +2609,10 @@ class TestExpressions(tb.QueryTestCase):
         # syntactically legal (see test_edgeql_syntax_constants_09),
         # but will fail to resolve to anything.
         with self.assertRaisesRegex(
-                edgedb.QueryError, r'could not resolve partial path'):
+            edgedb.QueryError,
+            r'could not resolve partial path',
+            _hint=None
+        ):
             await self.con.execute(r"""
                 SELECT .1;
             """)

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -103,6 +103,7 @@ class TestInsert(tb.QueryTestCase):
         with self.assertRaisesRegex(
             edgedb.QueryError,
             r"could not resolve partial path",
+            _hint=None
         ):
             await self.con.execute('''
                 INSERT Person { name := .name };

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1292,8 +1292,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_limit_08(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'could not resolve partial path'):
+            edgedb.QueryError,
+            r'could not resolve partial path',
+            _hint=None
+        ):
 
             await self.con.query("""
                 SELECT
@@ -1303,8 +1305,10 @@ class TestEdgeQLSelect(tb.QueryTestCase):
 
     async def test_edgeql_select_limit_09(self):
         with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'could not resolve partial path'):
+            edgedb.QueryError,
+            r'could not resolve partial path',
+            _hint=None
+        ):
 
             await self.con.query("""
                 SELECT

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -455,8 +455,11 @@ class TestSchema(tb.BaseSchemaLoadTest):
             };
         """
 
-    @tb.must_fail(errors.QueryError,
-                  "could not resolve partial path")
+    @tb.must_fail(
+        errors.QueryError,
+        "could not resolve partial path",
+        hint="Did you mean __source__.name?"
+    )
     def test_schema_partial_path_in_default_of_link_prop_01(self):
         """
             module default {
@@ -472,6 +475,21 @@ class TestSchema(tb.BaseSchemaLoadTest):
                     }
 
                 }
+            }
+        """
+
+    @tb.must_fail(
+        errors.QueryError,
+        "could not resolve partial path",
+        hint="Did you mean __new__.wow?"
+    )
+    def test_schema_partial_path_in_trigger_01(self):
+        """
+            type Foo {
+                property wow: bool;
+                trigger prohibit_queue after insert for each do (
+                    select assert(.wow, message := "wow!")
+                );
             }
         """
 


### PR DESCRIPTION
Given the schema:
```
  type Foo {
    property wow: bool;
    trigger prohibit_queue after insert for each do (
        select assert(.wow, message := "wow!")
    );
  }
```

The error now comes with a hint:
```
error: could not resolve partial path 
  │
7 │         select assert(.wow, message := "wow!")
  │                       ^^^^ Did you mean __new__.wow?
```

Close #8199