### PR TITLE
Fix parser span over SQL adapter

### DIFF
--- a/edb/edgeql/tokenizer.py
+++ b/edb/edgeql/tokenizer.py
@@ -153,13 +153,17 @@ def inflate_span(
     (start, end) = span
     source_bytes = source.encode('utf-8')
 
-    [start_sp] = ql_parser.SourcePoint.from_offsets(source_bytes, [start])
-
+    points = [start]
     if end is not None:
-        [end_sp] = ql_parser.SourcePoint.from_offsets(source_bytes, [end])
+        points.append(start)
+
+    points_sp = ql_parser.SourcePoint.from_offsets(source_bytes, points)
+
+    start_sp = points_sp[0]
+    if end is not None:
+        end_sp = points_sp[1]
     else:
         end_sp = None
-
     return (start_sp, end_sp)
 
 

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -154,7 +154,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
         start: int = self.position
         end: int | None = self.position_end
-        if end < 0:
+        if end and end < 0:
             end = None
 
         start_s, end_s = tokenizer.inflate_span(source, (start, end))

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -104,7 +104,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         if span:
             self.set_span(span)
         elif position:
-            self.set_linecol(position[0], position[1])
+            self.set_linecol(position[1], position[0])
             self.set_position(position[2], position[3])
 
         if filename is not None:

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -104,7 +104,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         if span:
             self.set_span(span)
         elif position:
-            self.set_position(*position)
+            self.set_linecol(position[0], position[1])
+            self.set_position(position[2], position[3])
 
         if filename is not None:
             self.set_filename(filename)
@@ -138,11 +139,31 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def set_filename(self, filename):
         self._attrs[FIELD_FILENAME] = filename
 
-    def set_linecol(self, line: Optional[int], col: Optional[int]):
+    def set_linecol(
+        self,
+        line: Optional[int], # one-based
+        col: Optional[int], # one-based
+    ):
         if line is not None:
             self._attrs[FIELD_LINE_START] = str(line)
         if col is not None:
             self._attrs[FIELD_COLUMN_START] = str(col)
+
+    def compute_line_col(self, source: str):
+        from edb.edgeql import tokenizer
+
+        start: int = self.position
+        end: int | None = self.position_end
+        if end < 0:
+            end = None
+
+        start_s, end_s = tokenizer.inflate_span(source, (start, end))
+
+        self._attrs[FIELD_LINE_START] = str(start_s.line)
+        self._attrs[FIELD_COL_START] = str(start_s.column)
+        if end_s is not None:
+            self._attrs[FIELD_LINE_END] = str(end_s.line)
+            self._attrs[FIELD_COL_END] = str(end_s.column)
 
     def set_hint_and_details(self, hint, details=None):
         ex.replace_context(
@@ -179,12 +200,9 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def set_position(
         self,
-        column: int, # one-based
-        line: int, # one-based
         start: int, # zero-based
         end: Optional[int], # zero-based
     ):
-        self.set_linecol(line, column)
         self._attrs[FIELD_POSITION_START] = str(start)
         self._attrs[FIELD_POSITION_END] = str(end or start)
 
@@ -207,6 +225,10 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     @property
     def position(self):
         return int(self._attrs.get(FIELD_POSITION_START, -1))
+
+    @property
+    def position_end(self):
+        return int(self._attrs.get(FIELD_POSITION_END, -1))
 
     @property
     def hint(self):

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -179,10 +179,10 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def set_position(
         self,
-        column: int,
-        line: int,
-        start: int,
-        end: Optional[int],
+        column: int, # one-based
+        line: int, # one-based
+        start: int, # zero-based
+        end: Optional[int], # zero-based
     ):
         self.set_linecol(line, column)
         self._attrs[FIELD_POSITION_START] = str(start)

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -141,8 +141,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def set_linecol(
         self,
-        line: Optional[int], # one-based
-        col: Optional[int], # one-based
+        line: Optional[int],  # one-based
+        col: Optional[int],  # one-based
     ):
         if line is not None:
             self._attrs[FIELD_LINE_START] = str(line)
@@ -200,8 +200,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def set_position(
         self,
-        start: int, # zero-based
-        end: Optional[int], # zero-based
+        start: int,  # zero-based
+        end: Optional[int],  # zero-based
     ):
         self._attrs[FIELD_POSITION_START] = str(start)
         self._attrs[FIELD_POSITION_END] = str(end or start)

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -160,10 +160,10 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         start_s, end_s = tokenizer.inflate_span(source, (start, end))
 
         self._attrs[FIELD_LINE_START] = str(start_s.line)
-        self._attrs[FIELD_COL_START] = str(start_s.column)
+        self._attrs[FIELD_COLUMN_START] = str(start_s.column)
         if end_s is not None:
             self._attrs[FIELD_LINE_END] = str(end_s.line)
-            self._attrs[FIELD_COL_END] = str(end_s.column)
+            self._attrs[FIELD_COLUMN_END] = str(end_s.column)
 
     def set_hint_and_details(self, hint, details=None):
         ex.replace_context(

--- a/edb/pgsql/parser/exceptions.py
+++ b/edb/pgsql/parser/exceptions.py
@@ -28,7 +28,7 @@ class PSqlSyntaxError(PSqlParseError):
     def __init__(
         self,
         message: str,
-        cursor_pos: int, # 0-based
+        cursor_pos: int,  # 0-based
         query_source: str,
     ):
         self.message = message

--- a/edb/pgsql/parser/exceptions.py
+++ b/edb/pgsql/parser/exceptions.py
@@ -25,9 +25,8 @@ class PSqlParseError(Exception):
 
 
 class PSqlSyntaxError(PSqlParseError):
-    def __init__(self, message, lineno, cursorpos):
+    def __init__(self, message, cursorpos):
         self.message = message
-        self.lineno = lineno
         self.cursorpos = cursorpos
 
     def __str__(self):
@@ -35,6 +34,10 @@ class PSqlSyntaxError(PSqlParseError):
 
 
 class PSqlUnsupportedError(PSqlParseError):
+    node: Optional[Any]
+    location: Optional[int]
+    message: str
+
     def __init__(self, node: Optional[Any] = None, feat: Optional[str] = None):
         self.node = node
         self.location = None

--- a/edb/pgsql/parser/exceptions.py
+++ b/edb/pgsql/parser/exceptions.py
@@ -25,9 +25,15 @@ class PSqlParseError(Exception):
 
 
 class PSqlSyntaxError(PSqlParseError):
-    def __init__(self, message, cursorpos):
+    def __init__(
+        self,
+        message: str,
+        cursor_pos: int, # 0-based
+        query_source: str,
+    ):
         self.message = message
-        self.cursorpos = cursorpos
+        self.cursor_pos = cursor_pos
+        self.query_source = query_source
 
     def __str__(self):
         return self.message

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -90,7 +90,8 @@ def pg_parse(query) -> str:
     if result.error:
         error = PSqlSyntaxError(
             result.error.message.decode('utf8'),
-            result.error.cursorpos
+            result.error.cursorpos,
+            query,
         )
         pg_query_free_parse_result(result)
         raise error
@@ -141,7 +142,8 @@ def pg_normalize(query: str) -> NormalizedQuery:
         if result.error:
             error = PSqlSyntaxError(
                 result.error.message.decode('utf8'),
-                result.error.cursorpos
+                result.error.cursorpos,
+                query,
             )
             raise error
 

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -90,7 +90,7 @@ def pg_parse(query) -> str:
     if result.error:
         error = PSqlSyntaxError(
             result.error.message.decode('utf8'),
-            result.error.lineno, result.error.cursorpos
+            result.error.cursorpos
         )
         pg_query_free_parse_result(result)
         raise error
@@ -141,7 +141,7 @@ def pg_normalize(query: str) -> NormalizedQuery:
         if result.error:
             error = PSqlSyntaxError(
                 result.error.message.decode('utf8'),
-                result.error.lineno, result.error.cursorpos
+                result.error.cursorpos
             )
             raise error
 

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -758,7 +758,7 @@ def static_interpret_psql_parse_error(
     res: errors.EdgeDBError
     if isinstance(exc, parser_errors.PSqlSyntaxError):
         res = errors.EdgeQLSyntaxError(str(exc))
-        res.set_position(exc.lineno, 0, exc.cursorpos - 1, None)
+        res.set_position(0, 0, exc.cursorpos - 1, None)
     elif isinstance(exc, parser_errors.PSqlUnsupportedError):
         res = errors.UnsupportedFeatureError(str(exc))
     else:

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -758,9 +758,11 @@ def static_interpret_psql_parse_error(
     res: errors.EdgeDBError
     if isinstance(exc, parser_errors.PSqlSyntaxError):
         res = errors.EdgeQLSyntaxError(str(exc))
-        res.set_position(0, 0, exc.cursorpos - 1, None)
+        res.set_position(exc.cursorpos - 1, None)
     elif isinstance(exc, parser_errors.PSqlUnsupportedError):
         res = errors.UnsupportedFeatureError(str(exc))
+        if exp.location is not None:
+            res.set_position(exp.location, None)
     else:
         res = errors.InternalServerError(str(exc))
 

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -758,7 +758,8 @@ def static_interpret_psql_parse_error(
     res: errors.EdgeDBError
     if isinstance(exc, parser_errors.PSqlSyntaxError):
         res = errors.EdgeQLSyntaxError(str(exc))
-        res.set_position(exc.cursorpos - 1, None)
+        res.set_position(exc.cursor_pos - 1, None)
+        res.compute_line_col(exc.query_source)
     elif isinstance(exc, parser_errors.PSqlUnsupportedError):
         res = errors.UnsupportedFeatureError(str(exc))
         if exp.location is not None:

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -762,8 +762,8 @@ def static_interpret_psql_parse_error(
         res.compute_line_col(exc.query_source)
     elif isinstance(exc, parser_errors.PSqlUnsupportedError):
         res = errors.UnsupportedFeatureError(str(exc))
-        if exp.location is not None:
-            res.set_position(exp.location, None)
+        if exc.location is not None:
+            res.set_position(exc.location, None)
     else:
         res = errors.InternalServerError(str(exc))
 

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -1008,9 +1008,8 @@ async def interpret_error(
             # Translate error position for SQL queries if we can
             if source_map and isinstance(exc, errors.EdgeDBError):
                 if 'P' in fields:
-                    exc.set_position(
-                        0,
-                        0,
+                    errors.EdgeDBError.set_position(
+                        exc,
                         source_map.translate(int(fields['P'])),
                         None,
                     )

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -440,7 +440,7 @@ cdef class PgConnection(frontend.FrontendConnection):
             exc = pgerror.new(
                 pgerror.ERROR_SYNTAX_ERROR,
                 str(exc),
-                P=str(exc.cursorpos),
+                P=str(exc.cursor_pos),
             )
         elif isinstance(exc, errors.AuthenticationError):
             exc = pgerror.InvalidAuthSpec(str(exc), severity="FATAL")

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -440,7 +440,6 @@ cdef class PgConnection(frontend.FrontendConnection):
             exc = pgerror.new(
                 pgerror.ERROR_SYNTAX_ERROR,
                 str(exc),
-                L=str(exc.lineno),
                 P=str(exc.cursorpos),
             )
         elif isinstance(exc, errors.AuthenticationError):

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -2952,8 +2952,12 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         with self.assertRaisesRegex(
             edgedb.errors.EdgeQLSyntaxError,
             'syntax error at or near',
+            _position=54,
+            _col=25,
+            _line=3,
         ):
             await self.con.query_sql('''
+                -- a comment
                 select (), asdf
             ''')
 
@@ -2993,6 +2997,19 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         ):
             await self.con.query_sql('''
                 select relacl from pg_class limit 1
+            ''')
+
+    async def test_sql_native_query_31(self):
+        with self.assertRaisesRegex(
+            edgedb.EdgeQLSyntaxError,
+            'syntax error at or near "from"',
+            _position=48,
+            _col=25,
+            _line=3,
+        ):
+            await self.con.query_sql('''
+                select
+                  limit from x
             ''')
 
 


### PR DESCRIPTION
Closes https://github.com/geldata/gel/issues/8390

I suggest reviewing this commit by commit:

- **remove usage of lineno**

libpg_query's `PgQueryError` contains field `lineno`, which we assumed is the line of the query source where the error occurred. It is not. It is line of the .c file that has produced the parser error. We don't ever want to use this. 

- **minor optimization of inflate_span**

Just something I noticed.

- **don't emit bogus positions**

When we didn't have line and col info, we used to default to 0. Which is worse than nothing, so I removed it.

This also adds code for computing line&col, but I'm not yet calling it, because that requires the original source, which I don't know how to get.


