### PR TITLE
Add `versionadded` to a few new things.

### DIFF
--- a/docs/clients/js/reference.rst
+++ b/docs/clients/js/reference.rst
@@ -324,6 +324,8 @@ Client
 
     .. js:method:: executeSQL(query: string, args?: unknown[]): Promise<void>
 
+        .. versionadded:: 6.0
+
         Execute a SQL command.
 
         :param query: SQL query text.
@@ -339,6 +341,8 @@ Client
             `)
 
     .. js:method:: querySQL<T>(query: string, args?: unknown[]): Promise<T[]>
+
+        .. versionadded:: 6.0
 
         Run a SQL query and return the results as an array.
         This method **always** returns an array.

--- a/docs/reference/admin/index.rst
+++ b/docs/reference/admin/index.rst
@@ -26,13 +26,17 @@ Administrative commands for managing Gel:
 
       Create, remove, or alter a branch.
 
-    * :ref:`administer statistics_update() <ref_admin_statistics_update>`
-
-      Update internal statistics about data.
-
     * :ref:`administer vacuum() <ref_admin_vacuum>`
 
       Reclaim storage space.
+
+.. versionadded:: 6.0
+
+    Another administrative command was added in |Gel| 6 release:
+
+    * :ref:`administer statistics_update() <ref_admin_statistics_update>`
+
+      Update internal statistics about data.
 
 
 .. toctree::

--- a/docs/stdlib/math.rst
+++ b/docs/stdlib/math.rst
@@ -203,6 +203,8 @@ Math
 
     :index: trigonometry
 
+    .. versionadded:: 6.0
+
     Returns the value of pi.
 
     .. code-block:: edgeql-repl
@@ -217,6 +219,8 @@ Math
 .. eql:function:: math::acos(x: float64) -> float64
 
     :index: trigonometry
+
+    .. versionadded:: 6.0
 
     Returns the arc cosine of the input.
 
@@ -237,6 +241,8 @@ Math
 
     :index: trigonometry
 
+    .. versionadded:: 6.0
+
     Returns the arc sine of the input.
 
     .. code-block:: edgeql-repl
@@ -256,6 +262,8 @@ Math
 
     :index: trigonometry
 
+    .. versionadded:: 6.0
+
     Returns the arc tangent of the input.
 
     .. code-block:: edgeql-repl
@@ -274,6 +282,8 @@ Math
 .. eql:function:: math::atan2(y: float64, x: float64) -> float64
 
     :index: trigonometry
+
+    .. versionadded:: 6.0
 
     Returns the arc tangent of ``y / x``.
 
@@ -298,6 +308,8 @@ Math
 
     :index: trigonometry
 
+    .. versionadded:: 6.0
+
     Returns the cosine of the input.
 
     .. code-block:: edgeql-repl
@@ -319,6 +331,8 @@ Math
 
     :index: trigonometry
 
+    .. versionadded:: 6.0
+
     Returns the cotangent of the input.
 
     .. code-block:: edgeql-repl
@@ -337,6 +351,8 @@ Math
 .. eql:function:: math::sin(x: float64) -> float64
 
     :index: trigonometry
+
+    .. versionadded:: 6.0
 
     Returns the sinine of the input.
 
@@ -358,6 +374,8 @@ Math
 .. eql:function:: math::tan(x: float64) -> float64
 
     :index: trigonometry
+
+    .. versionadded:: 6.0
 
     Returns the tanangent of the input.
 


### PR DESCRIPTION
There were a few things we missed. I'm not sure if the `admin/index.rst` is rendered anymore (don't see it in the locally rendered docs using `master` branch of the new `gel` repo). I've updated it just in case. The actual page describing `administer statistics_update()` is already properly tagged with the `versionadded`.