### PR TITLE
Fix DSN env var usage docs

### DIFF
--- a/docs/reference/reference/dsn.rst
+++ b/docs/reference/reference/dsn.rst
@@ -101,5 +101,5 @@ containing the value (``?host_file=./hostname.txt``).
   .. code-block::
 
     MY_PASSWORD=p@$$w0rd
-    GEL_DSN=gel://hostname.com:1234?password_env=MY_PASSWORD
+    GEL_DSN=gel://hostname.com:1234?password_env=$MY_PASSWORD
 


### PR DESCRIPTION
Bug / Misdocumentation
```
❯ GEL_DSN=gel://hostname.com:1234?password_env=MY_PASSWORD
                                                            
❯ echo GEL_DSN
GEL_DSN
                                                            
❯ echo $GEL_DSN
gel://hostname.com:1234?password_env=MY_PASSWORD
```