### PR TITLE
Add `.. api-index::` directives to docs

### DIFF
--- a/docs/intro/migrations.rst
+++ b/docs/intro/migrations.rst
@@ -4,7 +4,7 @@
 Migrations
 ==========
 
-.. index:: migrations, fill_expr, cast_expr
+.. index:: fill_expr, cast_expr
 
 |Gel's| baked-in migration system lets you painlessly evolve your schema
 throughout the development process. If you want to work along with this guide,

--- a/docs/reference/clients/js/insert.rst
+++ b/docs/reference/clients/js/insert.rst
@@ -78,7 +78,8 @@ queries:
 
 Handling conflicts
 ^^^^^^^^^^^^^^^^^^
-:index: querybuilder unlessconflict unless conflict constraint
+
+.. index:: querybuilder, unless conflict, constraint
 
 In EdgeQL, "upsert" functionality is achieved by handling **conflicts** on
 ``insert`` statements with the ``unless conflict`` clause. In the query

--- a/docs/reference/clients/js/querybuilder.rst
+++ b/docs/reference/clients/js/querybuilder.rst
@@ -3,7 +3,8 @@
 =======================
 Query Builder Generator
 =======================
-:index: querybuilder generator typescript
+
+.. index:: querybuilder, generator, typescript
 
 The |Gel| query builder provides a **code-first** way to write
 **fully-typed** EdgeQL queries with TypeScript. We recommend it for TypeScript
@@ -196,7 +197,8 @@ that later.
 
 Converting to EdgeQL
 --------------------
-:index: querybuilder toedgeql
+
+.. index:: querybuilder, toedgeql
 
 You can extract an EdgeQL representation of any expression calling the
 ``.toEdgeQL()`` method. Below is a number of expressions and the EdgeQL they

--- a/docs/reference/datamodel/access_policies.rst
+++ b/docs/reference/datamodel/access_policies.rst
@@ -4,8 +4,7 @@
 Access Policies
 ===============
 
-.. index:: access policy, object-level security, row-level security, RLS,
-           allow, deny, using
+.. index:: object-level security, row-level security, RLS
 
 Object types in |Gel| can contain security policies that restrict the set of
 objects that can be selected, inserted, updated, or deleted by a particular
@@ -295,8 +294,7 @@ able to write a new blog post.
 Policy types
 ============
 
-.. index:: access policy, select, insert, delete, update, update read,
-           update write, all
+.. api-index:: select, insert, delete, update read, update write, all
 
 The types of policy rules map to the statement type in EdgeQL:
 
@@ -370,8 +368,6 @@ Policy expressions themselves do not take other policies into account
 Custom error messages
 =====================
 
-.. index:: access policy, errmessage, using
-
 When an ``insert`` or ``update write`` violates an access policy, Gel will
 raise a generic ``AccessPolicyError``:
 
@@ -432,7 +428,7 @@ will receive this error:
 Disabling policies
 ==================
 
-.. index:: apply_access_policies
+.. api-index:: apply_access_policies
 
 You may disable all access policies by setting the ``apply_access_policies``
 :ref:`configuration parameter <ref_std_cfg>` to ``false``.
@@ -573,6 +569,9 @@ E.g. here's a policy that limits the number of blog posts a
 
 Declaring access policies
 =========================
+
+.. api-index:: access policy, when, allow, deny, all, select, insert, delete,
+               update, update read, update write, using, errmessage
 
 This section describes the syntax to declare access policies in your schema.
 

--- a/docs/reference/datamodel/aliases.rst
+++ b/docs/reference/datamodel/aliases.rst
@@ -112,6 +112,8 @@ queries.
 Defining aliases
 ================
 
+.. api-index:: alias
+
 Syntax
 ------
 

--- a/docs/reference/datamodel/annotations.rst
+++ b/docs/reference/datamodel/annotations.rst
@@ -5,8 +5,6 @@
 Annotations
 ===========
 
-.. index:: annotation
-
 *Annotations* are named values associated with schema items and are
 designed to hold arbitrary schema-level metadata represented as a
 :eql:type:`str` (unstructured text).
@@ -18,7 +16,7 @@ more complex metadata.
 Standard annotations
 ====================
 
-.. index:: title, description, deprecated
+.. api-index:: title, description, deprecated
 
 There are a number of annotations defined in the standard library. The
 following are the annotations which can be set on any schema item:
@@ -47,8 +45,6 @@ should be used instead.
 User-defined annotations
 ========================
 
-.. index:: abstract annotation
-
 To declare a custom annotation type beyond the three built-ins, add an abstract
 annotation type to your schema. A custom annotation could be used to attach
 arbitrary JSON-encoded data to your schema—potentially useful for introspection
@@ -67,6 +63,8 @@ and code generation.
 
 Declaring annotations
 =====================
+
+.. api-index:: abstract, inheritable, annotation
 
 This section describes the syntax to use annotations in your schema.
 

--- a/docs/reference/datamodel/computeds.rst
+++ b/docs/reference/datamodel/computeds.rst
@@ -6,7 +6,7 @@ Computeds
 
 :edb-alt-title: Computed properties and links
 
-.. index:: computeds, :=, __source__, backlinks
+.. api-index:: :=
 
 .. important::
 
@@ -51,6 +51,8 @@ field is referenced in a query.
 
 Leading dot notation
 --------------------
+
+.. api-index:: __source__
 
 The example above used the special keyword ``__source__`` to refer to the
 current object; it's analogous to ``this`` or ``self``  in many object-oriented

--- a/docs/reference/datamodel/constraints.rst
+++ b/docs/reference/datamodel/constraints.rst
@@ -5,9 +5,7 @@
 Constraints
 ===========
 
-.. index:: constraint, validation, exclusive, expression on, one_of, max_value,
-           max_ex_value, min_value, min_ex_value, max_len_value, min_len_value,
-           regexp, __subject__
+.. index:: validation
 
 Constraints give users fine-grained control to ensure data consistency.
 They can be defined on :ref:`properties <ref_datamodel_props>`,
@@ -20,6 +18,9 @@ and :ref:`custom scalars <ref_datamodel_links>`.
 
 Standard constraints
 ====================
+
+.. api-index:: exclusive, expression on, one_of, max_value, max_ex_value,
+               min_value, min_ex_value, max_len_value, min_len_value, regexp
 
 |Gel| includes a number of standard ready-to-use constraints:
 
@@ -49,7 +50,7 @@ no longer than 25 characters:
 Constraints on object types
 ===========================
 
-.. index:: __subject__
+.. api-index:: __subject__
 
 Constraints can be defined on object types. This is useful when the
 constraint logic must reference multiple links or properties.
@@ -98,6 +99,8 @@ Inside constraints, the keyword ``__subject__`` can be used to reference the
 Abstract constraints
 ====================
 
+.. api-index:: abstract constraint
+
 You can re-use constraints across multiple object types by declaring them as
 abstract constraints. Example:
 
@@ -143,7 +146,7 @@ Constraints can be defined on computed properties:
 Composite constraints
 =====================
 
-.. index:: tuple
+.. api-index:: constraint exclusive on
 
 To define a composite constraint, create an ``exclusive`` constraint on a
 tuple of properties or links.
@@ -167,7 +170,7 @@ tuple of properties or links.
 Partial constraints
 ===================
 
-.. index:: constraint exclusive on, except
+.. api-index:: constraint exclusive on, except
 
 Constraints on object types can be made partial, so that they are not enforced
 when the specified ``except`` condition is met.
@@ -226,7 +229,7 @@ You can also add constraints for :ref:`link properties
 Link's "@source" and "@target"
 ==============================
 
-.. index:: constraint exclusive on, @source, @target
+.. api-index:: @source, @target
 
 You can create a composite exclusive constraint on the object linking/linked
 *and* a link property by using ``@source`` or ``@target`` respectively. Here's
@@ -307,7 +310,7 @@ using arbitrary EdgeQL expressions. The example below uses the built-in
 Constraints and inheritance
 ===========================
 
-.. index:: delegated constraint
+.. api-index:: delegated constraint
 
 If you define a constraint on a type and then extend that type, the constraint
 will *not* be applied individually to each extending type. Instead, it will

--- a/docs/reference/datamodel/extensions.rst
+++ b/docs/reference/datamodel/extensions.rst
@@ -4,7 +4,7 @@
 Extensions
 ==========
 
-.. index:: using extension
+.. api-index:: using extension
 
 Extensions are the way |Gel| can be extended with more functionality.
 They can add new types, scalars, functions, etc., but, more
@@ -14,8 +14,8 @@ importantly, they can add new ways of interacting with the database.
 Built-in extensions
 ===================
 
-.. index:: edgeql_http, graphql, auth, ai, pg_trgm, pg_unaccent, pgcrypto,
-           pgvector
+.. api-index:: edgeql_http, graphql, auth, ai, pg_trgm, pg_unaccent, pgcrypto,
+               pgvector
 
 There are a few built-in extensions available:
 
@@ -51,7 +51,7 @@ your schema:
 Standalone extensions
 =====================
 
-.. index:: postgis
+.. api-index:: postgis
 
 Additionally, standalone extension packages can be installed via the CLI,
 with ``postgis`` being a notable example.

--- a/docs/reference/datamodel/functions.rst
+++ b/docs/reference/datamodel/functions.rst
@@ -5,8 +5,6 @@
 Functions
 =========
 
-.. index:: function, using
-
 .. note::
 
   This page documents how to define custom functions, however |Gel| provides a
@@ -157,6 +155,9 @@ aggregated into an array as described above:
 
 Declaring functions
 ===================
+
+.. api-index:: function, using, ->, variadic, named only, set of, optional,
+               volatility, Immutable, Stable, Volatile, Modifying
 
 This section describes the syntax to declare a function in your schema.
 

--- a/docs/reference/datamodel/future.rst
+++ b/docs/reference/datamodel/future.rst
@@ -4,7 +4,7 @@
 Future behavior
 ===============
 
-.. index:: future, nonrecursive_access_policies
+.. api-index:: using future
 
 This article explains what the ``using future ...;`` statement means in your
 schema.
@@ -28,6 +28,8 @@ add the ``future`` specification to gain early access.
 
 Flags
 =====
+
+.. api-index:: simple_scoping, warn_old_scoping, nonrecursive_access_policies
 
 At the moment there are three ``future`` flags available:
 

--- a/docs/reference/datamodel/globals.rst
+++ b/docs/reference/datamodel/globals.rst
@@ -4,8 +4,6 @@
 Globals
 =======
 
-.. index:: global, required global
-
 Schemas in Gel can contain typed *global variables*. These create a mechanism
 for specifying session-level context that can be referenced in queries,
 access policies, triggers, and elsewhere with the ``global`` keyword.
@@ -173,7 +171,7 @@ If marked ``required``, a default value must be provided.
 Computed globals
 ================
 
-.. index:: global, :=
+.. api-index:: global, :=
 
 Global variables can also be computed. The value of computed globals is
 dynamically computed when they are referenced in queries.
@@ -205,6 +203,8 @@ For example:
 Referencing globals
 ===================
 
+.. api-index:: global
+
 Unlike query parameters, globals can be referenced *inside your schema
 declarations*:
 
@@ -235,6 +235,8 @@ documentation.
 
 Declaring globals
 =================
+
+.. api-index:: required, optional, single, multi, global, :=, :, default
 
 This section describes the syntax to declare a global variable in your schema.
 

--- a/docs/reference/datamodel/indexes.rst
+++ b/docs/reference/datamodel/indexes.rst
@@ -4,8 +4,7 @@
 Indexes
 =======
 
-.. index::
-   index on, performance, postgres query planner
+.. index:: performance, postgres query planner
 
 An index is a data structure used internally to speed up filtering, ordering,
 and grouping operations in |Gel|. Indexes help accomplish this in two key ways:
@@ -95,8 +94,6 @@ Example:
 Index on multiple properties
 ============================
 
-.. index:: tuple
-
 A *composite index* references multiple properties. This can speed up queries
 that filter, order, or group on multiple properties at once.
 
@@ -124,8 +121,6 @@ In |Gel|, a composite index is created by indexing on a ``tuple`` of properties:
 
 Index on a link property
 ========================
-
-.. index:: __subject__, linkprops
 
 Link properties can also be indexed. The special placeholder
 ``__subject__`` refers to the source object in a link property expression:
@@ -162,7 +157,7 @@ When specifying an index, you can provide an optional ``except`` clause to exclu
 Specify a Postgres index type
 =============================
 
-.. index:: pg::hash, pg::btree, pg::gin, pg::gist, pg::spgist, pg::brin
+.. api-index:: pg::hash, pg::btree, pg::gin, pg::gist, pg::spgist, pg::brin
 
 .. versionadded:: 3.0
 
@@ -189,8 +184,6 @@ Example:
 Annotate an index
 =================
 
-.. index:: annotation
-
 Indexes can include annotations:
 
 .. code-block:: sdl
@@ -207,6 +200,8 @@ Indexes can include annotations:
 
 Declaring indexes
 =================
+
+.. api-index:: index on, except
 
 This section describes the syntax to use indexes in your schema.
 

--- a/docs/reference/datamodel/inheritance.rst
+++ b/docs/reference/datamodel/inheritance.rst
@@ -4,8 +4,7 @@
 Inheritance
 ===========
 
-.. index:: abstract, extending, extends, subtype, supertype, parent type,
-           child type
+.. index:: extending, extends, subtype, supertype, parent type, child type
 
 Inheritance is a crucial aspect of schema modeling in Gel. Schema items can
 *extend* one or more parent types. When extending, the child (subclass)
@@ -24,6 +23,8 @@ annotations.
 
 Object types
 ------------
+
+.. api-index:: abstract type, extending
 
 Object types can *extend* other object types. The extending type (AKA the
 *subtype*) inherits all links, properties, indexes, constraints, etc. from its
@@ -71,8 +72,6 @@ Polymorphic queries <ref_eql_select_polymorphic>`.
 Multiple Inheritance
 ^^^^^^^^^^^^^^^^^^^^
 
-.. index:: Multiple Inheritance
-
 Object types can :ref:`extend more
 than one type <ref_eql_sdl_object_types_inheritance>` — that's called
 *multiple inheritance*. This mechanism allows building complex object
@@ -99,7 +98,7 @@ types out of combinations of more basic types.
 Overloading
 ^^^^^^^^^^^
 
-.. index:: overloaded
+.. api-index:: overloaded
 
 An object type can overload an inherited property or link. All overloaded
 declarations must be prefixed with the ``overloaded`` prefix to avoid
@@ -129,6 +128,8 @@ additional constraints.
 Properties
 ----------
 
+.. api-index:: abstract property, readonly
+
 Properties can be *concrete* (the default) or *abstract*. Abstract properties
 are declared independent of a source or target, can contain :ref:`annotations
 <ref_datamodel_annotations>`, and can be marked as ``readonly``.
@@ -144,6 +145,8 @@ are declared independent of a source or target, can contain :ref:`annotations
 
 Links
 -----
+
+.. api-index:: abstract link
 
 It's possible to define ``abstract`` links that aren't tied to a particular
 *source* or *target*. Abstract links can be marked as readonly and contain
@@ -167,6 +170,7 @@ annotations, property declarations, constraints, and indexes.
 Constraints
 -----------
 
+.. api-index:: abstract constraint, using, errmessage
 
 Use ``abstract`` to declare reusable, user-defined constraint types.
 
@@ -188,6 +192,8 @@ Use ``abstract`` to declare reusable, user-defined constraint types.
 
 Annotations
 -----------
+
+.. api-index:: abstract annotation, inheritable
 
 EdgeQL supports three annotation types by default: ``title``, ``description``,
 and ``deprecated``. Use ``abstract annotation`` to declare custom user-defined

--- a/docs/reference/datamodel/introspection/index.rst
+++ b/docs/reference/datamodel/introspection/index.rst
@@ -3,7 +3,8 @@
 Introspection
 =============
 
-.. index:: describe, introspect, typeof, schema module
+.. index:: schema module
+.. api-index:: describe, introspect, typeof
 
 All of the schema information in Gel is stored in the ``schema``
 :ref:`module <ref_datamodel_modules>` and is accessible via

--- a/docs/reference/datamodel/linkprops.rst
+++ b/docs/reference/datamodel/linkprops.rst
@@ -4,8 +4,8 @@
 Link properties
 ===============
 
-.. index:: property, link property, linkprops, link table, relations, @
-
+.. index:: link property, linkprops, link table, relations
+.. api-index:: @
 
 Links, like objects, can also contain **properties**. These are used to store metadata about the link. Due to how they're persisted under the hood,
 link properties have a few additional constraints: they're always ``single``

--- a/docs/reference/datamodel/links.rst
+++ b/docs/reference/datamodel/links.rst
@@ -39,7 +39,7 @@ The ``link`` keyword is optional, and can be omitted.
 Link cardinality
 ================
 
-.. index:: single, multi
+.. api-index:: single, multi
 
 All links have a cardinality: either ``single`` or ``multi``. The default is
 ``single`` (a "to-one" link). Use the ``multi`` keyword to declare a "to-many"
@@ -55,7 +55,8 @@ link:
 Required links
 ==============
 
-.. index:: required, optional, not null
+.. index:: not null
+.. api-index:: required, optional
 
 All links are either ``optional`` or ``required``; the default is ``optional``.
 Use the ``required`` keyword to declare a required link. A required link must
@@ -87,7 +88,7 @@ Attempting to create a ``GroupChat`` with no members would fail.
 Exclusive constraints
 =====================
 
-.. index:: constraint exclusive
+.. api-index:: constraint exclusive
 
 You can add an ``exclusive`` constraint to a link to guarantee that no other
 instances can link to the same target(s):
@@ -111,7 +112,7 @@ link to the same ``Person``; put differently, no ``Person`` can be a
 Backlinks
 =========
 
-.. index:: backlink
+.. api-index:: .<
 
 In Gel you can traverse links in reverse to find objects that link to
 the object. You can do that directly in your query. E.g. for this example
@@ -175,7 +176,7 @@ Use the ``single`` keyword to declare a "to-one" backlink computed link:
 Default values
 ==============
 
-.. index:: default
+.. api-index:: default
 
 Links can declare a default value in the form of an EdgeQL expression, which
 will be executed upon insertion. In this example, new people are automatically
@@ -568,8 +569,8 @@ in the shape:
 Deletion policies
 =================
 
-.. index:: on target delete, on source delete, restrict, delete source, allow,
-           deferred restrict, delete target, if orphan
+.. api-index:: on target delete, on source delete, restrict, delete source,
+               allow, deferred restrict, delete target, if orphan
 
 Links can declare their own **deletion policy** for when the **target** or
 **source** is deleted.
@@ -653,8 +654,6 @@ linked elsewhere via the **same** link name.
 Polymorphic links
 =================
 
-.. index:: abstract, subtypes, polymorphic
-
 Links can be **polymorphic**, i.e., have an ``abstract`` target. In the
 example below, we have an abstract type ``Person`` with concrete subtypes
 ``Hero`` and ``Villain``:
@@ -689,7 +688,7 @@ for details.
 Abstract links
 ==============
 
-.. index:: abstract
+.. api-index:: abstract link
 
 It's possible to define ``abstract`` links that aren't tied to a particular
 source or target, and then extend them in concrete object types. This can help
@@ -714,7 +713,7 @@ eliminate repetitive declarations:
 Overloading
 ===========
 
-.. index:: overloaded
+.. api-index:: overloaded
 
 When an inherited link is modified (by adding more constraints or changing its
 target type, etc.), the ``overloaded`` keyword is required. This prevents

--- a/docs/reference/datamodel/mutation_rewrites.rst
+++ b/docs/reference/datamodel/mutation_rewrites.rst
@@ -4,8 +4,7 @@
 Mutation rewrites
 =================
 
-.. index:: rewrite, insert, update, using, __subject__, __specified__, __old__,
-           modify, modification
+.. index:: modify, modification
 
 Mutation rewrites allow you to intercept database mutations (i.e.,
 :ref:`inserts <ref_eql_insert>` and/or :ref:`updates <ref_eql_update>`) and set
@@ -115,7 +114,7 @@ while updates will set the ``modified`` property:
 Mutation context
 ================
 
-.. index:: rewrite, __subject__, __specified__, __old__
+.. api-index:: rewrite, __subject__, __specified__, __old__
 
 Inside the rewrite rule's expression, you have access to a few special values:
 
@@ -290,8 +289,6 @@ containing the new author value.
 Cached computed
 ===============
 
-.. index:: cached computeds, caching computeds
-
 Mutation rewrites can be used to effectively create a cached computed value as
 demonstrated with the ``byline`` property in this schema:
 
@@ -324,6 +321,8 @@ property <ref_datamodel_computed>`.
 
 Declaring mutation rewrites
 ===========================
+
+.. api-index:: rewrite insert, rewrite update, using
 
 This section describes the syntax to declare mutation rewrites in your schema.
 

--- a/docs/reference/datamodel/objects.rst
+++ b/docs/reference/datamodel/objects.rst
@@ -4,7 +4,7 @@
 Object Types
 ============
 
-.. index:: type, tables, models
+.. index:: tables, models
 
 *Object types* are the primary components of a Gel schema. They are
 analogous to SQL *tables* or ORM *models*, and consist of :ref:`properties
@@ -170,6 +170,8 @@ of the same type and cardinality.
 
 Defining object types
 =====================
+
+.. api-index:: abstract, type, extending
 
 This section describes the syntax to declare object types in your schema.
 

--- a/docs/reference/datamodel/properties.rst
+++ b/docs/reference/datamodel/properties.rst
@@ -31,7 +31,8 @@ readability, or it can be ommitted.
 Required properties
 ===================
 
-.. index:: required, optional, not null
+.. index:: not null
+.. api-index:: required, optional
 
 Properties can be either ``optional`` (the default) or ``required``.
 
@@ -59,7 +60,7 @@ Since ``optional`` keyword is the default, we can omit it:
 Cardinality
 ===========
 
-.. index:: cardinality, single, multi
+.. api-index:: single, multi
 
 Properties have a **cardinality**:
 
@@ -117,7 +118,7 @@ Essentially they are stored in a separate table ``(owner_id, value)``.
 Default values
 ==============
 
-.. index:: default
+.. api-index:: default
 
 Properties can have a default value. This default can be a static value or an
 arbitrary EdgeQL expression, which will be evaluated upon insertion.
@@ -138,7 +139,8 @@ arbitrary EdgeQL expression, which will be evaluated upon insertion.
 Readonly properties
 ===================
 
-.. index:: readonly, immutable
+.. index:: immutable
+.. api-index:: readonly
 
 Properties can be marked as ``readonly``. In the example below, the
 ``User.external_id`` property can be set at the time of creation but not
@@ -156,7 +158,7 @@ modified thereafter.
 Constraints
 ===========
 
-.. index:: constraint
+.. api-index:: constraint
 
 Properties can be augmented wth constraints. The example below showcases a
 subset of Gel's built-in constraints.
@@ -206,7 +208,7 @@ reference <ref_std_constraints>`.
 Annotations
 ===========
 
-.. index:: annotation, metadata, title, description, deprecated
+.. index:: metadata
 
 Properties can contain annotations, small human-readable notes. The built-in
 annotations are ``title``, ``description``, and ``deprecated``. You may also
@@ -224,7 +226,7 @@ declare :ref:`custom annotation types <ref_datamodel_inheritance_annotations>`.
 Abstract properties
 ===================
 
-.. index:: abstract property
+.. api-index:: abstract property
 
 Properties can be *concrete* (the default) or *abstract*. Abstract properties
 are declared independent of a source or target, can contain :ref:`annotations

--- a/docs/reference/datamodel/triggers.rst
+++ b/docs/reference/datamodel/triggers.rst
@@ -5,9 +5,6 @@
 Triggers
 ========
 
-.. index:: trigger, after insert, after update, after delete, for each, for all,
-           when, do, __new__, __old__
-
 Triggers allow you to define an expression to be executed whenever a given
 query type is run on an object type. The original query will *trigger* your
 pre-defined expression to run in a transaction along with the original query.
@@ -402,6 +399,9 @@ query makes a change to a ``User`` object:
 
 Declaring triggers
 ==================
+
+.. api-index:: trigger, after insert, after update, after delete, for each,
+               for all, when, do, __new__, __old__
 
 This section describes the syntax to declare a trigger in your schema.
 

--- a/docs/reference/edgeql/analyze.rst
+++ b/docs/reference/edgeql/analyze.rst
@@ -3,7 +3,8 @@
 Analyze
 =======
 
-.. index:: analyze, explain, performance, postgres query planner
+.. index:: explain, performance, postgres query planner
+.. api-index:: analyze
 
 Prefix an EdgeQL query with ``analyze`` to run a performance analysis of that
 query.

--- a/docs/reference/edgeql/delete.rst
+++ b/docs/reference/edgeql/delete.rst
@@ -3,7 +3,7 @@
 Delete
 ======
 
-.. index:: delete
+.. api-index:: delete
 
 The ``delete`` command is used to delete objects from the database.
 
@@ -30,7 +30,7 @@ on these clauses.
 Link deletion
 -------------
 
-.. index:: ConstraintViolationError
+.. api-index:: ConstraintViolationError
 
 Every link is associated with a *link deletion policy*. By default, it isn't
 possible to delete an object linked to by another.
@@ -75,7 +75,8 @@ the ``allow`` deletion policy.
 Cascading deletes
 ^^^^^^^^^^^^^^^^^
 
-.. index:: delete cascade, delete source, delete target, deletion policy
+.. index:: deletion policy
+.. api-index:: delete source, delete target
 
 If a link uses the ``delete source`` policy, then deleting a *target* of the
 link will also delete the object that links to it (the *source*). This behavior
@@ -87,7 +88,7 @@ The full list of deletion policies is documented at :ref:`Schema > Links
 Return value
 ------------
 
-.. index:: delete, returning
+.. index:: returning
 
 A ``delete`` statement returns the set of deleted objects. You can pass this
 set into ``select`` to fetch properties and links of the (now-deleted)

--- a/docs/reference/edgeql/for.rst
+++ b/docs/reference/edgeql/for.rst
@@ -3,7 +3,7 @@
 For
 ===
 
-.. index:: for in, union
+.. api-index:: for in, union
 
 EdgeQL supports a top-level ``for`` statement. These "for loops" iterate over
 each element of some input set, execute some expression with it, and merge the
@@ -43,8 +43,6 @@ are merged into a single output set.
 
 Bulk inserts
 ------------
-
-.. index:: bulk inserts
 
 The ``for`` statement is commonly used for bulk inserts.
 
@@ -91,7 +89,7 @@ A similar approach can be used for bulk updates.
 Conditional DML
 ---------------
 
-.. index:: for, if else, unless conflict
+.. api-index:: for, if else, unless conflict
 
 .. versionadded:: 4.0
 

--- a/docs/reference/edgeql/group.rst
+++ b/docs/reference/edgeql/group.rst
@@ -3,8 +3,8 @@
 Group
 =====
 
-.. index:: group by, group using by, key, grouping, elements, analytics,
-           aggregate, rollup, cube, partition
+.. index:: analytics, aggregate
+.. api-index:: group by, group using by, key, grouping, elements, rollup, cube
 
 EdgeQL supports a top-level ``group`` statement. This is used to partition
 sets into subsets based on some parameters. These subsets then can be

--- a/docs/reference/edgeql/insert.rst
+++ b/docs/reference/edgeql/insert.rst
@@ -3,7 +3,7 @@
 Insert
 ======
 
-.. index:: insert, returning
+.. api-index:: insert, :=
 
 The ``insert`` command is used to create instances of object types. The code
 samples on this page assume the following schema:
@@ -114,8 +114,6 @@ You can use :ref:`ref_eql_with` to tidy this up if you prefer:
 Inserting links
 ---------------
 
-.. index:: inserting links
-
 EdgeQL's composable syntax makes link insertion painless. Below, we insert
 "Spider-Man: No Way Home" and include all known heroes and villains as
 ``characters`` (which is basically true).
@@ -174,8 +172,6 @@ returned, this query will fail at runtime.
 Nested inserts
 --------------
 
-.. index:: nested inserts
-
 Just as we used subqueries to populate links with existing objects, we can also
 execute *nested inserts*.
 
@@ -232,7 +228,7 @@ actually exist in the database.
 With block
 ----------
 
-.. index:: with insert
+.. api-index:: with
 
 In the previous query, we selected Black Widow twice: once in the
 ``characters`` set and again as the ``nemesis`` of Dreykov. In circumstances
@@ -279,7 +275,7 @@ can reference earlier ones.
 Conflicts
 ---------
 
-.. index:: unless conflict on, else
+.. api-index:: unless conflict on, else
 
 |Gel| provides a general-purpose mechanism for gracefully handling possible
 exclusivity constraint violations. Consider a scenario where we are trying to
@@ -317,8 +313,6 @@ conflicts and provide a fallback expression.
 
 Upserts
 ^^^^^^^
-
-.. index:: upserts, unless conflict on, else update
 
 There are no limitations on what the ``else`` clause can contain; it can be any
 EdgeQL expression, including an :ref:`update <ref_eql_update>` statement. This
@@ -419,7 +413,7 @@ to the ``update`` statement in the ``else`` clause. This updates the
 Suppressing failures
 ^^^^^^^^^^^^^^^^^^^^
 
-.. index:: unless conflict
+.. api-index:: unless conflict
 
 The ``else`` clause is optional; when omitted, the ``insert`` statement will
 return an *empty set* if a conflict occurs. This is a common way to prevent
@@ -438,8 +432,6 @@ return an *empty set* if a conflict occurs. This is a common way to prevent
 
 Bulk inserts
 ------------
-
-.. index:: bulk inserts
 
 Bulk inserts are performed by passing in a JSON array as a :ref:`query
 parameter <ref_eql_params>`, :eql:func:`unpacking <json_array_unpack>` it, and

--- a/docs/reference/edgeql/literals.rst
+++ b/docs/reference/edgeql/literals.rst
@@ -57,7 +57,8 @@ link in the left column to jump to the associated section.
 Strings
 -------
 
-.. index:: str, unicode, quotes, raw strings, escape character
+.. index:: unicode, quotes, raw strings, escape character
+.. api-index:: str, r'', r"", $$, $§label§$, \\§char§
 
 The :eql:type:`str` type is a variable-length string of Unicode characters. A
 string can be declared with either single or double quotes.
@@ -150,7 +151,7 @@ For a complete reference on strings, see :ref:`Standard Library > String
 Booleans
 --------
 
-.. index:: bool
+.. api-index:: bool
 
 The :eql:type:`bool` type represents a true/false value.
 
@@ -302,7 +303,7 @@ Generate a random UUID.
 Enums
 -----
 
-.. index:: enums
+.. api-index:: scalar type, extending enum
 
 Enum types must be :ref:`declared in your schema <ref_datamodel_enums>`.
 
@@ -325,8 +326,6 @@ casting an appropriate string literal:
 
 Dates and times
 ---------------
-
-.. index:: temporal
 
 |Gel's| typesystem contains several temporal types.
 
@@ -489,8 +488,7 @@ EdgeQL supports a set of functions and operators on duration types.
 Ranges
 ------
 
-.. index:: ranges, lower bound, upper bound, inclusive, inc_lower, inc_upper,
-           empty
+.. api-index:: range, inc_lower, inc_upper, empty
 
 Ranges represent a range of orderable scalar values. A range comprises a lower
 bound, upper bound, and two boolean flags indicating whether each bound is
@@ -543,6 +541,7 @@ Bytes
 -----
 
 .. index:: binary, raw byte strings
+.. api-index:: b'', b"", rb'', br'', rb"", br""
 
 The ``bytes`` type represents raw binary data.
 
@@ -568,7 +567,7 @@ character.
 Arrays
 ------
 
-.. index:: collection, lists, ordered
+.. index:: collection, lists
 
 An array is an *ordered* collection of values of the *same type*. For example:
 
@@ -609,8 +608,6 @@ reference on array data types.
 
 Tuples
 ------
-
-.. index:: fixed length ordered collection, named tuples
 
 A tuple is *fixed-length*, *ordered* collection of values, each of which may
 have a *different type*. The elements of a tuple can be of any type, including
@@ -661,8 +658,6 @@ For a full reference on tuples, see :ref:`Standard Library > Tuple
 
 JSON
 ----
-
-.. index:: json
 
 The :eql:type:`json` scalar type is a stringified representation of structured
 data. JSON literals are declared by explicitly casting other values or passing

--- a/docs/reference/edgeql/parameters.rst
+++ b/docs/reference/edgeql/parameters.rst
@@ -3,7 +3,8 @@
 Parameters
 ==========
 
-.. index:: query params, query arguments, query args, $, < >$, input
+.. index:: query params, query arguments, query args, input
+.. api-index:: $, <§type§>$
 
 :edb-alt-title: Query Parameters
 
@@ -96,8 +97,6 @@ language-native types.
 Parameter types and JSON
 ------------------------
 
-.. index:: complex parameters
-
 In Gel, parameters can also be tuples. If you need to pass complex structures
 as parameters, use Gel's built-in :ref:`JSON <ref_std_json>` functionality.
 
@@ -130,7 +129,7 @@ properties.
 Optional parameters
 -------------------
 
-.. index:: <optional >$
+.. api-index:: <optional §type§>$
 
 By default, query parameters are ``required``; the query will fail if the
 parameter value is an empty set. You can use an ``optional`` modifier inside
@@ -154,7 +153,7 @@ the type cast if the parameter is optional.
 Default parameter values
 ------------------------
 
-.. index:: ??
+.. api-index:: ??
 
 When using optional parameters, you may want to provide a default value to use
 in case the parameter is not passed. You can do this by using the
@@ -172,8 +171,6 @@ in case the parameter is not passed. You can do this by using the
 
 What can be parameterized?
 --------------------------
-
-.. index:: order by parameters
 
 Any data manipulation language (DML) statement can be
 parameterized: ``select``, ``insert``, ``update``, and ``delete``. Since

--- a/docs/reference/edgeql/paths.rst
+++ b/docs/reference/edgeql/paths.rst
@@ -112,7 +112,7 @@ Paths can terminate with a property reference.
 Backlinks
 ---------
 
-.. index:: .<
+.. api-index:: .<
 
 All examples thus far have traversed links in the *forward direction*, however
 it's also possible to traverse links *backwards* with ``.<`` notation. These
@@ -209,7 +209,8 @@ that the type name (in this case ``User``) doesn't need to be specified.
 Link properties
 ---------------
 
-.. index:: linkprops, @
+.. index:: linkprops
+.. api-index:: @
 
 Paths can also reference :ref:`link properties <ref_datamodel_link_properties>`
 with ``@`` notation. To demonstrate this, let's add a property to the ``User.

--- a/docs/reference/edgeql/select.rst
+++ b/docs/reference/edgeql/select.rst
@@ -3,7 +3,7 @@
 Select
 ======
 
-.. index:: select
+.. api-index:: select
 
 The ``select`` command retrieves or computes a set of values. We've already
 seen simple queries that select primitive values.
@@ -164,7 +164,7 @@ this result would look like this:
 Shapes
 ------
 
-.. index:: select, shapes, { }
+.. api-index:: select, { }
 
 To specify which properties to select, we attach a **shape** to ``Villain``. A
 shape can be attached to any object type expression in EdgeQL.
@@ -182,8 +182,6 @@ shape can be attached to any object type expression in EdgeQL.
 
 Nested shapes
 ^^^^^^^^^^^^^
-
-.. index:: select, nested shapes
 
 Nested shapes can be used to fetch linked objects and their properties. Here we
 fetch all ``Villain`` objects and their nemeses.
@@ -230,7 +228,8 @@ identically to concrete/non-computed links like ``Villain.nemesis``.
 Splats
 ^^^^^^
 
-.. index:: select, splats, *, **, select *, select all, [is ].*, [is ].**
+.. index:: select *, select all
+.. api-index:: *, **, §type§.*, §type§.**, [is §type§].*, [is §type§].**
 
 Splats allow you to select all properties of a type using the asterisk (``*``)
 or all properties of the type and a single level of linked types with a double
@@ -481,7 +480,8 @@ we wouldn't get those with this query either.
 Filtering
 ---------
 
-.. index:: select, filter, where
+.. index:: where
+.. api-index:: filter
 
 To filter the set of selected objects, use a ``filter <expr>`` clause. The
 ``<expr>`` that follows the ``filter`` keyword can be *any boolean expression*.
@@ -651,7 +651,8 @@ If properties are selected, place the clauses after the link's shape:
 Ordering
 --------
 
-.. index:: order by, sorting, asc, desc, then, empty first, empty last
+.. index:: sorting
+.. api-index:: order by, asc, desc, then, empty first, empty last
 
 Order the result of a query with an ``order by`` clause.
 
@@ -712,7 +713,7 @@ are handled, see :ref:`Reference > Commands > Select
 Pagination
 ----------
 
-.. index:: limit, offset
+.. api-index:: limit, offset
 
 |Gel| supports ``limit`` and ``offset`` clauses. These are
 typically used in conjunction with ``order by`` to maintain a consistent
@@ -777,7 +778,7 @@ providing one or the other.
 Computed fields
 ---------------
 
-.. index:: computeds, :=
+.. api-index:: :=
 
 Shapes can contain *computed fields*. These are EdgeQL expressions that are
 computed on the fly during the execution of the query. As with other clauses,
@@ -832,7 +833,7 @@ As with nested filters, the *current scope* changes inside nested shapes.
 Backlinks
 ---------
 
-.. index:: .<
+.. api-index:: .<
 
 Fetching backlinks is a common use case for computed fields. To demonstrate
 this, let's fetch a list of all movies starring a particular Hero.
@@ -978,7 +979,7 @@ abstract type (such as ``Movie.characters``) or a :eql:op:`union type
 Polymorphic fields
 ^^^^^^^^^^^^^^^^^^
 
-.. index:: [is ].
+.. api-index:: [is §type§].
 
 We can fetch different properties *conditional* on the subtype of each object
 by prefixing property/link references with ``[is <type>]``. This is known as a

--- a/docs/reference/edgeql/sets.rst
+++ b/docs/reference/edgeql/sets.rst
@@ -8,7 +8,7 @@ Sets
 Everything is a set
 -------------------
 
-.. index:: set, multiset, cardinality, empty set, singleton
+.. index:: multiset, cardinality, empty set, singleton
 
 All values in EdgeQL are actually **sets**: a collection of values of a given
 **type**. All elements of a set must have the same type. The number of items in
@@ -21,7 +21,7 @@ referred to as an **empty set**. A set with a cardinality of one is known as a
 Constructing sets
 -----------------
 
-.. index:: constructor, { }, union
+.. api-index:: {§expr [\, ...]§}, union
 
 Set literals are declared with *set constructor* syntax: a comma-separated
 list of values inside a set of ``{curly braces}``.
@@ -215,7 +215,7 @@ schema.
 Multisets
 ---------
 
-.. index:: multisets, distinct, duplicates
+.. api-index:: distinct
 
 Technically sets in Gel are actually *multisets*, because they can contain
 duplicates of the same element. To eliminate duplicates, use the
@@ -233,7 +233,7 @@ duplicates of the same element. To eliminate duplicates, use the
 Checking membership
 -------------------
 
-.. index:: in
+.. api-index:: §element§ in §set§
 
 Use the :eql:op:`in` operator to check whether a set contains a particular
 element.
@@ -251,7 +251,7 @@ element.
 Merging sets
 ------------
 
-.. index:: union, merge
+.. api-index:: union
 
 Use the :eql:op:`union` operator to merge two sets.
 
@@ -265,7 +265,7 @@ Use the :eql:op:`union` operator to merge two sets.
 Finding common members
 ----------------------
 
-.. index:: intersect
+.. api-index:: intersect
 
 Use the :eql:op:`intersect` operator to find common members between two sets.
 
@@ -295,7 +295,7 @@ resulting set.
 Removing common members
 -----------------------
 
-.. index:: except
+.. api-index:: except
 
 Use the :eql:op:`except` operator to leave only the members in the first set
 that do not appear in the second set.
@@ -328,7 +328,8 @@ first set's ``3`` members are eliminated from the resulting set.
 Coalescing
 ----------
 
-.. index:: empty set, ??, default values, optional
+.. index:: empty set, default values, optional
+.. api-index:: ??
 
 Occasionally in queries, you need to handle the case where a set is empty. This
 can be achieved with a coalescing operator :eql:op:`?? <coalesce>`. This is
@@ -357,7 +358,8 @@ commonly used to provide default values for optional :ref:`query parameters
 Inheritance
 -----------
 
-.. index:: type intersection, backlinks, [is ]
+.. index:: type intersection, backlinks
+.. api-index:: §expr§[is §type§]
 
 |Gel| schemas support :ref:`inheritance <ref_datamodel_objects_inheritance>`;
 types (usually object types) can extend one or more other types. For instance
@@ -477,7 +479,7 @@ Cardinality <ref_reference_cardinality>`.
 Conversion to/from arrays
 -------------------------
 
-.. index:: array_unpack, array_agg, converting sets
+.. api-index:: array_unpack, array_agg
 
 Both arrays and sets are collections of values that share a type. EdgeQL
 provides ways to convert one into the other.

--- a/docs/reference/edgeql/transactions.rst
+++ b/docs/reference/edgeql/transactions.rst
@@ -3,8 +3,8 @@
 Transactions
 ============
 
-.. index:: start transaction, declare savepoint, release savepoint,
-           rollback to savepoint, rollback, commit
+.. api-index:: start transaction, declare savepoint, release savepoint,
+               rollback to savepoint, rollback, commit
 
 EdgeQL supports atomic transactions. The transaction API consists
 of several commands:

--- a/docs/reference/edgeql/types.rst
+++ b/docs/reference/edgeql/types.rst
@@ -14,7 +14,7 @@ types.
 Type expressions
 ----------------
 
-.. index:: array< >, tuple< >
+.. api-index:: array<§type§>, tuple<§type [\, ...]§>
 
 Type expressions are exactly what they sound like: EdgeQL expressions that
 refer to a type. Most commonly, these are simply the *names* of established
@@ -40,7 +40,8 @@ For additional details on type syntax, see :ref:`Schema > Primitive Types
 Type casting
 ------------
 
-.. index:: casts, < >, find object by id
+.. index:: casts, find object by id
+.. api-index:: <§type§>§expr§
 
 Type casting is used to convert primitive values into another type. Casts are
 indicated with angle brackets containing a type expression.
@@ -116,7 +117,7 @@ property, you'll get an error:
 Type intersections
 ------------------
 
-.. index:: [is ]
+.. api-index:: [is §type§]
 
 All elements of a given set have the same type; however, in the context of
 *sets of objects*, this type might be ``abstract`` and contain elements of
@@ -164,7 +165,7 @@ a "filter" that removes all elements that aren't of type ``Movie``.
 Type checking
 -------------
 
-.. index:: is
+.. api-index:: §expr§ is §type§, §expr§ is not §type§
 
 The ``[is foo]`` "type intersection" syntax should not be confused with the
 *type checking* operator :eql:op:`is`.
@@ -182,7 +183,7 @@ The ``[is foo]`` "type intersection" syntax should not be confused with the
 The ``typeof`` operator
 -----------------------
 
-.. index:: typeof
+.. api-index:: typeof §expr§
 
 The type of any expression can be extracted with the :eql:op:`typeof`
 operator. This can be used in any expression that expects a type.

--- a/docs/reference/edgeql/update.rst
+++ b/docs/reference/edgeql/update.rst
@@ -3,7 +3,7 @@
 Update
 ======
 
-.. index:: update, filter, set
+.. api-index:: update, filter, set
 
 The ``update`` command is used to update existing objects.
 
@@ -37,8 +37,6 @@ set is specified, then filters are applied, then the data is updated.
 Updating properties
 -------------------
 
-.. index:: unset
-
 To explicitly unset a property that is not required, set it to an empty set.
 
 .. code-block:: edgeql
@@ -48,7 +46,7 @@ To explicitly unset a property that is not required, set it to an empty set.
 Updating links
 --------------
 
-.. index:: :=, +=, -=
+.. api-index:: :=, +=, -=
 
 When updating links, the ``:=`` operator will *replace* the set of linked
 values.
@@ -99,8 +97,6 @@ To remove items, use ``-=``.
 Returning data on update
 ------------------------
 
-.. index:: update, returning
-
 By default, ``update`` returns only the inserted object's ``id`` as seen in the
 examples above. If you want to get additional data back, you may wrap your
 ``update`` with a ``select`` and apply a shape specifying any properties and
@@ -121,8 +117,6 @@ links you want returned:
 
 With blocks
 -----------
-
-.. index:: with update
 
 All top-level EdgeQL statements (``select``, ``insert``, ``update``, and
 ``delete``) can be prefixed with a ``with`` block. This is useful for updating

--- a/docs/reference/edgeql/with.rst
+++ b/docs/reference/edgeql/with.rst
@@ -5,6 +5,7 @@ With
 
 .. index:: composition, composing queries, composable, CTE,
            common table expressions, subquery, subqueries
+.. api-index:: with
 
 All top-level EdgeQL statements (``select``, ``insert``, ``update``, and
 ``delete``) can be prefixed by a ``with`` block. These blocks contain
@@ -65,8 +66,6 @@ Avengers.
 Query parameters
 ^^^^^^^^^^^^^^^^
 
-.. index:: with
-
 A common use case for ``with`` clauses is the initialization of :ref:`query
 parameters <ref_eql_params>`.
 
@@ -83,7 +82,7 @@ For a full reference on using query parameters, see :ref:`EdgeQL > Parameters
 Module alias
 ^^^^^^^^^^^^
 
-.. index:: with, as module
+.. api-index:: with, as module
 
 Another use of ``with`` is to provide aliases for modules. This can be useful
 for long queries which reuse many objects or functions from the same module.
@@ -107,7 +106,8 @@ part of the ``std`` module, that will be used automatically.
 Module selection
 ^^^^^^^^^^^^^^^^
 
-.. index:: with module, fully-qualified names
+.. index:: fully-qualified names
+.. api-index:: with module
 
 By default, the *active module* is ``default``, so all schema objects inside
 this module can be referenced by their *short name*, e.g. ``User``,

--- a/docs/reference/reference/edgeql/for.rst
+++ b/docs/reference/reference/edgeql/for.rst
@@ -6,8 +6,6 @@ For
 :eql-statement:
 :eql-haswith:
 
-:index: for union filter order offset limit
-
 
 ``for``--compute a union of subsets based on values of another set
 

--- a/docs/reference/reference/edgeql/group.rst
+++ b/docs/reference/reference/edgeql/group.rst
@@ -6,8 +6,6 @@ Group
 :eql-statement:
 :eql-haswith:
 
-:index: group using by
-
 ``group``--partition a set into subsets based on one or more keys
 
 .. eql:synopsis::

--- a/docs/reference/reference/edgeql/select.rst
+++ b/docs/reference/reference/edgeql/select.rst
@@ -6,8 +6,6 @@ Select
 :eql-statement:
 :eql-haswith:
 
-:index: order filter select offset limit with then asc desc first last empty
-
 ``select``--retrieve or compute a set of values.
 
 .. eql:synopsis::

--- a/docs/reference/reference/edgeql/with.rst
+++ b/docs/reference/reference/edgeql/with.rst
@@ -3,8 +3,6 @@
 With block
 ==========
 
-:index: alias module
-
 .. eql:keyword:: with
 
     The ``with`` block in EdgeQL is used to define aliases.

--- a/docs/reference/stdlib/array.rst
+++ b/docs/reference/stdlib/array.rst
@@ -149,7 +149,7 @@ Reference
 
 .. eql:operator:: arrayidx: array<anytype> [ int64 ] -> anytype
 
-    .. api-index:: §array§[§int64§]
+    .. api-index:: §array§[§int§]
 
     Accesses the array element at a given index.
 
@@ -183,7 +183,7 @@ Reference
 
 .. eql:operator:: arrayslice: array<anytype> [ int64 : int64 ] -> anytype
 
-    :index: [int:int]
+    .. api-index:: §array§[§int§:§int§]
 
     Produces a sub-array from an existing array.
 
@@ -228,7 +228,8 @@ Reference
 
 .. eql:operator:: arrayplus: array<anytype> ++ array<anytype> -> array<anytype>
 
-    :index: ++, concatenate, join, add
+    .. index:: concatenate, join, add
+    .. api-index:: §array §++§ array§
 
     Concatenates two arrays of the same type into one.
 
@@ -243,7 +244,7 @@ Reference
 
 .. eql:function:: std::array_agg(s: set of anytype) -> array<anytype>
 
-    :index: aggregate array set
+    .. index:: aggregate
 
     Returns an array made from all of the input set elements.
 
@@ -265,8 +266,6 @@ Reference
                                  index: int64, \
                                  named only default: anytype = {} \
                               ) -> optional anytype
-
-    :index: array access get
 
     Returns the element of a given *array* at the specified *index*.
 
@@ -292,8 +291,6 @@ Reference
 
 .. eql:function:: std::array_unpack(array: array<anytype>) -> set of anytype
 
-    :index: set array unpack
-
     Returns the elements of an array as a set.
 
     .. note::
@@ -318,7 +315,7 @@ Reference
                   std::array_join(array: array<bytes>, \
                                   delimiter: bytes) -> bytes
 
-    :index: join array_to_string implode
+    .. index:: array_to_string, implode
 
     Renders an array to a string or byte-string.
 
@@ -342,8 +339,6 @@ Reference
 
 
 .. eql:function:: std::array_fill(val: anytype, n: int64) -> array<anytype>
-
-    :index: fill
 
     Returns an array of the specified size, filled with the provided value.
 

--- a/docs/reference/stdlib/array.rst
+++ b/docs/reference/stdlib/array.rst
@@ -105,8 +105,6 @@ Reference
 
 .. eql:type:: std::array
 
-    :index: array
-
     An ordered list of values of the same type.
 
     Array indexing starts at zero.
@@ -151,7 +149,7 @@ Reference
 
 .. eql:operator:: arrayidx: array<anytype> [ int64 ] -> anytype
 
-    :index: [int], index access
+    .. api-index:: §array§[§int64§]
 
     Accesses the array element at a given index.
 

--- a/docs/reference/stdlib/bool.rst
+++ b/docs/reference/stdlib/bool.rst
@@ -134,7 +134,7 @@ Booleans
 
 .. eql:operator:: or: bool or bool -> bool
 
-    :index: or
+    .. api-index:: or
 
     Evaluates ``true`` if either boolean is ``true``.
 
@@ -168,7 +168,7 @@ Booleans
 
 .. eql:operator:: and: bool and bool -> bool
 
-    :index: and
+    .. api-index:: and
 
     Evaluates ``true`` if both booleans are ``true``.
 
@@ -202,7 +202,7 @@ Booleans
 
 .. eql:operator:: not: not bool -> bool
 
-    :index: not
+    .. api-index:: not
 
     Logically negates a given boolean value.
 

--- a/docs/reference/stdlib/bytes.rst
+++ b/docs/reference/stdlib/bytes.rst
@@ -139,7 +139,7 @@ Bytes
 
 .. eql:operator:: bytesidx: bytes [ int64 ] -> bytes
 
-    :index: [int]
+    .. api-index:: §bytes§[§int§]
 
     Accesses a byte at a given index.
 
@@ -158,7 +158,7 @@ Bytes
 
 .. eql:operator:: bytesslice: bytes [ int64 : int64 ] -> bytes
 
-    :index: [int:int]
+    .. api-index:: §bytes§[§int§:§int§]
 
     Produces a bytes sub-sequence from an existing bytes value.
 
@@ -177,7 +177,8 @@ Bytes
 
 .. eql:operator:: bytesplus: bytes ++ bytes ->
 
-    :index: ++, bytes, concatenate, join, add
+    .. index:: join, add
+    .. api-index:: §bytes §++§ bytes§
 
     Concatenates two bytes values into one.
 
@@ -197,9 +198,9 @@ Bytes
                   std::to_bytes(val: int64, endian: Endian) -> bytes
                   std::to_bytes(val: uuid) -> bytes
 
-    :index: encode stringencoder
-
     .. versionadded:: 4.0
+
+    .. index:: encode, stringencoder
 
     Converts a given value into binary representation as :eql:type:`bytes`.
 

--- a/docs/reference/stdlib/cfg.rst
+++ b/docs/reference/stdlib/cfg.rst
@@ -64,7 +64,7 @@ Configuration Parameters
 Connection settings
 -------------------
 
-.. index:: listen_addresses, listen_port
+.. api-index:: listen_addresses, listen_port
 
 :eql:synopsis:`listen_addresses -> multi str`
   Specifies the TCP/IP address(es) on which the server is to listen for
@@ -78,7 +78,7 @@ Connection settings
 Resource usage
 --------------
 
-.. index:: effective_io_concurrency, query_work_mem, shared_buffers
+.. api-index:: effective_io_concurrency, query_work_mem, shared_buffers
 
 :eql:synopsis:`effective_io_concurrency -> int64`
   Sets the number of concurrent disk I/O operations that can be
@@ -99,7 +99,7 @@ Resource usage
 Query planning
 --------------
 
-.. index:: default_statistics_target, effective_cache_size
+.. api-index:: default_statistics_target, effective_cache_size
 
 :eql:synopsis:`default_statistics_target -> int64`
   Sets the default data statistics target for the planner.
@@ -118,7 +118,7 @@ Query cache
 
 .. versionadded:: 5.0
 
-.. index:: auto_rebuild_query_cache, query_cache_mode, cfg::QueryCacheMode
+.. api-index:: auto_rebuild_query_cache, query_cache_mode, cfg::QueryCacheMode
 
 :eql:synopsis:`auto_rebuild_query_cache -> bool`
   Determines whether to recompile the existing query cache to SQL any time DDL
@@ -143,7 +143,7 @@ Query cache
 Query behavior
 --------------
 
-.. index:: allow_bare_ddl, cfg::AllowBareDDL, apply_access_policies,
+.. api-index:: allow_bare_ddl, cfg::AllowBareDDL, apply_access_policies,
            apply_access_policies_pg, force_database_error
 
 :eql:synopsis:`allow_bare_ddl -> cfg::AllowBareDDL`
@@ -203,7 +203,7 @@ Query behavior
 Client connections
 ------------------
 
-.. index:: allow_user_specified_id, session_idle_timeout,
+.. api-index:: allow_user_specified_id, session_idle_timeout,
            session_idle_transaction_timeout, query_execution_timeout
 
 :eql:synopsis:`allow_user_specified_id -> bool`

--- a/docs/reference/stdlib/constraints.rst
+++ b/docs/reference/stdlib/constraints.rst
@@ -127,8 +127,6 @@ Constraints
 
 .. eql:constraint:: std::regexp(pattern: str)
 
-    :index: regex regexp regular
-
     Limits to string values matching a regular expression.
 
     Example:

--- a/docs/reference/stdlib/datetime.rst
+++ b/docs/reference/stdlib/datetime.rst
@@ -571,7 +571,7 @@ functionality.
                               -> cal::local_datetime
                           cal::local_date + duration -> cal::local_datetime
 
-    :index: +, duration, datetime, add
+    .. api-index:: §datetime | duration §+§ datetime | duration§
 
     Adds a duration and any other datetime value.
 
@@ -621,7 +621,7 @@ functionality.
                            cal::relative_duration - duration\
                                 -> cal::relative_duration
 
-    :index: -, duration, datetime, subtract
+    .. api-index:: §datetime | duration §-§ datetime | duration§
 
     Subtracts two compatible datetime or duration values.
 
@@ -683,7 +683,7 @@ functionality.
 
 .. eql:function:: std::datetime_current() -> datetime
 
-    :index: now
+    .. index:: now
 
     Returns the server's current date and time.
 
@@ -702,7 +702,7 @@ functionality.
 
 .. eql:function:: std::datetime_of_transaction() -> datetime
 
-    :index: now
+    .. index:: now
 
     Returns the date and time of the start of the current transaction.
 
@@ -716,7 +716,7 @@ functionality.
 
 .. eql:function:: std::datetime_of_statement() -> datetime
 
-    :index: now
+    .. index:: now
 
     Returns the date and time of the start of the current statement.
 
@@ -1132,7 +1132,7 @@ functionality.
                   std::to_datetime(epochseconds: float64) -> datetime
                   std::to_datetime(epochseconds: int64) -> datetime
 
-    :index: parse datetime
+    .. index:: parse datetime
 
     Create a :eql:type:`datetime` value.
 
@@ -1190,7 +1190,7 @@ functionality.
                     day: int64, hour: int64, min: int64, sec: float64) \
                     -> local_datetime
 
-    :index: parse local_datetime
+    .. index:: parse local_datetime
 
     Create a :eql:type:`cal::local_datetime` value.
 
@@ -1238,7 +1238,7 @@ functionality.
                   cal::to_local_date(year: int64, month: int64, \
                     day: int64) -> cal::local_date
 
-    :index: parse local_date
+    .. index:: parse local_date
 
     Create a :eql:type:`cal::local_date` value.
 
@@ -1280,7 +1280,7 @@ functionality.
                   cal::to_local_time(hour: int64, min: int64, sec: float64) \
                     -> local_time
 
-    :index: parse local_time
+    .. index:: parse local_time
 
     Create a :eql:type:`cal::local_time` value.
 
@@ -1322,7 +1322,7 @@ functionality.
                     named only microseconds: int64=0 \
                   ) -> duration
 
-    :index: duration
+    .. index:: parse duration
 
     Create a :eql:type:`duration` value.
 
@@ -1365,7 +1365,7 @@ functionality.
                     named only microseconds: int64=0 \
                   ) -> cal::relative_duration
 
-    :index: parse relative_duration
+    .. index:: parse relative_duration
 
     Create a :eql:type:`cal::relative_duration` value.
 
@@ -1391,7 +1391,7 @@ functionality.
                     named only days: int64=0 \
                   ) -> cal::date_duration
 
-    :index: parse date_duration
+    .. index:: parse date_duration
 
     Create a :eql:type:`cal::date_duration` value.
 
@@ -1414,7 +1414,7 @@ functionality.
                     dur: cal::relative_duration \
                   ) -> cal::relative_duration
 
-    :index: justify_hours
+    .. index:: justify_hours
 
     Convert 24-hour chunks into days.
 
@@ -1444,7 +1444,7 @@ functionality.
                     dur: cal::date_duration \
                   ) -> cal::date_duration
 
-    :index: justify_days
+    .. index:: justify_days
 
     Convert 30-day chunks into months.
 

--- a/docs/reference/stdlib/enum.rst
+++ b/docs/reference/stdlib/enum.rst
@@ -9,8 +9,6 @@ Enums
 
 .. eql:type:: std::enum
 
-    :index: enum
-
     An enumerated type is a data type consisting of an ordered list of values.
 
     An enum type can be declared in a schema by using the following

--- a/docs/reference/stdlib/generic.rst
+++ b/docs/reference/stdlib/generic.rst
@@ -53,7 +53,8 @@ Generic
 
 .. eql:operator:: eq: anytype = anytype -> bool
 
-    :index: =, equal, comparison, compare
+    .. index:: comparison
+    .. api-index:: =
 
     Compares two values for equality.
 
@@ -91,7 +92,8 @@ Generic
 
 .. eql:operator:: neq: anytype != anytype -> bool
 
-    :index: !=, not equal, comparison, compare
+    .. index:: not equal, comparison
+    .. api-index:: !=
 
     Compares two values for inequality.
 
@@ -131,7 +133,8 @@ Generic
 
 .. eql:operator:: coaleq: optional anytype ?= optional anytype -> bool
 
-    :index: ?=, coalesce equal, comparison, compare, empty set
+    .. index:: coalesce equal, comparison, empty set
+    .. api-index:: ?=
 
     Compares two (potentially empty) values for equality.
 
@@ -153,7 +156,8 @@ Generic
 
 .. eql:operator:: coalneq: optional anytype ?!= optional anytype -> bool
 
-    :index: ?!=, coalesce not equal, comparison, compare
+    .. index:: coalesce not equal, comparison
+    .. api-index:: ?!=
 
     Compares two (potentially empty) values for inequality.
 
@@ -175,7 +179,8 @@ Generic
 
 .. eql:operator:: lt: anytype < anytype -> bool
 
-    :index: <, less than, comparison, compare
+    .. index:: comparison
+    .. api-index:: <
 
     Less than operator.
 
@@ -218,7 +223,8 @@ Generic
 
 .. eql:operator:: gt: anytype > anytype -> bool
 
-    :index: >, greater than, comparison, compare
+    .. index:: comparison
+    .. api-index:: >
 
     Greater than operator.
 
@@ -261,7 +267,8 @@ Generic
 
 .. eql:operator:: lteq: anytype <= anytype -> bool
 
-    :index: <=, less than or equal, comparison, compare
+    .. index:: comparison
+    .. api-index:: <=
 
     Less or equal operator.
 
@@ -306,7 +313,8 @@ Generic
 
 .. eql:operator:: gteq: anytype >= anytype -> bool
 
-    :index: >=, greater than or equal, comparison, compare
+    .. index:: comparison
+    .. api-index:: >=
 
     Greater or equal operator.
 
@@ -353,7 +361,7 @@ Generic
                   std::len(value: bytes) -> int64
                   std::len(value: array<anytype>) -> int64
 
-    :index: length count array
+    .. index:: length, count
 
     Returns the number of elements of a given value.
 
@@ -395,7 +403,7 @@ Generic
                                 needle: anypoint) \
                   -> std::bool
 
-    :index: find strpos strstr position array
+    .. index:: find, strpos, includes
 
     Returns true if the given sub-value exists within the given value.
 
@@ -495,7 +503,7 @@ Generic
                   std::find(haystack: array<anytype>, needle: anytype, \
                             from_pos: int64=0) -> int64
 
-    :index: find strpos strstr position array
+    .. index:: find, strpos
 
     Returns the index of a given sub-value in a given value.
 

--- a/docs/reference/stdlib/json.rst
+++ b/docs/reference/stdlib/json.rst
@@ -183,7 +183,7 @@ JSON array.
 
 .. eql:operator:: jsonidx: json [ int64 ] -> json
 
-    :index: [int], index access
+    .. api-index:: §json§[§int§]
 
     Accesses the element of the JSON string or array at a given index.
 
@@ -211,7 +211,7 @@ JSON array.
 
 .. eql:operator:: jsonslice: json [ int64 : int64 ] -> json
 
-    :index: [int:int]
+    .. api-index:: §json§[§int§:§int§]
 
     Produces a JSON value comprising a portion of the existing JSON value.
 
@@ -238,7 +238,8 @@ JSON array.
 
 .. eql:operator:: jsonplus: json ++ json -> json
 
-    :index: ++, concatenate, join, add
+    .. index:: join, add
+    .. api-index:: §json §++§ json§
 
     Concatenates two JSON arrays, objects, or strings into one.
 
@@ -265,7 +266,8 @@ JSON array.
 
 .. eql:operator:: jsonobjdest: json [ str ] -> json
 
-    :index: [str], json get key
+    .. index:: json get key
+    .. api-index:: §json§[§str§]
 
     Accesses an element of a JSON object given its key.
 
@@ -293,7 +295,7 @@ JSON array.
 
 .. eql:function:: std::to_json(string: str) -> json
 
-    :index: json parse loads
+    .. index:: json parse, loads
 
     Returns a JSON value parsed from the given string.
 
@@ -309,8 +311,6 @@ JSON array.
 
 
 .. eql:function:: std::json_array_unpack(json: json) -> set of json
-
-    :index: array unpack
 
     Returns the elements of a JSON array as a set of :eql:type:`json`.
 
@@ -333,7 +333,7 @@ JSON array.
 .. eql:function:: std::json_get(json: json, \
                                 variadic path: str) -> optional json
 
-    :index: safe navigation
+    .. index:: safe navigation
 
     Returns a value from a JSON object or array given its path.
 
@@ -524,8 +524,6 @@ JSON array.
 
 
 .. eql:function:: std::json_typeof(json: json) -> str
-
-    :index: type
 
     Returns the type of the outermost JSON value as a string.
 

--- a/docs/reference/stdlib/math.rst
+++ b/docs/reference/stdlib/math.rst
@@ -14,8 +14,6 @@ Math
 
 .. eql:function:: math::abs(x: anyreal) -> anyreal
 
-    :index: absolute
-
     Returns the absolute value of the input.
 
 
@@ -35,8 +33,6 @@ Math
                   math::ceil(x: bigint) -> bigint
                   math::ceil(x: decimal) -> decimal
 
-    :index: round
-
     Rounds up a given value to the nearest integer.
 
     .. code-block:: edgeql-repl
@@ -55,8 +51,6 @@ Math
                   math::floor(x: bigint) -> bigint
                   math::floor(x: decimal) -> decimal
 
-    :index: round
-
     Rounds down a given value to the nearest integer.
 
     .. code-block:: edgeql-repl
@@ -74,8 +68,6 @@ Math
                   math::ln(x: float64) -> float64
                   math::ln(x: decimal) -> decimal
 
-    :index: logarithm
-
     Returns the natural logarithm of a given value.
 
     .. code-block:: edgeql-repl
@@ -91,8 +83,6 @@ Math
                   math::lg(x: float64) -> float64
                   math::lg(x: decimal) -> decimal
 
-    :index: logarithm
-
     Returns the base 10 logarithm of a given value.
 
     .. code-block:: edgeql-repl
@@ -104,8 +94,6 @@ Math
 
 
 .. eql:function:: math::log(x: decimal, named only base: decimal) -> decimal
-
-    :index: logarithm
 
     Returns the logarithm of a given value in the specified base.
 
@@ -122,7 +110,7 @@ Math
                   math::mean(vals: set of float64) -> float64
                   math::mean(vals: set of decimal) -> decimal
 
-    :index: average avg
+    .. index:: average, avg
 
     Returns the arithmetic mean of the input set.
 
@@ -139,7 +127,7 @@ Math
                   math::stddev(vals: set of float64) -> float64
                   math::stddev(vals: set of decimal) -> decimal
 
-    :index: average
+    .. index:: average, avg
 
     Returns the sample standard deviation of the input set.
 
@@ -152,7 +140,7 @@ Math
                   math::stddev_pop(vals: set of float64) -> float64
                   math::stddev_pop(vals: set of decimal) -> decimal
 
-    :index: average
+    .. index:: average, avg
 
     Returns the population standard deviation of the input set.
 
@@ -169,7 +157,7 @@ Math
                   math::var(vals: set of float64) -> float64
                   math::var(vals: set of decimal) -> decimal
 
-    :index: average
+    .. index:: average, avg
 
     Returns the sample variance of the input set.
 
@@ -186,7 +174,7 @@ Math
                   math::var_pop(vals: set of float64) -> float64
                   math::var_pop(vals: set of decimal) -> decimal
 
-    :index: average
+    .. index:: average, avg
 
     Returns the population variance of the input set.
 
@@ -201,7 +189,7 @@ Math
 
 .. eql:function:: math::pi() -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the value of pi.
 
@@ -216,7 +204,7 @@ Math
 
 .. eql:function:: math::acos(x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the arc cosine of the input.
 
@@ -235,7 +223,7 @@ Math
 
 .. eql:function:: math::asin(x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the arc sine of the input.
 
@@ -254,7 +242,7 @@ Math
 
 .. eql:function:: math::atan(x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the arc tangent of the input.
 
@@ -273,7 +261,7 @@ Math
 
 .. eql:function:: math::atan2(y: float64, x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the arc tangent of ``y / x``.
 
@@ -296,7 +284,7 @@ Math
 
 .. eql:function:: math::cos(x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the cosine of the input.
 
@@ -317,7 +305,7 @@ Math
 
 .. eql:function:: math::cot(x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the cotangent of the input.
 
@@ -336,7 +324,7 @@ Math
 
 .. eql:function:: math::sin(x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the sinine of the input.
 
@@ -357,7 +345,7 @@ Math
 
 .. eql:function:: math::tan(x: float64) -> float64
 
-    :index: trigonometry
+    .. index:: trigonometry
 
     Returns the tanangent of the input.
 

--- a/docs/reference/stdlib/numbers.rst
+++ b/docs/reference/stdlib/numbers.rst
@@ -144,8 +144,6 @@ Definitions
 
 .. eql:type:: std::int16
 
-    :index: int integer
-
     A 16-bit signed integer.
 
     ``int16`` is capable of representing values from ``-32768`` to
@@ -156,8 +154,6 @@ Definitions
 
 
 .. eql:type:: std::int32
-
-    :index: int integer
 
     A 32-bit signed integer.
 
@@ -170,8 +166,6 @@ Definitions
 
 .. eql:type:: std::int64
 
-    :index: int integer
-
     A 64-bit signed integer.
 
     ``int64`` is capable of representing values from ``-9223372036854775808``
@@ -183,7 +177,7 @@ Definitions
 
 .. eql:type:: std::float32
 
-    :index: float
+    .. index:: float
 
     A variable precision, inexact number.
 
@@ -197,7 +191,7 @@ Definitions
 
 .. eql:type:: std::float64
 
-    :index: float double
+    .. index:: float, double
 
     A variable precision, inexact number.
 
@@ -211,7 +205,7 @@ Definitions
 
 .. eql:type:: std::bigint
 
-    :index: numeric bigint
+    .. index:: numeric
 
     An arbitrary precision integer.
 
@@ -280,7 +274,7 @@ Definitions
 
 .. eql:type:: std::decimal
 
-    :index: numeric float
+    .. index:: numeric, float
 
     Any number of arbitrary precision.
 
@@ -358,7 +352,8 @@ Definitions
 
 .. eql:operator:: plus: anyreal + anyreal -> anyreal
 
-    :index: +, addition
+    .. index:: plus
+    .. api-index:: §number §+§ number§
 
     Arithmetic addition.
 
@@ -373,7 +368,8 @@ Definitions
 
 .. eql:operator:: minus: anyreal - anyreal -> anyreal
 
-    :index: -, subtraction
+    .. index:: minus
+    .. api-index:: §number §-§ number§
 
     Arithmetic subtraction.
 
@@ -388,7 +384,8 @@ Definitions
 
 .. eql:operator:: uminus: - anyreal -> anyreal
 
-    :index: -, unary minus, subtraction
+    .. index:: unary minus, subtraction
+    .. api-index:: -§ number§
 
     Arithmetic negation.
 
@@ -403,7 +400,8 @@ Definitions
 
 .. eql:operator:: mult: anyreal * anyreal -> anyreal
 
-    :index: \*, multiply, multiplication
+    .. index:: times, multiply
+    .. api-index:: §number §*§ number§
 
     Arithmetic multiplication.
 
@@ -418,7 +416,8 @@ Definitions
 
 .. eql:operator:: div: anyreal / anyreal -> anyreal
 
-    :index: /, divide, division
+    .. index:: divide
+    .. api-index:: §number §/§ number§
 
     Arithmetic division.
 
@@ -440,7 +439,8 @@ Definitions
 
 .. eql:operator:: floordiv: anyreal // anyreal -> anyreal
 
-    :index: //, floor divide, division
+    .. index:: floor divide
+    .. api-index:: §number §//§ number§
 
     Floor division.
 
@@ -479,7 +479,7 @@ Definitions
 
 .. eql:operator:: mod: anyreal % anyreal -> anyreal
 
-    :index: %, modulo division, remainder
+    .. api-index:: §number §%§ number§
 
     Remainder from division (modulo).
 
@@ -522,7 +522,8 @@ Definitions
 
 .. eql:operator:: pow: anyreal ^ anyreal -> anyreal
 
-    :index: ^, power, exponentiation
+    .. index:: exponentiation
+    .. api-index:: §number §^§ number§
 
     Power operation.
 
@@ -794,7 +795,7 @@ Definitions
 
 .. eql:function:: std::to_bigint(s: str, fmt: optional str={}) -> bigint
 
-    :index: parse bigint
+    .. index:: parse bigint
 
     Returns a :eql:type:`bigint` value parsed from the given string.
 
@@ -816,7 +817,7 @@ Definitions
 
 .. eql:function:: std::to_decimal(s: str, fmt: optional str={}) -> decimal
 
-    :index: parse decimal
+    .. index:: parse decimal
 
     Returns a :eql:type:`decimal` value parsed from the given string.
 
@@ -840,7 +841,7 @@ Definitions
 .. eql:function:: std::to_int16(s: str, fmt: optional str={}) -> int16
                   std::to_int16(val: bytes, endian: Endian) -> int16
 
-    :index: parse int16
+    .. index:: parse int16
 
     Returns an :eql:type:`int16` value parsed from the given input.
 
@@ -877,7 +878,7 @@ Definitions
 .. eql:function:: std::to_int32(s: str, fmt: optional str={}) -> int32
                   std::to_int32(val: bytes, endian: Endian) -> int32
 
-    :index: parse int32
+    .. index:: parse int32
 
     Returns an :eql:type:`int32` value parsed from the given input.
 
@@ -914,7 +915,7 @@ Definitions
 .. eql:function:: std::to_int64(s: str, fmt: optional str={}) -> int64
                   std::to_int64(val: bytes, endian: Endian) -> int64
 
-    :index: parse int64
+    .. index:: parse int64
 
     Returns an :eql:type:`int64` value parsed from the given input.
 
@@ -952,7 +953,7 @@ Definitions
 
 .. eql:function:: std::to_float32(s: str, fmt: optional str={}) -> float32
 
-    :index: parse float32
+    .. index:: parse float32
 
     Returns a :eql:type:`float32` value parsed from the given string.
 
@@ -966,7 +967,7 @@ Definitions
 
 .. eql:function:: std::to_float64(s: str, fmt: optional str={}) -> float64
 
-    :index: parse float64
+    .. index:: parse float64
 
     Returns a :eql:type:`float64` value parsed from the given string.
 

--- a/docs/reference/stdlib/range.rst
+++ b/docs/reference/stdlib/range.rst
@@ -272,7 +272,8 @@ Reference
 .. eql:operator:: rangelt: range<anypoint> < range<anypoint> -> bool
                   multirange<anypoint> < multirange<anypoint> -> bool
 
-    :index: <, multirange, less than, before, comparison, compare
+    .. index:: less than, comparison
+    .. api-index:: §range §<§ range§
 
     One range or multirange is before the other.
 
@@ -320,7 +321,8 @@ Reference
 .. eql:operator:: rangegt: range<anypoint> > range<anypoint> -> bool
                   multirange<anypoint> > multirange<anypoint> -> bool
 
-    :index: >, multirange, greater than, after, comparison, compare
+    .. index:: greater than, comparison
+    .. api-index:: §range §>§ range§
 
     One range or multirange is after the other.
 
@@ -368,7 +370,8 @@ Reference
 .. eql:operator:: rangelteq: range<anypoint> <= range<anypoint> -> bool
                   multirange<anypoint> <= multirange<anypoint> -> bool
 
-    :index: <=, multirange, less than or equal, before, comparison, compare
+    .. index:: less than or equal, comparison
+    .. api-index:: §range §<=§ range§
 
     One range or multirange is before or same as the other.
 
@@ -423,7 +426,8 @@ Reference
 .. eql:operator:: rangegteq: range<anypoint> >= range<anypoint> -> bool
                   multirange<anypoint> >= multirange<anypoint> -> bool
 
-    :index: >=, multirange, greater than or equal, after, comparison, compare
+    .. index:: greater than or equal, comparison
+    .. api-index:: §range §>=§ range§
 
     One range or multirange is after or same as the other.
 
@@ -477,7 +481,8 @@ Reference
                   multirange<anypoint> + multirange<anypoint> \
                     -> multirange<anypoint>
 
-    :index: +, multirange, plus, addition, union
+    .. index:: plus, addition
+    .. api-index:: §range §+§ range§
 
     Range or multirange union.
 
@@ -513,7 +518,8 @@ Reference
                   multirange<anypoint> - multirange<anypoint> \
                     -> multirange<anypoint>
 
-    :index: -, multirange, minus, subtraction
+    .. index:: minus
+    .. api-index:: §range §-§ range§
 
     Range or multirange subtraction.
 
@@ -553,9 +559,9 @@ Reference
                   multirange<anypoint> * multirange<anypoint> \
                     -> multirange<anypoint>
 
-    :index: \*, multirange, intersection
+    .. api-index:: §range §*§ range§
 
-    Range or multirnage intersection.
+    Range or multirange intersection.
 
     Find the intersection of two ranges or multiranges.
 

--- a/docs/reference/stdlib/set.rst
+++ b/docs/reference/stdlib/set.rst
@@ -5,7 +5,6 @@ Sets
 ====
 
 :edb-alt-title: Set Functions and Operators
-:index: set aggregate
 
 
 .. list-table::
@@ -95,7 +94,7 @@ Sets
 
 .. eql:operator:: distinct: distinct set of anytype -> set of anytype
 
-    :index: distinct, unique, set of
+    .. api-index:: distinct§ set of type§
 
     Produces a set of all unique elements in the given set.
 
@@ -114,7 +113,8 @@ Sets
 .. eql:operator:: in: anytype in set of anytype -> bool
                       anytype not in set of anytype -> bool
 
-    :index: in, not in, intersection, contains, set of
+    .. index:: intersection, contains
+    .. api-index:: §element §in§ set§, §element §not in§ set§
 
     Checks if a given element is a member of a given set.
 
@@ -150,7 +150,8 @@ Sets
 
 .. eql:operator:: union: set of anytype union set of anytype -> set of anytype
 
-    :index: union, merge, join, set of
+    .. index:: join
+    .. api-index:: union
 
     Merges two sets.
 
@@ -170,7 +171,7 @@ Sets
 .. eql:operator:: intersect: set of anytype intersect set of anytype \
                                 -> set of anytype
 
-    :index: intersect, common, set of
+    .. api-index:: intersect
 
     Produces a set containing the common items between the given sets.
 
@@ -188,7 +189,7 @@ Sets
 .. eql:operator:: except: set of anytype except set of anytype \
                                 -> set of anytype
 
-    :index: except, set of
+    .. api-index:: except
 
     Produces a set of all items in the first set which are not in the second.
 
@@ -206,7 +207,8 @@ Sets
 .. eql:operator:: if..else: set of anytype if bool else set of anytype \
                                 -> set of anytype
 
-    :index: if else, ifelse, elif, ternary, conditional
+    .. index:: ternary, conditional
+    .. api-index:: §expr §if§ bool §else§ expr§
 
     Produces one of two possible results based on a given condition.
 
@@ -254,9 +256,10 @@ Sets
 .. eql:operator:: if..then..else: if bool then set of anytype else set of \
                                 anytype -> set of anytype
 
-    :index: if then else, ifelse, elif, conditional
-
     .. versionadded:: 4.0
+
+    .. index:: ternary, conditional
+    .. api-index:: if§ bool §then§ expr §else§ expr§
 
     Produces one of two possible results based on a given condition.
 
@@ -312,7 +315,7 @@ Sets
 .. eql:operator:: coalesce: optional anytype ?? set of anytype \
                               -> set of anytype
 
-    :index: ??, empty set
+    .. api-index:: ??
 
     Produces the first of its operands that is not an empty set.
 
@@ -346,7 +349,7 @@ Sets
 
 .. eql:operator:: detached: detached set of anytype -> set of anytype
 
-    :index: detached, set of
+    .. api-index:: detached
 
     Detaches the input set reference from the current scope.
 
@@ -401,7 +404,7 @@ Sets
 
 .. eql:operator:: exists: exists set of anytype -> bool
 
-    :index: exists, set of, is empty
+    .. api-index:: exists
 
     Determines whether a set is empty or not.
 
@@ -420,7 +423,8 @@ Sets
 
 .. eql:operator:: isintersect: anytype [is type] -> anytype
 
-    :index: [is type], type intersection, filter
+    .. index:: type intersection, filter
+    .. api-index:: §expr§[is §type§]
 
     Filters a set based on its type. Will return back the specified type.
 
@@ -480,7 +484,7 @@ Sets
                     named only message: optional str = <str>{} \
                   ) -> set of anytype
 
-    :index: multiplicity uniqueness
+    .. index:: multiplicity, uniqueness
 
     Checks that the input set contains only unique elements.
 
@@ -527,7 +531,7 @@ Sets
                     named only message: optional str = <str>{} \
                   ) -> set of anytype
 
-    :index: cardinality singleton
+    .. index:: cardinality, singleton
 
     Checks that the input set contains no more than one element.
 
@@ -567,7 +571,7 @@ Sets
                     named only message: optional str = <str>{} \
                   ) -> set of anytype
 
-    :index: cardinality existence empty
+    .. index:: cardinality, existence
 
     Checks that the input set contains at least one element.
 
@@ -601,7 +605,7 @@ Sets
 
 .. eql:function:: std::count(s: set of anytype) -> int64
 
-    :index: aggregate
+    .. index:: aggregate
 
     Returns the number of elements in a set.
 
@@ -624,7 +628,7 @@ Sets
                   std::sum(s: set of bigint) -> bigint
                   std::sum(s: set of decimal) -> decimal
 
-    :index: aggregate
+    .. index:: aggregate
 
     Returns the sum of the set of numbers.
 
@@ -647,7 +651,7 @@ Sets
 
 .. eql:function:: std::all(values: set of bool) -> bool
 
-    :index: aggregate
+    .. index:: aggregate
 
     Returns ``true`` if none of the values in the given set are ``false``.
 
@@ -668,7 +672,7 @@ Sets
 
 .. eql:function:: std::any(values: set of bool) -> bool
 
-    :index: aggregate
+    .. index:: aggregate
 
     Returns ``true`` if any of the values in the given set is ``true``.
 
@@ -690,7 +694,7 @@ Sets
 .. eql:function:: std::enumerate(values: set of anytype) -> \
                   set of tuple<int64, anytype>
 
-    :index: enumerate
+    .. index:: enumerate
 
     Returns a set of tuples in the form of ``(index, element)``.
 
@@ -720,7 +724,7 @@ Sets
 
 .. eql:function:: std::min(values: set of anytype) -> optional anytype
 
-    :index: aggregate
+    .. index:: aggregate
 
     Returns the smallest value in the given set.
 
@@ -735,7 +739,7 @@ Sets
 
 .. eql:function:: std::max(values: set of anytype) -> optional anytype
 
-    :index: aggregate
+    .. index:: aggregate
 
     Returns the largest value in the given set.
 

--- a/docs/reference/stdlib/string.rst
+++ b/docs/reference/stdlib/string.rst
@@ -98,7 +98,7 @@ Strings
 
 .. eql:type:: std::str
 
-    :index: continuation cont
+    .. index:: continuation
 
     A unicode string of text.
 
@@ -191,7 +191,7 @@ Strings
 
 .. eql:operator:: stridx: str [ int64 ] -> str
 
-    :index: [int], index access
+    .. api-index:: §str§[§int§]
 
     String indexing.
 
@@ -231,7 +231,7 @@ Strings
 
 .. eql:operator:: strslice: str [ int64 : int64 ] -> str
 
-    :index: [int:int]
+    .. api-index:: §str§[§int§:§int§]
 
     String slicing.
 
@@ -265,7 +265,8 @@ Strings
 
 .. eql:operator:: strplus: str ++ str -> str
 
-    :index: ++, string, concatenate, join, add
+    .. index:: join, add
+    .. api-index:: §str §++§ str§
 
     String concatenation.
 
@@ -281,7 +282,8 @@ Strings
 .. eql:operator:: like: str like str -> bool
                         str not like str -> bool
 
-    :index: like, not like, case sensitive, string matching, comparison, compare
+    .. index:: comparison, compare
+    .. api-index:: §str §like§ str§, §str §not like§ str§
 
     Case-sensitive simple string matching.
 
@@ -333,7 +335,8 @@ Strings
 .. eql:operator:: ilike: str ilike str -> bool
                          str not ilike str -> bool
 
-    :index: ilike, not ilike, case insensitive, string matching, comparison, compare
+    .. index:: comparison, compare
+    .. api-index:: §str §ilike§ str§, §str §not ilike§ str§
 
     Case-insensitive simple string matching.
 
@@ -567,7 +570,7 @@ Strings
 
 .. eql:function:: std::str_split(s: str, delimiter: str) -> array<str>
 
-    :index: split str_split explode
+    .. index:: explode
 
     Splits a string into array elements using the supplied delimiter.
 
@@ -588,7 +591,7 @@ Strings
 .. eql:function:: std::re_match(pattern: str, \
                                 string: str) -> array<str>
 
-    :index: regex regexp regular
+    .. index:: regexp
 
     Finds the first regular expression match in a string.
 
@@ -609,7 +612,7 @@ Strings
 .. eql:function:: std::re_match_all(pattern: str, \
                                     string: str) -> set of array<str>
 
-    :index: regex regexp regular
+    .. index:: regexp
 
     Finds all regular expression matches in a string.
 
@@ -632,7 +635,7 @@ Strings
                                   named only flags: str='') \
                   -> str
 
-    :index: regex regexp regular replace
+    .. index:: regexp
 
     Replaces matching substrings in a given string.
 
@@ -656,7 +659,7 @@ Strings
 
 .. eql:function:: std::re_test(pattern: str, string: str) -> bool
 
-    :index: regex regexp regular match
+    .. index:: regexp
 
     Tests if a regular expression has a match in a string.
 
@@ -689,7 +692,7 @@ Strings
                   std::to_str(val: cal::local_time, \
                               fmt: optional str={}) -> str
 
-    :index: stringify dumps join array_to_string decode TextDecoder
+    .. index:: stringify, dumps, join, array_to_string, decode, TextDecoder
 
     Returns the string representation of the input value.
 

--- a/docs/reference/stdlib/sys.rst
+++ b/docs/reference/stdlib/sys.rst
@@ -127,8 +127,6 @@ System
 
 .. eql:type:: sys::TransactionIsolation
 
-    :index: enum transaction isolation
-
     :eql:type:`Enum <enum>` indicating the possible transaction
     isolation modes.
 

--- a/docs/reference/stdlib/tuple.rst
+++ b/docs/reference/stdlib/tuple.rst
@@ -126,8 +126,6 @@ Here's a few examples of using tuple types in EdgeQL queries:
 
 .. eql:type:: std::tuple
 
-    :index: tuple
-
     A tuple type is a heterogeneous sequence of other types.
 
     Tuple elements can optionally have names,

--- a/docs/reference/stdlib/type.rst
+++ b/docs/reference/stdlib/type.rst
@@ -63,7 +63,8 @@ the ``name`` property inside ``__type__``:
 .. eql:operator:: is: anytype is type -> bool
                       anytype is not type -> bool
 
-    :index: is, type checking, compare, comparison
+    .. index:: comparison
+    .. api-index:: §type §is§ type§
 
     Type checking operator.
 
@@ -95,7 +96,8 @@ the ``name`` property inside ``__type__``:
 
 .. eql:operator:: typeor: type | type -> type
 
-    :index: \|, type union, polymorphism, polymorphic queries, nested shapes
+    .. index:: polymorphism, polymorphic queries, nested shapes
+    .. api-index:: §type §|§ type§
 
     Type union operator.
 
@@ -174,7 +176,8 @@ the ``name`` property inside ``__type__``:
 
 .. eql:operator:: cast: < type > anytype -> anytype
 
-    :index: <type>, type conversion, convert type
+    .. index:: type conversion, convert type
+    .. api-index:: <§type§>§expr§
 
     Type cast operator.
 
@@ -277,7 +280,8 @@ the ``name`` property inside ``__type__``:
 
 .. eql:operator:: typeof: typeof anytype -> type
 
-    :index: typeof, introspection
+    .. index:: introspection
+    .. api-index:: typeof§ type§
 
     Static type inference operator.
 
@@ -345,7 +349,7 @@ the ``name`` property inside ``__type__``:
 
 .. eql:operator:: introspect: introspect type -> schema::Type
 
-    :index: introspect, type introspection, typeof
+    .. api-index:: introspect§ type§
 
     Static type introspection operator.
 

--- a/docs/reference/stdlib/uuid.rst
+++ b/docs/reference/stdlib/uuid.rst
@@ -95,7 +95,7 @@ UUIDs
 
 .. eql:function:: std::to_uuid(val: bytes) -> uuid
 
-    :index: parse uuid
+    .. index:: parse uuid
 
     Returns a :eql:type:`uuid` value parsed from 128-bit input.
 

--- a/edb/tools/docs/__init__.py
+++ b/edb/tools/docs/__init__.py
@@ -23,6 +23,7 @@ from docutils import nodes as d_nodes
 from docutils.parsers import rst as d_rst
 from sphinx import addnodes as s_nodes
 from sphinx import transforms as s_transforms
+from sphinx.domains.index import IndexDirective
 
 from . import edb
 from . import cli
@@ -111,6 +112,14 @@ class VersionedReplaceRole:
             node += d_nodes.Text(parts[1].strip())
             nodes.append(node)
         return nodes, []
+    
+
+class APIIndex(IndexDirective):
+    
+    def run(self):
+        nodes = super().run()
+        nodes[0]['api-index'] = True
+        return nodes
 
 
 def setup(app):
@@ -126,6 +135,7 @@ def setup(app):
     app.add_directive('versionchanged', VersionChanged, True)
     app.add_directive('code-block', shared.CodeBlock, True)
     app.add_directive('versioned-section', VersionedSection)
+    app.add_directive('api-index', APIIndex)
     app.add_role('versionreplace', VersionedReplaceRole())
 
     app.add_transform(ProhibitedNodeTransform)

--- a/edb/tools/docs/__init__.py
+++ b/edb/tools/docs/__init__.py
@@ -112,10 +112,10 @@ class VersionedReplaceRole:
             node += d_nodes.Text(parts[1].strip())
             nodes.append(node)
         return nodes, []
-    
+
 
 class APIIndex(IndexDirective):
-    
+
     def run(self):
         nodes = super().run()
         nodes[0]['api-index'] = True

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -466,7 +466,11 @@ class BaseEQLDirective(s_directives.ObjectDescription):
             first_node_index += 1
             first_node = desc_cnt.children[first_node_index]
 
-        if isinstance(first_node, s_nodes.versionmodified):
+        while (
+            isinstance(first_node, s_nodes.versionmodified)
+            or isinstance(first_node, s_nodes.index)
+            or isinstance(first_node, d_nodes.target)
+        ):
             first_node_index += 1
             first_node = desc_cnt.children[first_node_index]
 


### PR DESCRIPTION
The new docs search strategy uses two search indexes: A full text search powered by algolia, and a more basic fuzzy 'api' search tuned to just searching keywords, stdlib functions, operator symbols, etc.

So to annotate sections/desc blocks for the api index, this PR adds a new `.. api-index::` directive and updates the docs to use it. Multiple terms can be comma seperated, and wrapping content within a term in `§` will make it non-searchable and rendered de-emphasized in the docs search results (eg. can used to differentiate between array indexing: `§array§[§int§]` and str indexing `§str§[§int§]` while making `[]` the searchable operator term).

The sphinx builtin `.. index::` is still used for adding extra terms to the full text search index.