### PR TITLE
Increase recursion limit in compiler worker processes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -530,7 +530,7 @@ def _compile_cli(build_base, build_temp):
     args = [
         'cargo', 'install',
         '--verbose', '--verbose',
-        '--bin', 'edgedb',
+        '--bin', 'gel',
         '--root', rust_root,
         '--features=dev_mode',
         '--locked',
@@ -564,7 +564,7 @@ def _compile_cli(build_base, build_temp):
             pass
 
         shutil.copy(
-            rust_root / 'bin' / 'edgedb',
+            rust_root / 'bin' / 'gel',
             cli_dest,
         )
 


### PR DESCRIPTION
I've been threatening to do this for a while and it is finally time, I
think. Compiling the (complex!) query for `DESCRIBE INSTANCE CONFIG AS
DDL` as part of `dump --all` has been failing.