### PR TITLE
Do not duplicate kwarg in WebAuthnFactor creation

### DIFF
--- a/edb/server/protocol/auth_ext/webauthn.py
+++ b/edb/server/protocol/auth_ext/webauthn.py
@@ -221,7 +221,7 @@ select factor { ** };""",
         assert len(result_json) == 1
 
         factor_dict = result_json[0]
-        local_identity = data.LocalIdentity(**factor_dict["identity"])
+        local_identity = data.LocalIdentity(**factor_dict.pop("identity"))
         return data.WebAuthnFactor(**factor_dict, identity=local_identity)
 
     async def _get_registration_challenge(


### PR DESCRIPTION
You cannot provide the same argument twice in a dataclass instantiation like I was doing attempting to overide the existing argument with a new one, but instead we pop the value from the `identity` property off when instantiating the `LocalIdentity` class instance which removes it from the source dictionary.