### PR TITLE
Fix 6.x regression when using fts::index and certain inheritance patterns

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -60,7 +60,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_02_26_00_00
+EDGEDB_CATALOG_VERSION = 2025_03_12_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8361,6 +8361,31 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }],
         )
 
+    async def test_edgeql_migration_eq_index_05(self):
+        await self.migrate('''
+            abstract type Named {
+                index fts::index on (
+                    std::fts::with_options(
+                        .name, language := std::fts::Language.eng));
+                required property name: std::str;
+            };
+        ''')
+
+        await self.start_migration('''
+            abstract type Named {
+                index std::fts::index on (
+                    std::fts::with_options(
+                        .name, language := std::fts::Language.eng));
+                required property name: std::str;
+            };
+        ''')
+
+        # no changes
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'complete': True,
+        })
+
     async def test_edgeql_migration_eq_collections_01(self):
         await self.migrate(r"""
             type Base;

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -1374,7 +1374,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                 'title': 'index_name',
                                 'type': 'index',
                                 'value':
-                                    f"index 'pg::gist' of object type "
+                                    f"index 'std::pg::gist' of object type "
                                     f"'default::RangeTest' on (.{fname})",
                             },
                             {
@@ -1410,7 +1410,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                         'title': 'index_name',
                                         'type': 'index',
                                         'value':
-                                            f"index 'pg::gist' of object"
+                                            f"index 'std::pg::gist' of object"
                                             f" type 'default::RangeTest'"
                                             f" on (.{fname})",
                                     },
@@ -1897,7 +1897,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                         'title': 'index_name',
                                         'type': 'index',
                                         'value':
-                                            f"index 'pg::gin' of object"
+                                            f"index 'std::pg::gin' of object"
                                             f" type 'default::JSONTest'"
                                             f" on (.val)",
                                     },

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -295,7 +295,7 @@ class TestIndexes(tb.DDLTestCase):
                 {
                     'indexes': [
                         {
-                            'name': 'fts::index',
+                            'name': 'std::fts::index',
                             'kwargs': [],
                             'expr': (
                                 'std::fts::with_options(.name, '


### PR DESCRIPTION
In #7743, we moved `fts` and some other modules underneath `std`.
Unfortunately, index names are not properly normalized to refer to
them as such, and so FTS indexes specified as `fts::index` would
typically have `fts::index` as their shortname. This is wrong in
general, and also specifically wrong since some code paths *do*
produce normalized names, causing breakages.

Fix it by normalizing the name.

I did some testing, and this should be backportable if we use
`schema-repair`. I hate `schema-repair` but I think it is safer than
some of the non-repair ideas I had, like trying to ignore this
particular name difference.

Fixes #8465