### PR TITLE
Fix referencing ext::auth::ClientTokenIdentity from a link default

### DIFF
--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -785,6 +785,8 @@ def get_ref_storage_info(
             source_typeref = ref.typeref
             if not irtyputils.is_object(source_typeref):
                 continue
+            if irtyputils.is_free_object(source_typeref):
+                continue
             schema, t = irtyputils.ir_typeref_to_type(schema, ref.typeref)
             assert isinstance(t, s_sources.Source)
             ptr = t.getptr(schema, s_name.UnqualName('id'))

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -2046,6 +2046,28 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             insert T;
         """)
 
+    async def test_edgeql_ddl_default_16(self):
+        await self.con.execute(r"""
+            create type T;
+            insert T;
+            alter type T {
+                create required property y: str {
+                    set default := (with x := { y := "lol" }, select x.y)
+                }
+            };
+            insert T;
+        """)
+
+        await self.assert_query_result(
+            r"""
+                select T { y }
+            """,
+            [
+                {'y': "lol"},
+                {'y': "lol"},
+            ],
+        )
+
     async def test_edgeql_ddl_default_circular(self):
         await self.con.execute(r"""
             CREATE TYPE TestDefaultCircular {

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -347,6 +347,15 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
 
         CONFIGURE CURRENT DATABASE
         INSERT ext::auth::MagicLinkProviderConfig {{}};
+
+        # Pure testing code:
+        CREATE TYPE TestUser;
+        ALTER TYPE TestUser {{
+            CREATE REQUIRED LINK identity: ext::auth::Identity {{
+                SET default := (GLOBAL ext::auth::ClientTokenIdentity)
+            }};
+        }};
+
         """,
     ]
 


### PR DESCRIPTION
More broadly, fix using free objects in a default.

Fixes #8393