### PR TITLE
Make free objects always considered UNIQUE

### DIFF
--- a/edb/edgeql/compiler/inference/context.py
+++ b/edb/edgeql/compiler/inference/context.py
@@ -37,9 +37,6 @@ class MultiplicityInfo:
     #: Whether this multiplicity descriptor describes
     #: part of a disjoint set.
     disjoint_union: bool = False
-    #: Whether this multiplicity descriptor represents
-    #: a freshly created free object.
-    fresh_free_object: bool = False
 
     def is_empty(self) -> bool:
         return self.own.is_empty()

--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -801,7 +801,7 @@ def __infer_group_stmt(
     infer_multiplicity(ir.subject, scope_tree=scope_tree, ctx=ctx)
     for binding, _ in ir.using.values():
         infer_multiplicity(binding, scope_tree=scope_tree, ctx=ctx)
-    result_mult = _infer_stmt_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
+    _infer_stmt_multiplicity(ir, scope_tree=scope_tree, ctx=ctx)
 
     for clause in (ir.orderby or ()):
         new_scope = inf_utils.get_set_scope(clause.expr, scope_tree, ctx=ctx)

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -751,12 +751,20 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
         UNIQUE
         """
 
+    def test_edgeql_ir_mult_inference_77b(self):
+        """
+        for x in {1, 1} union { foo := 10 }
+% OK %
+        UNIQUE
+        """
+
     def test_edgeql_ir_mult_inference_78(self):
+        # free objects always unique, now
         """
         with F := { foo := 10 }
         for x in {1, 2} union F
 % OK %
-        DUPLICATE
+        UNIQUE
         """
 
     def test_edgeql_ir_mult_inference_79(self):


### PR DESCRIPTION
Freshly created free objects in for loops (`for x in {1,2,3} select {
x := x }`) were supposed to have always been considered unique, but a
bug in multiplicity inference meant that this only happened when the
multiplicity inference could prove that the iterator was unique.

This is both not necessary and basically never happens except in the
multiplicity test suite, because of constant extraction.

As a result, code that tried to put free objects like that into a
pointer needed to use `assert_distinct`. Unfortunately, a 6.x
regression made `assert_distinct` on free objects always *fail*, now
that the `id` field has been removed.

A user ran into this one. It will also cause bad problems for our
"cast to free object" plans.

Fix both of these issues and more by making free objects always
considered UNIQUE. Comparing them isn't allowed, and making them
UNIQUE means assert_distinct will be elided.

Another alternative would be to just fix the FOR+free object inference
code, and then do some more special casing in assert_distinct.