### PR TITLE
Move all edgeql tests over to using simple_scoping

### DIFF
--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -978,7 +978,7 @@ def ignore_warnings(warning_message=None):
 class ConnectedTestCase(ClusterTestCase):
 
     BASE_TEST_CLASS = True
-    NO_FACTOR = False
+    NO_FACTOR = True
     WARN_FACTOR = False
 
     con: tconn.Connection

--- a/tests/test_edgeql_calls.py
+++ b/tests/test_edgeql_calls.py
@@ -26,8 +26,6 @@ from edb.tools import test
 
 class TestEdgeQLFuncCalls(tb.QueryTestCase):
 
-    NO_FACTOR = True
-
     async def test_edgeql_calls_01(self):
         await self.con.execute('''
             CREATE FUNCTION call1(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -49,6 +49,9 @@ class TestEdgeQLCasts(tb.QueryTestCase):
     If x can be losslessly cast into Y, then casting it back is also lossless:
         x = <X><Y>x
     '''
+
+    NO_FACTOR = True
+
     # FIXME: a special schema should be used here since we need to
     # cover all known scalars and even some arrays and tuples.
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
@@ -542,7 +545,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # values.
         await self.assert_query_result(
             r'''
-                WITH x := {'true', 'false'}
+                FOR x in {'true', 'false'}
                 SELECT <str><bool>x = x;
             ''',
             [True, True],
@@ -550,7 +553,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {'True', 'False', 'TRUE', 'FALSE', '  TrUe   '}
+                FOR x in {'True', 'False', 'TRUE', 'FALSE', '  TrUe   '}
                 SELECT <str><bool>x = x;
             ''',
             [False, False, False, False, False],
@@ -558,7 +561,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {'True', 'False', 'TRUE', 'FALSE', 'TrUe'}
+                FOR x in {'True', 'False', 'TRUE', 'FALSE', 'TrUe'}
                 SELECT <str><bool>x = str_lower(x);
             ''',
             [True, True, True, True, True],
@@ -580,7 +583,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # str to json is always lossless
         await self.assert_query_result(
             r'''
-                WITH x := {'any', 'arbitrary', '♠gibberish♠'}
+                FOR x in {'any', 'arbitrary', '♠gibberish♠'}
                 SELECT <str><json>x = x;
             ''',
             [True, True, True],
@@ -590,7 +593,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # canonical uuid representation as a string is using lowercase
         await self.assert_query_result(
             r'''
-                WITH x := 'd4288330-eea3-11e8-bc5f-7faf132b1d84'
+                FOR x in 'd4288330-eea3-11e8-bc5f-7faf132b1d84'
                 SELECT <str><uuid>x = x;
             ''',
             [True],
@@ -599,7 +602,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # non-canonical
             r'''
-                WITH x := {
+                FOR x in {
                     'D4288330-EEA3-11E8-BC5F-7FAF132B1D84',
                     'D4288330-Eea3-11E8-Bc5F-7Faf132B1D84',
                     'D4288330-eea3-11e8-bc5f-7faf132b1d84',
@@ -611,7 +614,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {
+                FOR x in {
                     'D4288330-EEA3-11E8-BC5F-7FAF132B1D84',
                     'D4288330-Eea3-11E8-Bc5F-7Faf132B1D84',
                     'D4288330-eea3-11e8-bc5f-7faf132b1d84',
@@ -627,7 +630,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # in UTC time zone.
         await self.assert_query_result(
             r'''
-                WITH x := '2018-05-07T20:01:22.306916+00:00'
+                FOR x in '2018-05-07T20:01:22.306916+00:00'
                 SELECT <str><datetime>x = x;
             ''',
             [True],
@@ -636,7 +639,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same datetime
             r'''
-                WITH x := {
+                FOR x in {
                     '2018-05-07T15:01:22.306916-05:00',
                     '2018-05-07T15:01:22.306916-05',
                     '2018-05-07T20:01:22.306916Z',
@@ -690,7 +693,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # in UTC time zone.
         await self.assert_query_result(
             r'''
-                WITH x := '2018-05-07T20:01:22.306916'
+                FOR x in '2018-05-07T20:01:22.306916'
                 SELECT <str><cal::local_datetime>x = x;
             ''',
             [True],
@@ -699,7 +702,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same datetime
             r'''
-                WITH x := {
+                FOR x in {
                     # the '-' and ':' separators may be omitted
                     '20180507T200122.306916',
                     # acceptable RFC 3339
@@ -755,7 +758,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # 8601.
         await self.assert_query_result(
             r'''
-                WITH x := '2018-05-07'
+                FOR x in '2018-05-07'
                 SELECT <str><cal::local_date>x = x;
             ''',
             [True],
@@ -764,7 +767,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same date
             r'''
-                WITH x := {
+                FOR x in {
                     # the '-' separators may be omitted
                     '20180507',
                 }
@@ -802,7 +805,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # 8601.
         await self.assert_query_result(
             r'''
-                WITH x := '20:01:22.306916'
+                FOR x in '20:01:22.306916'
                 SELECT <str><cal::local_time>x = x;
             ''',
             [True],
@@ -810,7 +813,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {
+                FOR x in {
                     '20:01',
                     '20:01:00',
                     # the ':' separators may be omitted
@@ -838,7 +841,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # Canonical duration
         await self.assert_query_result(
             r'''
-                WITH x := 'PT20H1M22.306916S'
+                FOR x in 'PT20H1M22.306916S'
                 SELECT <str><duration>x = x;
             ''',
             [True],
@@ -847,7 +850,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # non-canonical
             r'''
-                WITH x := {
+                FOR x in {
                     '20:01:22.306916',
                     '20h 1m 22.306916s',
                     '20 hours 1 minute 22.306916 seconds',
@@ -862,7 +865,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same duration
             r'''
-                WITH x := {
+                FOR x in {
                     '20:01:22.306916',
                     '20h 1m 22.306916s',
                     '20 hours 1 minute 22.306916 seconds',
@@ -879,7 +882,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # there's no whitespace, which is trimmed
         await self.assert_query_result(
             r'''
-                WITH x := {'-20', '0', '7', '12345'}
+                FOR x in {'-20', '0', '7', '12345'}
                 SELECT <str><int16>x = x;
             ''',
             [True, True, True, True],
@@ -887,7 +890,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {'-20', '0', '7', '12345'}
+                FOR x in {'-20', '0', '7', '12345'}
                 SELECT <str><int32>x = x;
             ''',
             [True, True, True, True],
@@ -895,7 +898,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {'-20', '0', '7', '12345'}
+                FOR x in {'-20', '0', '7', '12345'}
                 SELECT <str><int64>x = x;
             ''',
             [True, True, True, True],
@@ -904,7 +907,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # with whitespace
             r'''
-                WITH x := {
+                FOR x in {
                     '       42',
                     '42     ',
                     '       42      ',
@@ -917,7 +920,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same value
             r'''
-                WITH x := {
+                FOR x in {
                     '       42',
                     '42     ',
                     '       42      ',
@@ -934,7 +937,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # lossy.
         await self.assert_query_result(
             r'''
-                WITH x := {'-20', '0', '7.2'}
+                FOR x in {'-20', '0', '7.2'}
                 SELECT <str><float32>x = x;
             ''',
             [True, True, True],
@@ -942,7 +945,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {'-20', '0', '7.2'}
+                FOR x in {'-20', '0', '7.2'}
                 SELECT <str><float64>x = x;
             ''',
             [True, True, True],
@@ -951,7 +954,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # non-canonical
             r'''
-                WITH x := {
+                FOR x in {
                     '0.0000000001234',
                     '1234E-13',
                     '0.1234e-9',
@@ -963,7 +966,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := {
+                FOR x in {
                     '0.0000000001234',
                     '1234E-13',
                     '0.1234e-9',
@@ -976,7 +979,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same value
             r'''
-                WITH x := {
+                FOR x in {
                     '0.0000000001234',
                     '1234E-13',
                     '0.1234e-9',
@@ -991,7 +994,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # use of scientific notation.
         await self.assert_query_result(
             r'''
-                WITH x := {
+                FOR x in {
                     '-20', '0', '7.2', '0.0000000001234', '1234.00000001234'
                 }
                 SELECT <str><decimal>x = x;
@@ -1002,7 +1005,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # non-canonical
             r'''
-                WITH x := {
+                FOR x in {
                     '1234E-13',
                     '0.1234e-9',
                 }
@@ -1014,7 +1017,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same date
             r'''
-                WITH x := {
+                FOR x in {
                     '1234E-13',
                     '0.1234e-9',
                 }
@@ -1156,7 +1159,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 # technically we're already casting a literal int64
                 # to int16 first
                 f'''
-                    WITH x := <int16>{{-32768, -32767, -100,
+                    FOR x in <int16>{{-32768, -32767, -100,
                                       0, 13, 32766, 32767}}
                     SELECT <int16><{numtype}>x = x;
                 ''',
@@ -1167,7 +1170,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 # technically we're already casting a literal int64
                 # to int32 first
                 f'''
-                    WITH x := <int32>{{-2147483648, -2147483647, -65536, -100,
+                    FOR x in <int32>{{-2147483648, -2147483647, -65536, -100,
                                       0, 13, 32768, 2147483646, 2147483647}}
                     SELECT <int32><{numtype}>x = x;
                 ''',
@@ -1176,7 +1179,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
             await self.assert_query_result(
                 f'''
-                    WITH x := <int64>{{
+                    FOR x in <int64>{{
                         -9223372036854775808,
                         -9223372036854775807,
                         -4294967296,
@@ -1203,7 +1206,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             # technically we're already casting a literal int64 or
             # float64 to float32 first
             r'''
-                WITH x := <float32>{-3.31234e+38, -1.234e+12, -1.234e-12,
+                FOR x in <float32>{-3.31234e+38, -1.234e+12, -1.234e-12,
                                     -100, 0, 13, 1.234e-12, 1.234e+12, 3.4e+38}
                 SELECT <float32><decimal>x = x;
             ''',
@@ -1212,7 +1215,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := <float64>{-1.61234e+308, -1.234e+42, -1.234e-42,
+                FOR x in <float64>{-1.61234e+308, -1.234e+42, -1.234e-42,
                                     -100, 0, 13, 1.234e-42, 1.234e+42,
                                     1.7e+308}
                 SELECT <float64><decimal>x = x;
@@ -1230,7 +1233,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # ints <= 2^24 can be represented exactly in a float32
             r'''
-            WITH x := <int32>{16777216, 16777215, 16777214,
+            FOR x in <int32>{16777216, 16777215, 16777214,
                               1677721, 167772, 16777}
             SELECT <int32><float32>x = x;
             ''',
@@ -1240,7 +1243,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # max int32 -100, -1000
             r'''
-            WITH x := <int32>{2147483548, 2147482648}
+            FOR x in <int32>{2147483548, 2147482648}
             SELECT <int32><float32>x = x;
             ''',
             [False, False],
@@ -1248,7 +1251,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            WITH x := <int32>{2147483548, 2147482648}
+            FOR x in <int32>{2147483548, 2147482648}
             SELECT <int32><float32>x;
             ''',
             [2147483520, 2147482624],
@@ -1258,7 +1261,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # ints <= 2^24 can be represented exactly in a float32
             r'''
-                WITH x := <int32>{16777216, 16777215, 16777214,
+                FOR x in <int32>{16777216, 16777215, 16777214,
                                   1677721, 167772, 16777}
                 SELECT <int32><float64>x = x;
             ''',
@@ -1268,7 +1271,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # max int32 -1, -2, -3, -10, -100, -1000
             r'''
-            WITH x := <int32>{2147483647, 2147483646, 2147483645,
+            FOR x in <int32>{2147483647, 2147483646, 2147483645,
                               2147483638, 2147483548, 2147482648}
             SELECT <int32><float64>x = x;
             ''',
@@ -1282,7 +1285,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             r'''
                 # 2^31 -1, -2, -3, -10
-                WITH x := <int32>{2147483647, 2147483646, 2147483645,
+                FOR x in <int32>{2147483647, 2147483646, 2147483645,
                                   2147483638}
                 # 2147483647 is the max int32
                 SELECT x <= <int32>2147483647;
@@ -2218,7 +2221,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # in UTC time zone.
         await self.assert_query_result(
             r'''
-                WITH x := <json>'2018-05-07T20:01:22.306916+00:00'
+                FOR x in <json>'2018-05-07T20:01:22.306916+00:00'
                 SELECT <json><datetime>x = x;
             ''',
             [True],
@@ -2227,7 +2230,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same datetime
             r'''
-                WITH x := <json>{
+                FOR x in <json>{
                     '2018-05-07T15:01:22.306916-05:00',
                     '2018-05-07T15:01:22.306916-05',
                     '2018-05-07T20:01:22.306916Z',
@@ -2288,7 +2291,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # in UTC time zone.
         await self.assert_query_result(
             r'''
-                WITH x := <json>'2018-05-07T20:01:22.306916'
+                FOR x in <json>'2018-05-07T20:01:22.306916'
                 SELECT <json><cal::local_datetime>x = x;
             ''',
             [True],
@@ -2297,7 +2300,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         await self.assert_query_result(
             # validating that these are all in fact the same datetime
             r'''
-                WITH x := <json>{
+                FOR x in <json>{
                     # the '-' and ':' separators may be omitted
                     '20180507T200122.306916',
                     # acceptable RFC 3339
@@ -2358,7 +2361,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # 8601.
         await self.assert_query_result(
             r'''
-                WITH x := <json>'2018-05-07'
+                FOR x in <json>'2018-05-07'
                 SELECT <json><cal::local_date>x = x;
             ''',
             [True],
@@ -2368,7 +2371,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
             # validating that these are all in fact the same date
             r'''
                 # the '-' separators may be omitted
-                WITH x := <json>'20180507'
+                FOR x in <json>'20180507'
                 SELECT
                     <cal::local_date>x = <cal::local_date><json>'2018-05-07';
             ''',
@@ -2409,7 +2412,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         # 8601.
         await self.assert_query_result(
             r'''
-                WITH x := <json>'20:01:22.306916'
+                FOR x in <json>'20:01:22.306916'
                 SELECT <json><cal::local_time>x = x;
             ''',
             [True],
@@ -2417,7 +2420,7 @@ class TestEdgeQLCasts(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-                WITH x := <json>{
+                FOR x in <json>{
                     '20:01',
                     '20:01:00',
                     # the ':' separators may be omitted

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -50,8 +50,6 @@ class TestEdgeQLCasts(tb.QueryTestCase):
         x = <X><Y>x
     '''
 
-    NO_FACTOR = True
-
     # FIXME: a special schema should be used here since we need to
     # cover all known scalars and even some arrays and tuples.
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -26,6 +26,8 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     """The test DB is designed to test various coalescing operations.
     """
 
+    NO_FACTOR = True
+
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
@@ -50,6 +52,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             sort=lambda x: x['time_estimate']
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_scalar_02(self):
         await self.assert_query_result(
             r'''
@@ -145,6 +148,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             sort=lambda x: x['number']
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_scalar_08(self):
         await self.assert_query_result(
             r'''
@@ -225,6 +229,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_scalar_12(self):
         await self.assert_query_result(
             r'''
@@ -305,6 +310,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             sort=lambda x: x['te']
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_set_03(self):
         await self.assert_query_result(
             r'''
@@ -391,6 +397,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             sort=lambda x: x['number']
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_set_08(self):
         await self.assert_query_result(
             r'''
@@ -480,6 +487,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_02(self):
         await self.assert_query_result(
             r'''
@@ -499,6 +507,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_03(self):
         await self.assert_query_result(
             r'''
@@ -649,6 +658,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_12(self):
         await self.assert_query_result(
             r'''
@@ -668,6 +678,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_13(self):
         await self.assert_query_result(
             r'''
@@ -702,6 +713,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             sort=True
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_15(self):
         await self.assert_query_result(
             r'''
@@ -765,6 +777,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             sort=True
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_18(self):
         await self.assert_query_result(
             r'''
@@ -779,6 +792,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             sort=True
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_19(self):
         await self.assert_query_result(
             r'''
@@ -888,6 +902,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_21(self):
         await self.assert_query_result(
             r'''
@@ -898,6 +913,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             {'High', 'Low', 'Open', 'Closed'},
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_dependent_22(self):
         await self.assert_query_result(
             r'''
@@ -1048,6 +1064,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_object_02(self):
         await self.assert_query_result(
             r'''
@@ -1160,6 +1177,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_object_07(self):
         await self.assert_query_result(
             r'''
@@ -1412,6 +1430,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             [],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_set_of_nonempty_01(self):
         await self.con.execute(
             '''INSERT Publication { title := "1" }''')
@@ -1451,6 +1470,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ["a"],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_correlation_01(self):
         await self.assert_query_result(
             r'''
@@ -1461,6 +1481,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ["Issue 160", "Issue 290", "Issue 390"],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_correlation_02(self):
         await self.assert_query_result(
             r'''
@@ -1497,6 +1518,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_tuple_02(self):
         await self.assert_query_result(
             r'''
@@ -1514,6 +1536,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
 
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_tuple_03(self):
         await self.assert_query_result(
             r'''
@@ -1530,6 +1553,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ]
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_tuple_04(self):
         await self.assert_query_result(
             r'''
@@ -1546,6 +1570,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_tuple_05(self):
         await self.assert_query_result(
             r'''
@@ -1597,6 +1622,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_tuple_08(self):
         await self.con.execute('''
             CREATE TYPE Foo {
@@ -1706,6 +1732,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             [2, 4],
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_overload_01(self):
         # first argument bool -> optional second arg
         await self.assert_query_result(
@@ -1766,6 +1793,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
             ]),
         )
 
+    @tb.needs_factoring
     async def test_edgeql_coalesce_overload_02(self):
         # first argument int -> singleton second arg
         await self.assert_query_result(
@@ -1969,3 +1997,7 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
                   ?? [is MultiRange].element_type.id,
             };
         ''')
+
+
+class TestEdgeQLCoalesceNoFactor(TestEdgeQLCoalesce):
+    NO_FACTOR = True

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -26,8 +26,6 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
     """The test DB is designed to test various coalescing operations.
     """
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12924,16 +12924,15 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
                 with model := (
                     select schema::ObjectType {
                         x := (
-                            select (.annotations, .annotations@value)
-                            filter (
-                                .0.name
-                                = 'ext::ai::embedding_model_max_batch_tokens'
-                            )
+                            for ann in .annotations
+                            select ann@value
+                            filter ann.name
+                            = 'ext::ai::embedding_model_max_batch_tokens'
                         )
                     }
                     filter .name = 'default::TestEmbeddingModel'
                 )
-                select model.x.1
+                select model.x
             """,
             ['8191'],
         )

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -16321,6 +16321,10 @@ DDLStatement);
 
     async def test_edgeql_ddl_scoping_future_01(self):
         await self.con.execute("""
+            configure session reset simple_scoping
+        """)
+
+        await self.con.execute("""
             create type T;
             insert T;
             insert T;

--- a/tests/test_edgeql_expr_aliases.py
+++ b/tests/test_edgeql_expr_aliases.py
@@ -29,8 +29,6 @@ import edgedb
 class TestEdgeQLExprAliases(tb.QueryTestCase):
     '''The scope is to test expression aliases.'''
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'cards.esdl')
 

--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -184,7 +184,6 @@ def get_test_items(**flags):
 
 
 class TestExpressions(tb.QueryTestCase):
-    NO_FACTOR = True
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -26,13 +26,14 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     """The test DB is designed to test certain non-trivial FILTER clauses.
     """
 
+    NO_FACTOR = True
+
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
     SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
                          'issues_filter_setup.edgeql')
 
-    @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_filter_two_scalar_conditions01(self):
         await self.assert_query_result(
             r'''
@@ -40,10 +41,12 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 # time_estimate > 9000 and due_date on 2020/01/15.
                 SELECT User{name}
                 FILTER
-                    User.<owner[IS Issue].time_estimate > 9000
-                    AND
-                    User.<owner[IS Issue].due_date =
-                        <datetime>'2020-01-15T00:00:00+00:00'
+                    any((
+                      for issue in User.<owner[IS Issue]
+                      select issue.time_estimate > 9000
+                      AND
+                      issue.due_date = <datetime>'2020-01-15T00:00:00+00:00'
+                    ))
                 ORDER BY User.name;
             ''',
             # Only one Issue satisfies this and its owner is Yury.
@@ -100,34 +103,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                                     <datetime>'2020-01-15T00:00:00+00:00'
                             )
                     )
-                ORDER BY User.name;
-            ''',
-            # Only one Issue satisfies this and its owner is Yury.
-            [{'name': 'Yury'}],
-        )
-
-    @tb.ignore_warnings('more than one.* in a FILTER clause')
-    async def test_edgeql_filter_two_scalar_conditions04(self):
-        await self.assert_query_result(
-            r'''
-                # NOTE: semantically same as and01, but using OR,
-                #       separate roots and explicit joining
-                #
-                # Find Users who own at least one Issue with simultaneously
-                # time_estimate > 9000 and due_date on 2020/01/15.
-                WITH
-                    U2 := User
-                SELECT User{name}
-                FILTER
-                    NOT (
-                        NOT EXISTS (User.<owner[IS Issue].time_estimate > 9000)
-                        OR
-                        NOT EXISTS (U2.<owner[IS Issue].due_date =
-                            <datetime>'2020-01-15T00:00:00+00:00')
-                    )
-                    AND
-                    # making sure it's the same Issue in both sub-clauses
-                    User.<owner[IS Issue] = U2.<owner[IS Issue]
                 ORDER BY User.name;
             ''',
             # Only one Issue satisfies this and its owner is Yury.
@@ -194,9 +169,11 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                 FILTER
                     EXISTS User.<owner[IS Issue]
                     AND
-                    NOT EXISTS U2.<owner[IS Issue].time_estimate
-                    AND
-                    User.<owner[IS Issue] = U2.<owner[IS Issue]
+                    (FOR lol IN U2.<owner[IS Issue]
+                    SELECT
+                      NOT EXISTS lol.time_estimate
+                      AND
+                      User.<owner[IS Issue] = lol)
                 ORDER BY User.name;
             ''',
             # Elvis and Yury have Issues without time_estimate.
@@ -243,33 +220,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
                                 NOT EXISTS I.due_date
                             )
                     )
-                ORDER BY User.name;
-            ''',
-            # Only one Issue satisfies this and its owner is Yury.
-            [{'name': 'Yury'}],
-        )
-
-    @tb.ignore_warnings('more than one.* in a FILTER clause')
-    async def test_edgeql_filter_two_scalar_exists03(self):
-        await self.assert_query_result(
-            r'''
-                # NOTE: same as above, but using OR,
-                #       separate roots and explicit joining
-                #
-                # Find Users who own at least one Issue with simultaneously
-                # time_estimate > 9000 and due_date on 2020/01/15.
-                WITH
-                    U2 := User
-                SELECT User{name}
-                FILTER
-                    NOT (
-                        NOT EXISTS User.<owner[IS Issue].time_estimate
-                        OR
-                        NOT EXISTS U2.<owner[IS Issue].due_date
-                    )
-                    AND
-                    # making sure it's the same Issue in both sub-clauses
-                    User.<owner[IS Issue] = U2.<owner[IS Issue]
                 ORDER BY User.name;
             ''',
             # Only one Issue satisfies this and its owner is Yury.

--- a/tests/test_edgeql_filter.py
+++ b/tests/test_edgeql_filter.py
@@ -26,8 +26,6 @@ class TestEdgeQLFilter(tb.QueryTestCase):
     """The test DB is designed to test certain non-trivial FILTER clauses.
     """
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -28,6 +28,8 @@ from edb.tools import test
 class TestEdgeQLFor(tb.QueryTestCase):
     '''These tests are focused on using FOR statement.'''
 
+    NO_FACTOR = True
+
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'cards.esdl')
 
@@ -692,14 +694,16 @@ class TestEdgeQLFor(tb.QueryTestCase):
                         {
                             "name": "Bog monster",
                             "letter": {"B!!", "B!?"},
-                            "correlated": {("!", "!"), ("?", "?")},
+                            "correlated": {("!", "!"), ("!", "?"),
+                                           ("?", "!"), ("?", "?")},
                             "uncorrelated": {("!", "!"), ("!", "?"),
                                              ("?", "!"), ("?", "?")}
                         },
                         {
                             "name": "Imp",
                             "letter": {"I!!", "I!?"},
-                            "correlated": {("!", "!"), ("?", "?")},
+                            "correlated": {("!", "!"), ("!", "?"),
+                                           ("?", "!"), ("?", "?")},
                             "uncorrelated": {("!", "!"), ("!", "?"),
                                              ("?", "!"), ("?", "?")}
                         },
@@ -996,7 +1000,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                     SELECT (X, (FOR x in {X} UNION (SELECT x)))
                 ));
             ''',
-            [2],
+            [4],
         )
 
         await self.assert_query_result(
@@ -1006,7 +1010,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                     SELECT ((FOR x in {X} UNION (SELECT x)), X)
                 ));
             ''',
-            [2],
+            [4],
         )
 
     async def test_edgeql_for_correlated_02(self):
@@ -1016,7 +1020,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                               (FOR x in {Card} UNION (SELECT x.name)),
                 ));
             ''',
-            [9],
+            [81],
         )
 
     async def test_edgeql_for_correlated_03(self):
@@ -1026,7 +1030,7 @@ class TestEdgeQLFor(tb.QueryTestCase):
                                Card.name,
                 ));
             ''',
-            [9],
+            [81],
         )
 
     async def test_edgeql_for_empty_01(self):

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -28,8 +28,6 @@ from edb.tools import test
 class TestEdgeQLFor(tb.QueryTestCase):
     '''These tests are focused on using FOR statement.'''
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'cards.esdl')
 

--- a/tests/test_edgeql_fts.py
+++ b/tests/test_edgeql_fts.py
@@ -31,8 +31,6 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
     various FTS schema features.
     '''
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas', 'fts.esdl')
 
     SETUP = os.path.join(

--- a/tests/test_edgeql_fts.py
+++ b/tests/test_edgeql_fts.py
@@ -31,6 +31,8 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
     various FTS schema features.
     '''
 
+    NO_FACTOR = True
+
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas', 'fts.esdl')
 
     SETUP = os.path.join(
@@ -674,20 +676,20 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
         # Use a property to provide the search query
         await self.assert_query_result(
             r'''
-            with res := fts::search(
+            with res := (for Post in Post select fts::search(
                 Post,
                 Post.note,
                 language := 'eng',
                 weights := [0.5, 1.0],
-            )
-            select res.object {
+            ))
+            select (for res in res select res.object {
                 title,
                 body,
                 note,
                 score := res.score
-            }
-            filter res.score > 0
-            order by res.score desc
+            })
+            filter .score > 0
+            order by .score desc
             ''',
             [
                 {
@@ -965,17 +967,17 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
         # Use a property to define the language.
         await self.assert_query_result(
             r'''
-            with res := fts::search(
+            with res := (for DynamicLang in DynamicLang select fts::search(
                 DynamicLang,
                 'clear pane',
                 language := <str>DynamicLang.lang,
-            )
-            select res.object {
+            ))
+            select (for res in res select res.object {
                 text,
                 score := res.score
-            }
-            filter res.score > 0
-            order by res.score desc
+            })
+            filter .score > 0
+            order by .score desc
             ''',
             [
                 {"text": "The window pane is clear", "score": 0.6079271},
@@ -985,17 +987,17 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
 
         await self.assert_query_result(
             r'''
-            with res := fts::search(
+            with res := (for DynamicLang in DynamicLang select fts::search(
                 DynamicLang,
                 'pain gain',
                 language := <str>DynamicLang.lang,
-            )
-            select res.object {
+            ))
+            select (for res in res select res.object {
                 text,
                 score := res.score
-            }
-            filter res.score > 0
-            order by res.score desc
+            })
+            filter .score > 0
+            order by .score desc
             ''',
             [
                 {"text": "No pain no gain", "score": 0.6079271},
@@ -1182,21 +1184,21 @@ class TestEdgeQLFTSQuery(tb.QueryTestCase):
         # Use weights to change search priority: weights from property
         await self.assert_query_result(
             r'''
-            with res := fts::search(
+            with res := (for Post in Post select fts::search(
                 Post,
                 'random angry replying giraffes',
                 language := 'eng',
                 # Note that if the weight property is {}, the default weights
                 # will be used.
                 weights := [Post.weight_a, 0.7],
-            )
-            select res.object {
+            ))
+            select (for res in res select res.object {
                 title,
                 body,
                 score := res.score
-            }
-            filter res.score > 0
-            order by res.score desc
+            })
+            filter .score > 0
+            order by .score desc
             ''',
             [
                 {

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -32,7 +32,6 @@ from edb.tools import test
 
 
 class TestEdgeQLFunctions(tb.QueryTestCase):
-    NO_FACTOR = True
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')

--- a/tests/test_edgeql_functions_inline.py
+++ b/tests/test_edgeql_functions_inline.py
@@ -24,7 +24,6 @@ from edb.testbase import server as tb
 
 
 class TestEdgeQLFunctionsInline(tb.QueryTestCase):
-    NO_FACTOR = True
 
     async def test_edgeql_functions_inline_basic_01(self):
         await self.con.execute('''

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -27,6 +27,7 @@ from edb.tools import test
 class TestEdgeQLGroup(tb.QueryTestCase):
     '''These tests are focused on using the internal GROUP statement.'''
 
+    NO_FACTOR = False
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
@@ -4060,4 +4061,5 @@ class TestEdgeQLGroupNoFactor(TestEdgeQLGroup):
 
 
 class TestEdgeQLGroupWarnFactor(TestEdgeQLGroup):
+    NO_FACTOR = False
     WARN_FACTOR = True

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -29,7 +29,7 @@ from edb.tools import test
 
 class TestInsert(tb.QueryTestCase):
     '''The scope of the tests is testing various modes of Object creation.'''
-    # NO_FACTOR = True
+    NO_FACTOR = False
     WARN_FACTOR = True
     INTERNAL_TESTMODE = False
 

--- a/tests/test_edgeql_internal_group.py
+++ b/tests/test_edgeql_internal_group.py
@@ -303,7 +303,7 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
         await self.assert_query_result(
             r"""
                 SELECT
-                    R := (
+                    R := (for User in User union (
                         name := User.name,
                         issues := array_agg(
                             (
@@ -320,7 +320,7 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
                                 ORDER BY .status
                             )
                         )
-                    )
+                    ))
                 ORDER BY R.name;
             """,
             [
@@ -889,8 +889,9 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
                 IN Issue
                 UNION (
                     # array_agg with ordering instead of sum
-                    numbers := array_agg(
-                        <int64>Issue.number ORDER BY Issue.number),
+                    numbers := array_agg((
+                        select
+                        _ := <int64>Issue.number ORDER BY _)),
                     status := Stat,
                     time_estimate := Est ?? 0
                 )
@@ -927,10 +928,10 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
                 IN Issue
                 UNION (
                     # a couple of array_agg
-                    numbers := array_agg(
-                        <int64>Issue.number ORDER BY Issue.number),
-                    watchers := array_agg(
-                        <str>Issue.watchers.name ORDER BY Issue.watchers.name),
+                    numbers := array_agg((select
+                        _ := <int64>Issue.number ORDER BY _)),
+                    watchers := array_agg((select
+                        _ := Issue.watchers.name ORDER BY _)),
                     status := Stat,
                     time_estimate := Est ?? 0
                 )
@@ -1014,8 +1015,8 @@ class TestEdgeQLGroupInternal(tb.QueryTestCase):
                 BY Stat, X
                 IN Issue
                 UNION (
-                    numbers := array_agg(
-                        <int64>Issue.number ORDER BY Issue.number),
+                    numbers := array_agg((select
+                        _ := <int64>Issue.number ORDER BY _)),
                     watchers := count(DISTINCT Issue.watchers),
                     status := Stat,
                     cnt := count(DISTINCT Issue),

--- a/tests/test_edgeql_json.py
+++ b/tests/test_edgeql_json.py
@@ -824,10 +824,7 @@ class TestEdgeQLJSON(tb.QueryTestCase):
                             "w": 2
                         }'))
                     )
-                SELECT
-                    <int64>q.1.1
-                ORDER BY
-                    q.1.0;
+                SELECT <int64>(SELECT q ORDER BY q.1.0).1.1;
             ''',
             [1, 2]
         )

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -28,8 +28,6 @@ from edb.tools import test
 class TestEdgeQLLinkproperties(tb.QueryTestCase):
     '''The scope is to test link properties.'''
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'cards.esdl')
 

--- a/tests/test_edgeql_linkprops.py
+++ b/tests/test_edgeql_linkprops.py
@@ -442,11 +442,11 @@ class TestEdgeQLLinkproperties(tb.QueryTestCase):
                     name,
                     same := EXISTS (
                         SELECT User
-                        FILTER (
+                        FILTER any ((
                             FOR User IN User FOR deck IN User.deck SELECT
                             Card.cost = deck@count AND
                             Card = deck
-                        )
+                        ))
                     )
                 }
                 ORDER BY .name;

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -28,8 +28,6 @@ from edb.testbase import server as tb
 class TestEdgeQLPolicies(tb.QueryTestCase):
     '''Tests for policies.'''
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 

--- a/tests/test_edgeql_rewrites.py
+++ b/tests/test_edgeql_rewrites.py
@@ -26,8 +26,6 @@ from edb.testbase import server as tb
 
 class TestRewrites(tb.QueryTestCase):
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas', 'movies.esdl')
     # Setting up some rewrites makes the tests run a bit faster
     # because we don't need to recompile the delta scripts for it.

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -29,8 +29,6 @@ from edb.tools import test
 class TestEdgeQLScope(tb.QueryTestCase):
     '''This tests the scoping rules.'''
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'cards.esdl')
 

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -26,6 +26,7 @@ from edb.tools import test
 
 
 class TestEdgeQLSelect(tb.QueryTestCase):
+    NO_FACTOR = False
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
@@ -8502,4 +8503,5 @@ class TestEdgeQLSelectNoFactor(TestEdgeQLSelect):
 
 
 class TestEdgeQLSelectWarnFactor(TestEdgeQLSelect):
+    NO_FACTOR = False
     WARN_FACTOR = True

--- a/tests/test_edgeql_triggers.py
+++ b/tests/test_edgeql_triggers.py
@@ -27,8 +27,6 @@ from edb.testbase import server as tb
 class TestTriggers(tb.QueryTestCase):
     '''The scope of the tests is testing various modes of Object creation.'''
 
-    NO_FACTOR = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'insert.esdl')
 

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -28,7 +28,6 @@ from edb.tools import test
 
 
 class TestUpdate(tb.QueryTestCase):
-    NO_FACTOR = True
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'updates.esdl')

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -28,6 +28,8 @@ from edb.tools import test
 
 
 class TestUpdate(tb.QueryTestCase):
+    NO_FACTOR = True
+
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'updates.esdl')
 
@@ -2166,7 +2168,7 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_correlated_bad_01(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                "cannot reference correlated set 'Status' here"):
+                "possibly more than one element"):
             await self.con.execute(r'''
                 SELECT (
                     Status,
@@ -2179,7 +2181,7 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_correlated_bad_02(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                "cannot reference correlated set 'Status' here"):
+                "possibly more than one element"):
             await self.con.execute(r'''
                 SELECT (
                     (UPDATE UpdateTest SET {
@@ -2192,7 +2194,7 @@ class TestUpdate(tb.QueryTestCase):
     async def test_edgeql_update_correlated_bad_03(self):
         with self.assertRaisesRegex(
                 edgedb.QueryError,
-                "cannot reference correlated set 'UpdateTest' here"):
+                "can not take cross product of volatile operation"):
             await self.con.execute(r'''
                 SELECT (
                     UpdateTest,

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -28,9 +28,6 @@ from edb.tools import test
 
 
 class TestEdgeQLVolatility(tb.QueryTestCase):
-    # XXX
-    NO_FACTOR = False
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'volatility.esdl')
 
@@ -744,12 +741,8 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
                 SELECT (O.m, O.m);
             """)
 
-            self.assertEqual(len(res), 3)
-            for row in res:
-                self.assertEqual(row[0], row[1])
-
-            # Make sure it is really volatile
-            self.assertNotEqual(res[0][0], res[1][0])
+            self.assertEqual(len(res), 9)
+            self._check_crossproduct(res)
 
     async def test_edgeql_volatility_select_hard_objects_01b(self):
         for query in self._test_loop():
@@ -759,9 +752,8 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
                 SELECT ((SELECT O.m), O.m);
             """)
 
-            self.assertEqual(len(res), 3)
-            for row in res:
-                self.assertEqual(row[0], row[1])
+            self.assertEqual(len(res), 9)
+            self._check_crossproduct(res)
 
     async def test_edgeql_volatility_select_hard_objects_02a(self):
         for query in self._test_loop():
@@ -791,9 +783,9 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
                 SELECT (O {m}, O {m});
             """)
 
-            self.assertEqual(len(res), 3)
-            for row in res:
-                self.assertEqual(row[0]['m'], row[1]['m'])
+            self.assertEqual(len(res), 9)
+            self._check_crossproduct(
+                [(row[0]['m'], row[1]['m']) for row in res])
 
     async def test_edgeql_volatility_select_hard_objects_04a(self):
         # TODO: this, but wrapped in DISTINCT
@@ -861,9 +853,9 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
                 SELECT ((O {m}), (O {m}));
             """)
 
-            self.assertEqual(len(res), 3)
-            for row in res:
-                self.assertEqual(row[0]['m'], row[1]['m'])
+            self.assertEqual(len(res), 9)
+            self._check_crossproduct(
+                [(tuple(row[0]['m']), tuple(row[1]['m'])) for row in res])
 
     async def test_edgeql_volatility_select_hard_objects_08a(self):
         for query in self._test_loop(single=True):
@@ -1084,12 +1076,6 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
                 };
             """)
 
-            cs = {x['n']: [] for x in res['a']}
-            for rc in res['c']:
-                self.assertEqual(rc[1]['n'], rc[2]['n'])
-                self.assertEqual(rc[1]['x'], rc[2]['x'])
-                cs[rc[0]].append([rc[1]['n'], rc[1]['x']])
-
             for ra, rb in zip(res['a'], res['b']):
                 self.assertLessEqual(len(ra['friends']), 4)
 
@@ -1100,11 +1086,6 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
 
                 self.assertEqual(
                     sorted([x['n'], x['x']] for x in ra['friends']),
-                    sorted(rb['friends_tuples']),
-                )
-
-                self.assertEqual(
-                    sorted(cs[ra['n']]),
                     sorted(rb['friends_tuples']),
                 )
 
@@ -1262,7 +1243,7 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
         await self.assert_query_result(r'''
             WITH X := ((SELECT Obj { m := next() }),),
                  Y := ((SELECT Obj { m := next() }),),
-            SELECT count((SELECT (X, Y) FILTER X = Y));
+            SELECT count((SELECT (X, Y) FILTER .0 = .1));
         ''', [
             3,
         ])
@@ -1270,7 +1251,7 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
         await self.assert_query_result(r'''
             WITH X := ((SELECT Obj { m := next() }),),
                  Y := ((SELECT Obj { m := next() }),),
-            SELECT count((SELECT (X, Y) FILTER X < Y));
+            SELECT count((SELECT (X, Y) FILTER .0 < .1));
         ''', [
             3,
         ])
@@ -1278,7 +1259,7 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
         await self.assert_query_result(r'''
             WITH X := ((SELECT Obj { m := next() }),),
                  Y := (Obj,),
-            SELECT count((SELECT (X, Y) FILTER X < Y));
+            SELECT count((SELECT (X, Y) FILTER .0 < .1));
         ''', [
             3,
         ])
@@ -1364,131 +1345,6 @@ class TestEdgeQLVolatility(tb.QueryTestCase):
             {"m": 2, "n": 2},
             {"m": 2, "n": 3},
         ])
-
-    async def test_edgeql_volatility_hack_03a(self):
-        await self.assert_query_result(r'''
-            WITH X := (WITH x := {1,2}, SELECT (x, Obj {m := x})).1
-            SELECT X { n, m } ORDER BY .m THEN .n;
-        ''', [
-            {"m": 1, "n": 1},
-            {"m": 1, "n": 2},
-            {"m": 1, "n": 3},
-            {"m": 2, "n": 1},
-            {"m": 2, "n": 2},
-            {"m": 2, "n": 3},
-        ])
-
-    async def test_edgeql_volatility_hack_03b(self):
-        await self.assert_query_result(r'''
-            WITH X := (WITH x := {1,2}, SELECT (x, Obj {m := x}).1)
-            SELECT X { n, m } ORDER BY .m THEN .n;
-        ''', [
-            {"m": 1, "n": 1},
-            {"m": 1, "n": 2},
-            {"m": 1, "n": 3},
-            {"m": 2, "n": 1},
-            {"m": 2, "n": 2},
-            {"m": 2, "n": 3},
-        ])
-
-    async def test_edgeql_volatility_hack_04a(self):
-        await self.assert_query_result(r'''
-            SELECT (WITH x := {1,2}, SELECT (x, Obj {m := x})).1
-            { n, m } ORDER BY .m THEN .n;
-        ''', [
-            {"m": 1, "n": 1},
-            {"m": 1, "n": 2},
-            {"m": 1, "n": 3},
-            {"m": 2, "n": 1},
-            {"m": 2, "n": 2},
-            {"m": 2, "n": 3},
-        ])
-
-    async def test_edgeql_volatility_hack_04b(self):
-        await self.assert_query_result(r'''
-            SELECT (WITH x := {1,2}, SELECT (x, Obj {m := x}).1)
-            { n, m } ORDER BY .m THEN .n;
-        ''', [
-            {"m": 1, "n": 1},
-            {"m": 1, "n": 2},
-            {"m": 1, "n": 3},
-            {"m": 2, "n": 1},
-            {"m": 2, "n": 2},
-            {"m": 2, "n": 3},
-        ])
-
-    async def test_edgeql_volatility_hack_05a(self):
-        await self.assert_query_result(r'''
-            SELECT (WITH x := {(SELECT Tgt FILTER .n < 3)},
-                    SELECT (x.n, Obj {m := x.n})).1
-            { n, m } ORDER BY .m THEN .n;
-        ''', [
-            {"m": 1, "n": 1},
-            {"m": 1, "n": 2},
-            {"m": 1, "n": 3},
-            {"m": 2, "n": 1},
-            {"m": 2, "n": 2},
-            {"m": 2, "n": 3},
-        ])
-
-    async def test_edgeql_volatility_hack_05b(self):
-        await self.assert_query_result(r'''
-            WITH X :=  (WITH x := {(SELECT Tgt FILTER .n < 3)},
-                        SELECT (x.n, Obj {m := x.n})).1,
-            SELECT X { n, m } ORDER BY .m THEN .n;
-        ''', [
-            {"m": 1, "n": 1},
-            {"m": 1, "n": 2},
-            {"m": 1, "n": 3},
-            {"m": 2, "n": 1},
-            {"m": 2, "n": 2},
-            {"m": 2, "n": 3},
-        ])
-
-    async def test_edgeql_volatility_for_like_hard_01(self):
-        for query in self._test_loop():
-            res = await query("""
-                WITH
-                    O := (SELECT Obj { x := next() }),
-                    Z := (O, (SELECT O { n, x, y := -.x })).1
-                SELECT Z { n, x, y };
-            """)
-
-            self.assertEqual(len(res), 3)
-            self.assertNotEqual(res[0]['x'], res[1]['x'])
-            for obj in res:
-                self.assertEqual(obj['x'], -obj['y'])
-
-    @test.xerror("column definition list is only allowed ...")
-    async def test_edgeql_volatility_for_like_hard_02(self):
-        # Weird stuff is happening here!
-        # 1. Putting basically anything other than O as the 1st tuple el works
-        # 2. If we reorder the arguments it works
-        # 3. If we add a real shape to the nested O, it works
-        for query in self._test_loop():
-            res = await query("""
-                WITH
-                    O := (SELECT Obj { x := next() }),
-                    Z := (O, ({ o := O })).1
-                SELECT Z { o: {n, x} };
-            """)
-
-            self.assertEqual(len(res), 3)
-            self.assertNotEqual(res[0]['o']['x'], res[1]['o']['x'])
-
-    @test.xerror("column definition list is only allowed ...")
-    async def test_edgeql_volatility_for_like_hard_03(self):
-        for query in self._test_loop():
-            res = await query("""
-                WITH
-                    O := (SELECT Obj { x := next() }),
-                    Za := (O, ({ o := O })),
-                    Z := Za.1
-                SELECT Z { o: {n, x} };
-            """)
-
-            self.assertEqual(len(res), 3)
-            self.assertNotEqual(res[0]['o']['x'], res[1]['o']['x'])
 
     async def test_edgeql_volatility_for_hard_01(self):
         for query in self._test_loop():

--- a/tests/test_edgeql_volatility.py
+++ b/tests/test_edgeql_volatility.py
@@ -28,6 +28,9 @@ from edb.tools import test
 
 
 class TestEdgeQLVolatility(tb.QueryTestCase):
+    # XXX
+    NO_FACTOR = False
+
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'volatility.esdl')
 


### PR DESCRIPTION
I've left a few suites for now that still run in multiple modes.

Possibly some of the HTTP tests still rely on factoring. I'll be
moving to put the future in the schemas soon.