### PR TITLE
Do not use special Gel directive in alt-titles

### DIFF
--- a/docs/cloud/deploy/netlify.rst
+++ b/docs/cloud/deploy/netlify.rst
@@ -4,7 +4,7 @@
 Netlify
 =======
 
-:edb-alt-title: Deploying applications built on |Gel| Cloud to Netlify
+:edb-alt-title: Deploying applications built on Gel Cloud to Netlify
 
 .. note::
 

--- a/docs/cloud/deploy/railway.rst
+++ b/docs/cloud/deploy/railway.rst
@@ -4,7 +4,7 @@
 Railway
 =======
 
-:edb-alt-title: Deploying applications built on |Gel| Cloud to Railway
+:edb-alt-title: Deploying applications built on Gel Cloud to Railway
 
 1. Push project to GitHub or some other Git remote repository
 2. Create and make note of a secret key for your Gel Cloud instance

--- a/docs/cloud/deploy/render.rst
+++ b/docs/cloud/deploy/render.rst
@@ -4,7 +4,7 @@
 Render
 ======
 
-:edb-alt-title: Deploying applications built on |Gel| Cloud to Render
+:edb-alt-title: Deploying applications built on Gel Cloud to Render
 
 1. Push project to GitHub or some other Git remote repository
 2. Create and make note of a secret key for your Gel Cloud instance


### PR DESCRIPTION
This was causing the title to be truncated to just before the `|`.