### PR TITLE
Fix schema reflection losing track of changes made while `using future`

### DIFF
--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -139,12 +139,21 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
     def is_compiled(self) -> bool:
         return self.refs is not None
 
+    # Filter out refs that don't really exist; these can show up
+    # on 6.x because of issue #8431.
+    # TODO: Drop this once backported.
+    def _live_refs(self, schema: s_schema.Schema) -> tuple[so.Object, ...]:
+        return tuple([
+            schema.get_by_id(iid) for iid in self.refs._ids
+            if schema.has_object(iid)
+        ]) if self.refs else ()
+
     def _refs_keys(
         self, schema: s_schema.Schema
     ) -> Set[Tuple[Type[so.Object], sn.Name]]:
         return {
             (type(x), x.get_name(schema))
-            for x in (self.refs.objects(schema) if self.refs else ())
+            for x in (self._live_refs(schema) if self.refs else ())
         }
 
     @classmethod
@@ -305,7 +314,7 @@ class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
         return ExpressionShell(
             text=self.text,
             refs=(
-                r.as_shell(schema) for r in self.refs.objects(schema)
+                r.as_shell(schema) for r in self._live_refs(schema)
             ) if self.refs is not None else None,
             _qlast=self._qlast,
         )

--- a/edb/schema/futures.py
+++ b/edb/schema/futures.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Callable, Type, cast
 
 from edb import errors
+from edb.common import markup
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -88,6 +89,19 @@ class FutureBehaviorCommand(
     # If anything else ends up needing to do this, we can add another
     # variety of subcommand.
     future_cmd: sd.Command | None = None
+
+    @classmethod
+    def as_markup(
+        cls, self: sd.Command, *, ctx: markup.Context
+    ) -> markup.Markup:
+        assert isinstance(self, FutureBehaviorCommand)
+        node = super().as_markup(self, ctx=ctx)
+        assert isinstance(node, markup.elements.lang.TreeNode)
+        if self.future_cmd:
+            node.add_child(node=markup.elements.doc.Marker(text='future_cmd'))
+            node.add_child(node=markup.serialize(self.future_cmd, ctx=ctx))
+
+        return node
 
     def copy(self: FutureBehaviorCommand) -> FutureBehaviorCommand:
         result = super().copy()

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -17804,3 +17804,48 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             """,
             [True],
         )
+
+    async def test_edgeql_ddl_no_tx_scoping_future_03(self):
+        await self.con.execute("""
+            CREATE GLOBAL default::current_user_id -> std::uuid;
+
+            CREATE TYPE default::User {
+                CREATE REQUIRED PROPERTY is_admin: std::bool;
+            };
+
+            CREATE GLOBAL default::current_user := (SELECT
+                default::User
+            FILTER
+                (.id = GLOBAL default::current_user_id)
+            );
+
+            CREATE FUTURE simple_scoping;
+
+            ALTER TYPE default::User {
+                CREATE ACCESS POLICY admin_only
+                    ALLOW ALL USING (((GLOBAL default::current_user).is_admin
+                       ?? false));
+            };
+        """)
+
+        # Do some random configure current database in order to force
+        # a reload of the schema from reflection.
+        await self.con.execute("""
+            configure current database reset __internal_sess_testvalue
+        """)
+
+        await self.con.query_single("""
+            describe schema as ddl
+        """)
+        cur = await self.con.query_single("""
+            describe schema as sdl
+        """)
+        await self.con.execute(f"""
+            start migration to {{ {cur} }};
+            populate migration;
+            commit migration;
+        """)
+
+        await self.con.execute("""
+            reset schema to initial
+        """)


### PR DESCRIPTION
Setting `using future simple_scoping` (or `warn_old_scoping`) can cause
expressions to be recompiled. When globals and expression aliases are
recompiled, their underlying ObjectType may be deleted and then restored.

Not much depends on that, but it will frequently show up in expression
refs.

There is a bug in futures (there since the beginning) where we don't
reflect the changes made when compiling the future out to the in-database
schema, which can cause bad problems. Here, the problem is that refs can
refer to ObjectTypes for globals that don't exist in the database.

The forward fix is easy: do that.

Fixes #8431.

---
Handling the case where the mistake has already been made is more annoying.

The approach we take is to filter out expr `refs` that don't actually exist
in the schema. This does not really fix the state, but will unbreak doing a
dump, at least.

I think the state could also be fixed by dropping the future and recreating
it.

---

The test I added passes with *either* of the other two commits applied.