### PR TITLE
Add deno install instructions for npm package

### DIFF
--- a/docs/intro/clients.rst
+++ b/docs/intro/clients.rst
@@ -110,7 +110,7 @@ Install the Gel client library.
   .. code-tab:: txt
     :caption: Deno
 
-    n/a
+    deno install npm:gel
 
   .. code-tab:: bash
     :caption: Python
@@ -257,7 +257,7 @@ Finally, execute the file.
   .. code-tab:: bash
     :caption: Deno
 
-    $ deno run --allow-all --unstable index.deno.ts
+    $ deno run --allow-all index.ts
 
   .. code-tab:: bash
     :caption: Python


### PR DESCRIPTION
Deno now has a package manager and can install packages from npm. Update the instructions to reflect that.