### PR TITLE
[6.x] Fix 6.x regression when using fts::index and certain inheritance patterns

### DIFF
--- a/.github/workflows.src/tests-patches.tpl.yml
+++ b/.github/workflows.src/tests-patches.tpl.yml
@@ -54,7 +54,10 @@ jobs:
 
     - name: Create databases on the older version
       if: ${{ matrix.make-dbs }}
-      run: python3 .github/scripts/patches/create-databases.py ${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}/bin/edgedb-server
+      run: |
+        DIR=${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}
+        python3 .github/scripts/patches/create-databases.py $DIR/bin/edgedb-server
+        (cd $DIR && GEL_SERVER_SECURITY=insecure_dev_mode ./bin/python3 -m edb.tools --no-devmode inittestdb --update -D ../test-dir -t ../tests -k test_edgeql_fts_regression)
 
     - name: Run tests with instance created on an older version
       run: |
@@ -63,6 +66,10 @@ jobs:
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
         edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py
+
+        # Run the fts_regression tests directly against the old databases,
+        # without running setup.
+        edb test -j1 -k test_edgeql_fts_regression -v --data-dir test-dir --use-data-dir-dbs
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/.github/workflows/tests-patches.yml
+++ b/.github/workflows/tests-patches.yml
@@ -515,7 +515,10 @@ jobs:
 
     - name: Create databases on the older version
       if: ${{ matrix.make-dbs }}
-      run: python3 .github/scripts/patches/create-databases.py ${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}/bin/edgedb-server
+      run: |
+        DIR=${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}
+        python3 .github/scripts/patches/create-databases.py $DIR/bin/edgedb-server
+        (cd $DIR && GEL_SERVER_SECURITY=insecure_dev_mode ./bin/python3 -m edb.tools --no-devmode inittestdb --update -D ../test-dir -t ../tests -k test_edgeql_fts_regression)
 
     - name: Run tests with instance created on an older version
       run: |
@@ -524,6 +527,10 @@ jobs:
         edb server --bootstrap-only --data-dir test-dir
         # Should we run *all* the tests?
         edb test -j2 -v --data-dir test-dir tests/test_edgeql_json.py tests/test_edgeql_casts.py tests/test_edgeql_functions.py tests/test_edgeql_expressions.py tests/test_edgeql_policies.py tests/test_edgeql_vector.py tests/test_edgeql_scope.py tests/test_http_ext_auth.py tests/test_ext_ai.py
+
+        # Run the fts_regression tests directly against the old databases,
+        # without running setup.
+        edb test -j1 -k test_edgeql_fts_regression -v --data-dir test-dir --use-data-dir-dbs
 
     - name: Test downgrading a database after an upgrade
       if: ${{ !contains(matrix.edgedb-version, '-rc') && !contains(matrix.edgedb-version, '-beta') }}

--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -166,4 +166,6 @@ alter type ext::ai::EmbeddingModel {
       ext::ai::embedding_model_max_batch_tokens := "8191";
 }
 '''),
+    # 6.3
+    ('repair', ''),  # For #8466
 ]

--- a/tests/schemas/fts_regression.esdl
+++ b/tests/schemas/fts_regression.esdl
@@ -1,0 +1,26 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+abstract type Named {
+    index fts::index on (
+        std::fts::with_options(
+            .name, language := std::fts::Language.eng));
+    required name: std::str;
+};
+
+type Project0 extending Named;

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -8361,6 +8361,31 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }],
         )
 
+    async def test_edgeql_migration_eq_index_05(self):
+        await self.migrate('''
+            abstract type Named {
+                index fts::index on (
+                    std::fts::with_options(
+                        .name, language := std::fts::Language.eng));
+                required property name: std::str;
+            };
+        ''')
+
+        await self.start_migration('''
+            abstract type Named {
+                index std::fts::index on (
+                    std::fts::with_options(
+                        .name, language := std::fts::Language.eng));
+                required property name: std::str;
+            };
+        ''')
+
+        # no changes
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'complete': True,
+        })
+
     async def test_edgeql_migration_eq_collections_01(self):
         await self.migrate(r"""
             type Base;

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -13334,3 +13334,62 @@ class TestEdgeQLMigrationRewriteNonisolated(TestEdgeQLMigrationRewrite):
             await self.con.execute(r"""
                 create applied migration { }
             """)
+
+
+class TestEdgeQLFtsRegression(EdgeQLDataMigrationTestCase):
+    PARALLELISM_GRANULARITY = 'default'
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'fts_regression.esdl')
+
+    DEFAULT_MODULE = 'default'
+
+    async def test_edgeql_fts_regression_01(self):
+        await self.start_migration('''
+            abstract type Named {
+                index std::fts::index on (
+                    std::fts::with_options(
+                        .name, language := std::fts::Language.eng));
+                required name: std::str;
+            };
+
+            type Project0 extending Named;
+        ''', module='default')
+
+        # no changes
+        await self.assert_describe_migration({
+            'confirmed': [],
+            'complete': True,
+        })
+
+    async def test_edgeql_fts_regression_02(self):
+        await self.migrate('''
+            abstract type Named {
+                index fts::index on (
+                    fts::with_options(
+                        .name, language := std::fts::Language.eng));
+                required name: std::str;
+            };
+
+            type Project0 extending Named;
+            type Project1 extending Named {
+              overloaded name {
+                constraint exclusive;
+              }
+            };
+        ''', module='default')
+
+        await self.migrate('', module='default')
+
+    async def test_edgeql_fts_regression_03(self):
+        await self.migrate('', module='default')
+
+    async def test_edgeql_fts_regression_04(self):
+        await self.assert_query_result(
+            '''
+            select schema::Index { name }
+            filter exists .<indexes[is schema::ObjectType]
+            and .name like '%index';
+            ''',
+            [{"name": "std::fts::index"}, {"name": "std::fts::index"}]
+        )

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -1374,7 +1374,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                 'title': 'index_name',
                                 'type': 'index',
                                 'value':
-                                    f"index 'pg::gist' of object type "
+                                    f"index 'std::pg::gist' of object type "
                                     f"'default::RangeTest' on (.{fname})",
                             },
                             {
@@ -1410,7 +1410,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                         'title': 'index_name',
                                         'type': 'index',
                                         'value':
-                                            f"index 'pg::gist' of object"
+                                            f"index 'std::pg::gist' of object"
                                             f" type 'default::RangeTest'"
                                             f" on (.{fname})",
                                     },
@@ -1897,7 +1897,7 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                                         'title': 'index_name',
                                         'type': 'index',
                                         'value':
-                                            f"index 'pg::gin' of object"
+                                            f"index 'std::pg::gin' of object"
                                             f" type 'default::JSONTest'"
                                             f" on (.val)",
                                     },

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -295,7 +295,7 @@ class TestIndexes(tb.DDLTestCase):
                 {
                     'indexes': [
                         {
-                            'name': 'fts::index',
+                            'name': 'std::fts::index',
                             'kwargs': [],
                             'expr': (
                                 'std::fts::with_options(.name, '


### PR DESCRIPTION
This adds some tests where we will create a database using FTS using
old 6.x versions and then try to update it.