### PR TITLE
multitenant: improve system API responsiveness

### DIFF
--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -749,7 +749,7 @@ cdef class HttpProtocol:
                 path_parts[1:],
                 self.server,
                 self.tenant,
-                self.is_tenant_host,
+                is_tenant_host=not self.is_tls or self.is_tenant_host,
             )
         elif path_parts == ['metrics'] and request.method == b'GET':
             if not await self._authenticate_for_default_conn_transport(

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1961,6 +1961,16 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                 data,
             )
 
+    async def _test_server_ops_multi_tenant_9(self, mtargs: MultiTenantArgs):
+        self.assertEqual(
+            mtargs.sd.call_system_api("/server/status/alive"),
+            "OK",
+        )
+        self.assertEqual(
+            mtargs.sd.call_system_api("/server/status/ready"),
+            "OK",
+        )
+
 
 class MultiTenantArgs(NamedTuple):
     srv: tb._EdgeDBServer


### PR DESCRIPTION
The status/{ready,alive} endpoints now checks the compiler pool status from the server-side first without blocking, if requested from the multitenant host. This reduces the possible-long response time of system APIs when the compilation pool is fully busy.

Also allows HTTP access on multitenat host system API.

Fixes #8355 