### PR TITLE
Fix IS when the LHS is not just a path

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -1103,6 +1103,12 @@ def compile_type_check_op(
     typeref = typegen.ql_typeexpr_to_ir_typeref(expr.right, ctx=ctx)
 
     if ltype.is_object_type() and not ltype.is_free_object_type(ctx.env.schema):
+        # Argh, what a mess path factoring and deduplication is!  We
+        # need to dereference __type__, and <Expr> needs to be visible
+        # in the scope when we do it, or else it will get
+        # deduplicated.
+        pathctx.register_set_in_scope(left, ctx=ctx)
+
         left = setgen.ptr_step_set(
             left, expr=None, source=ltype, ptr_name='__type__',
             span=expr.span, ctx=ctx

--- a/tests/test_edgeql_introspection.py
+++ b/tests/test_edgeql_introspection.py
@@ -1127,6 +1127,22 @@ class TestIntrospection(tb.QueryTestCase):
             [True] * res
         )
 
+        # Try it in a sub scope!
+        await self.assert_query_result(
+            r"""
+                SELECT {schema::Object} IS std::BaseObject;
+            """,
+            [True] * res
+        )
+
+        # ...but not std::Objects
+        await self.assert_query_result(
+            r"""
+                SELECT {schema::Object} IS NOT std::Object;
+            """,
+            [True] * res
+        )
+
     @test.xerror(
         "Known collation issue on Heroku Postgres",
         unless=os.getenv("EDGEDB_TEST_BACKEND_VENDOR") != "heroku-postgres"


### PR DESCRIPTION
As part of IS, we inspect `.__type__`, and so need to be careful to
avoid triggering our despiséd (by me, at least) path deduplication.