### PR TITLE
Default `cors_always_allowed_origins` to localhost for `edb server`

### DIFF
--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -57,6 +57,8 @@ def server(version=False, **kwargs):
     os.environ['EDGEDB_DEBUG_SERVER'] = '1'
     debug.init_debug_flags()
     kwargs['security'] = srv_args.ServerSecurityMode.InsecureDevMode
+    if kwargs['cors_always_allowed_origins'] is None:
+       kwargs['cors_always_allowed_origins'] = "http://localhost:*"
     srv_main.server_main(**kwargs)
 
 

--- a/edb/tools/edb.py
+++ b/edb/tools/edb.py
@@ -58,7 +58,7 @@ def server(version=False, **kwargs):
     debug.init_debug_flags()
     kwargs['security'] = srv_args.ServerSecurityMode.InsecureDevMode
     if kwargs['cors_always_allowed_origins'] is None:
-       kwargs['cors_always_allowed_origins'] = "http://localhost:*"
+        kwargs['cors_always_allowed_origins'] = "http://localhost:*"
     srv_main.server_main(**kwargs)
 
 


### PR DESCRIPTION
To make local ui development easier, when running the `edb server` command set the `cors_always_allowed_origins` setting to `http://localhost:*` by default, so I don't have to remember to either set it via the command line arg/env var, or set the `cors_allow_origins` config.