### PR TITLE
Fixed computed ptr with group by incorrectly inferring multiplicity.

### DIFF
--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -815,9 +815,11 @@ def __infer_group_stmt(
         if set:
             infer_multiplicity(set, scope_tree=scope_tree, ctx=ctx)
 
-    # N.B: Since the type is usually a free object (except in some
-    # internal tests), this will typically get turned UNIQUE by the
-    # enclosing Set.
+    # N.B: The type is usually a free object (except in some
+    # internal tests), which are always unique
+    if irtyputils.is_free_object(ir.typeref):
+        return UNIQUE
+
     return DUPLICATE
 
 

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -3853,6 +3853,120 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             ],
         )
 
+    async def test_edgeql_group_link_property_02(self):
+        await self.assert_query_result(
+            r'''
+            WITH MODULE cards
+            select User { cards := (group .deck { name } by .element) };
+            ''',
+            tb.bag([
+                {
+                    'cards': tb.bag([
+                        {
+                            'key': {'element': 'Water'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Bog monster'},
+                                {'name': 'Giant turtle'}
+                            ])
+                        },
+                        {
+                            'key': {'element': 'Fire'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Imp'},
+                                {'name': 'Dragon'}
+                            ])
+                        },
+                    ]),
+                },
+                {
+                    'cards': tb.bag([
+                        {
+                            'key': {'element': 'Earth'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Dwarf'},
+                                {'name': 'Golem'}
+                            ])
+                        },
+                        {
+                            'key': {'element': 'Water'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Bog monster'},
+                                {'name': 'Giant turtle'}
+                            ])
+                        },
+                    ]),
+                },
+                {
+                    'cards': tb.bag([
+                        {
+                            'key': {'element': 'Earth'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Dwarf'},
+                                {'name': 'Golem'}
+                            ])
+                        },
+                        {
+                            'key': {'element': 'Water'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Bog monster'},
+                                {'name': 'Giant turtle'}
+                            ])
+                        },
+                        {
+                            'key': {'element': 'Air'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Sprite'},
+                                {'name': 'Giant eagle'},
+                                {'name': 'Djinn'}
+                            ])
+                        },
+                    ]),
+                },
+                {
+                    'cards': tb.bag([
+                        {
+                            'key': {'element': 'Earth'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Golem'}
+                            ])
+                        },
+                        {
+                            'key': {'element': 'Water'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Bog monster'},
+                                {'name': 'Giant turtle'}
+                            ])
+                        },
+                        {
+                            'key': {'element': 'Fire'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Dragon'}
+                            ])
+                        },
+                        {
+                            'key': {'element': 'Air'},
+                            'grouping': ['element'],
+                            'elements': tb.bag([
+                                {'name': 'Sprite'},
+                                {'name': 'Giant eagle'},
+                                {'name': 'Djinn'}
+                            ])
+                        },
+                    ]),
+                },
+            ]),
+        )
+
     async def test_edgeql_group_destruct_immediately_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -873,3 +873,11 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         UNIQUE
         """
+
+    def test_edgeql_ir_mult_inference_93(self):
+        """
+        with groupedCards := User { cards := (group .deck by .element) }
+        select groupedCards.cards
+% OK %
+        UNIQUE
+        """


### PR DESCRIPTION
Fixes query errors caused by using group by in a computed pointer.

For example, given the schema:
```
module default {
    type Foo { n: int64 };
    type Bar { multi foo: Foo };
}
```

The query `SELECT Bar { g := (group .foo by .n) };` would produce the error:
```
QueryError: possibly not a distinct set returned by an expression for a computed link 'g'
  ┌─ <query>:1:14
  │
1 │ SELECT Bar { g := (group .foo by .n) };
  │              ^^^^^^^^^^^^^^^^^^^^^^ You can use assert_distinct() around the expression to turn this into a runtime assertion, or the DISTINCT operator to silently discard duplicate elements.
```

close #8481