### PR TITLE
Fix arg type casting in FunctionExists

### DIFF
--- a/edb/pgsql/dbops/functions.py
+++ b/edb/pgsql/dbops/functions.py
@@ -77,7 +77,7 @@ class FunctionExists(base.Condition):
         self.args = FunctionOperation.normalize_args(args)
 
     def code(self) -> str:
-        targs = [f"{ql('.'.join(a))}::regtype::oid" for _, a, _ in self.args]
+        targs = [f"{ql(qt(a))}::regtype::oid" for _, a, _ in self.args]
         args = f"ARRAY[{','.join(targs)}]"
 
         return textwrap.dedent(f'''\


### PR DESCRIPTION
`FunctionExists` wasn't heavily used with wild argtypes until the persistent cache (single evict), where function argument types required proper quoting.

So instead of generating:

```sql
'edgedbpub.7c77c4b3-c60c-11ef-9dc9-45e8c8454bf8_domain'::regtype::oid
```

It should be:

```sql
'edgedbpub."7c77c4b3-c60c-11ef-9dc9-45e8c8454bf8_domain"'::regtype::oid
```

Fixes #8470 

- [ ] Add test