### PR TITLE
Make `std::net` polling output quieter

### DIFF
--- a/edb/server/net_worker.py
+++ b/edb/server/net_worker.py
@@ -304,9 +304,9 @@ async def _delete_requests(
             )
             result: list[int] = json.loads(result_json)
             if result[0] > 0:
-                logger.info(f"Deleted {result[0]} requests")
+                logger.debug(f"Deleted {result[0]} requests")
             else:
-                logger.info(f"No requests to delete")
+                logger.debug(f"No requests to delete")
 
 
 async def _gc(tenant: edbtenant.Tenant, expires_in: statypes.Duration) -> None:


### PR DESCRIPTION
`info` was very noisy in the logs.

![image](https://github.com/user-attachments/assets/340e222a-0ce6-4f26-b200-dfe9c0323162)
