### PR TITLE
Fix recent regression that discard ends of spans

### DIFF
--- a/edb/edgeql/tokenizer.py
+++ b/edb/edgeql/tokenizer.py
@@ -155,7 +155,7 @@ def inflate_span(
 
     points = [start]
     if end is not None:
-        points.append(start)
+        points.append(end)
 
     points_sp = ql_parser.SourcePoint.from_offsets(source_bytes, points)
 

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -2179,3 +2179,20 @@ annotation test::foo;
             global foo -> str;
         };
         """
+
+    @tb.must_fail(
+        errors.EdgeQLSyntaxError,
+        r"Unexpected keyword",
+        col=13,
+        col_end=19,
+        line=3,
+        line_end=3,
+        position=30,
+        position_end=36,
+    )
+    def test_eschema_syntax_extra_create(self):
+        """
+        type T {
+            create property lol -> str;
+        }
+        """


### PR DESCRIPTION
Bug was introduced in by a typo #8399 and hasn't made it out to a
release yet.

It turns out we never test for the end of spans in the server test
suite, so this got caught by the CLI!