### PR TITLE
Fix imports of language_server module

### DIFF
--- a/edb/tools/ls.py
+++ b/edb/tools/ls.py
@@ -23,7 +23,6 @@ import click
 
 from edb import buildmeta
 from edb.tools.edb import edbcommands
-from edb.language_server import main as ls_main
 
 
 @edbcommands.command("ls")
@@ -34,6 +33,10 @@ from edb.language_server import main as ls_main
     help="Use stdio for LSP. This is currently the only transport.",
 )
 def main(*, version: bool, stdio: bool):
+    # import language_server only if we are using this command
+    # otherwise this breaks when pygls is not installed
+    from edb.language_server import main as ls_main
+
     if version:
         print(f"gel-ls, version {buildmeta.get_version()}")
         sys.exit(0)


### PR DESCRIPTION
Fix of #8349

Importing language_server module requires pygls (and lsprotocol) be installed, which they are not in gel-server package.

Breakage in this build: https://github.com/geldata/gel/actions/runs/13511629648/job/37754102602