### PR TITLE
Add retries to GraphQL test suite runner

### DIFF
--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -32,10 +32,12 @@ import urllib.parse
 import urllib.request
 import dataclasses
 import time
+import random
 
 import edgedb
 
 from edb.errors import base as base_errors
+from edb import errors
 
 from edb.common import assert_data_shape
 
@@ -215,7 +217,7 @@ class GraphQLTestCase(BaseHttpExtensionTest):
         deprecated_globals=None,
     ):
         def inner():
-            self._graphql_query(
+            return self._graphql_query(
                 query,
                 operation_name=operation_name,
                 use_http_post=use_http_post,
@@ -223,9 +225,9 @@ class GraphQLTestCase(BaseHttpExtensionTest):
                 globals=globals,
                 deprecated_globals=deprecated_globals,
             )
-        self._retry_operation(inner)
+        return self._retry_operation(inner)
 
-    async def _retry_operation(self, func):
+    def _retry_operation(self, func):
         i = 0
         while True:
             i += 1

--- a/edb/testbase/http.py
+++ b/edb/testbase/http.py
@@ -31,6 +31,7 @@ import threading
 import urllib.parse
 import urllib.request
 import dataclasses
+import time
 
 import edgedb
 
@@ -204,6 +205,43 @@ class GraphQLTestCase(BaseHttpExtensionTest):
         return "graphql"
 
     def graphql_query(
+        self,
+        query,
+        *,
+        operation_name=None,
+        use_http_post=True,
+        variables=None,
+        globals=None,
+        deprecated_globals=None,
+    ):
+        def inner():
+            self._graphql_query(
+                query,
+                operation_name=operation_name,
+                use_http_post=use_http_post,
+                variables=variables,
+                globals=globals,
+                deprecated_globals=deprecated_globals,
+            )
+        self._retry_operation(inner)
+
+    async def _retry_operation(self, func):
+        i = 0
+        while True:
+            i += 1
+            try:
+                return func()
+
+            # Retry transaction conflict errors
+            except errors.TransactionConflictError:
+                if i >= 10 or self.is_in_transaction():
+                    raise
+                time.sleep(
+                    min((2 ** i) * 0.1, 10)
+                    + random.randrange(100) * 0.001
+                )
+
+    def _graphql_query(
         self,
         query,
         *,


### PR DESCRIPTION
Make our test suite runner for GraphQL retry queries on
TransactionConflictError.
We are getting serilization errors in some test runs.
(Tests on PostgreSQL Versions, remote compiler)
