### PR TITLE
Check that function parameter and return types exist when migrating.

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1053,6 +1053,18 @@ def trace_Function(
     # before the function.
     deps: List[Dependency] = []
 
+    # We don't actually care to resolve these, but we do need to check for
+    # tracing errors.
+    for param in node.params:
+        if (
+            isinstance(param.type, qlast.TypeName)
+            and isinstance(param.type.maintype, qlast.PseudoObjectRef)
+        ):
+            # generic types are handled elsewhere
+            continue
+        _resolve_type_expr(param.type, ctx=ctx)
+    _resolve_type_expr(node.returning, ctx=ctx)
+
     deps.extend(TypeDependency(texpr=param.type) for param in node.params)
     deps.append(TypeDependency(texpr=node.returning))
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -742,6 +742,44 @@ class TestSchema(tb.BaseSchemaLoadTest):
         };
         """
 
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::Bar' does not exist",
+    )
+    def test_schema_bad_type_19a(self):
+        """
+        function foo() -> Bar using (1);
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::Bar' does not exist",
+    )
+    def test_schema_bad_type_19b(self):
+        """
+        function foo(x: Bar) -> int64 using (1);
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::Baz' does not exist",
+    )
+    def test_schema_bad_type_19c(self):
+        """
+        type Bar;
+        function foo() -> Bar | Baz using (1);
+        """
+
+    @tb.must_fail(
+        errors.InvalidReferenceError,
+        "type 'test::Baz' does not exist",
+    )
+    def test_schema_bad_type_19d(self):
+        """
+        type Bar;
+        function foo(x: Bar | Baz) -> int64 using (1);
+        """
+
     def test_schema_computable_cardinality_inference_01(self):
         schema = self.load_schema("""
             type Object {


### PR DESCRIPTION
Fixes an ISE when a function signature contains a type which does not exist.

eg. If `Bar` does not exist, adding this to the schema produces a proper error: `function foo(x: Bar) -> int64 using (1)`

close #8376