### PR TITLE
pg-ext: add more SQL func wrappers

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -7706,6 +7706,11 @@ def _generate_sql_information_schema(
             views.append(v)
 
     util_functions = [
+        # WARNING: this `edgedbsql.to_regclass()` function is currently not
+        # accurately implemented to take application-level `search_path`
+        # into consideration. It is currently here to support the following
+        # `has_*privilege` functions (which are less sensitive to such issue).
+        # SO DO NOT USE `edgedbsql.to_regclass()` FOR ANYTHING ELSE.
         trampoline.VersionedFunction(
             name=('edgedbsql', 'to_regclass'),
             args=(
@@ -7720,6 +7725,7 @@ def _generate_sql_information_schema(
                                 SELECT oid::regclass
                                 FROM edgedbsql_VER.pg_class
                                 WHERE relname = parts[1]
+                                LIMIT 1  -- HACK: see comments above
                             )
                         WHEN array_length(parts, 1) = 2 THEN
                             (

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -7693,6 +7693,30 @@ def _generate_sql_information_schema(
 
     util_functions = [
         trampoline.VersionedFunction(
+            name=('edgedbsql', 'has_database_privilege'),
+            args=(
+                ('database_name', 'text'),
+                ('privilege', 'text'),
+            ),
+            returns=('bool',),
+            text="""
+                SELECT has_database_privilege(oid, privilege)
+                FROM edgedbsql_VER.pg_database
+                WHERE datname = database_name
+            """
+        ),
+        trampoline.VersionedFunction(
+            name=('edgedbsql', 'has_database_privilege'),
+            args=(
+                ('database_oid', 'oid'),
+                ('privilege', 'text'),
+            ),
+            returns=('bool',),
+            text="""
+                SELECT has_database_privilege(database_oid, privilege)
+            """
+        ),
+        trampoline.VersionedFunction(
             name=('edgedbsql', 'has_schema_privilege'),
             args=(
                 ('schema_name', 'text'),
@@ -7798,6 +7822,30 @@ def _generate_sql_information_schema(
                 FROM edgedbsql_VER.pg_class pc
                 JOIN edgedbsql_VER.pg_attribute_ext pa ON pa.attrelid = pc.oid
                 WHERE pc.relname = tbl AND pa.attname = col;
+            """
+        ),
+        trampoline.VersionedFunction(
+            name=('edgedbsql', 'has_any_column_privilege'),
+            args=(
+                ('tbl', 'oid'),
+                ('privilege', 'text'),
+            ),
+            returns=('bool',),
+            text="""
+                SELECT has_any_column_privilege(tbl, privilege)
+            """
+        ),
+        trampoline.VersionedFunction(
+            name=('edgedbsql', 'has_any_column_privilege'),
+            args=(
+                ('tbl', 'text'),
+                ('privilege', 'text'),
+            ),
+            returns=('bool',),
+            text="""
+                SELECT has_any_column_privilege(oid, privilege)
+                FROM edgedbsql_VER.pg_class
+                WHERE relname = tbl
             """
         ),
         trampoline.VersionedFunction(

--- a/edb/pgsql/resolver/static.py
+++ b/edb/pgsql/resolver/static.py
@@ -383,9 +383,11 @@ def eval_FuncCall(
         # schema and table names need to be remapped. This is accomplished
         # with wrapper functions defined in metaschema.py.
         has_wrapper = {
+            'has_database_privilege',
             'has_schema_privilege',
             'has_table_privilege',
             'has_column_privilege',
+            'has_any_column_privilege',
         }
         if fn_name in has_wrapper:
             return pgast.FuncCall(name=(V('edgedbsql'), fn_name), args=fn_args)

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1637,6 +1637,40 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         finally:
             await con.aclose()
 
+    async def test_sql_query_privileges_01(self):
+
+        res = await self.squery_values(
+            '''
+            select has_database_privilege($1, 'CONNECT');
+            ''',
+            self.con.dbname,
+        )
+        self.assertEqual(res, [[True]])
+
+    async def test_sql_query_privileges_02(self):
+        res = await self.squery_values(
+            '''
+            select has_table_privilege('"Movie"', 'SELECT');
+            '''
+        )
+        self.assertEqual(res, [[True]])
+
+    async def test_sql_query_privileges_03(self):
+        res = await self.squery_values(
+            '''
+            select has_column_privilege('"Movie"', 'title', 'SELECT');
+            '''
+        )
+        self.assertEqual(res, [[True]])
+
+    async def test_sql_query_privileges_04(self):
+        res = await self.squery_values(
+            '''
+            select has_any_column_privilege('"Movie"', 'SELECT');
+            '''
+        )
+        self.assertEqual(res, [[True]])
+
     async def test_sql_query_client_encoding_1(self):
         self.assertEqual(
             self.scon.get_settings().client_encoding.lower(), "utf_8"


### PR DESCRIPTION
Adds wrappers for:

* `has_database_privilege`
* `has_any_column_privilege`

`has_any_column_privilege` is needed by Metabase introspecting the schema.

Also added an internal util function `to_regclass()` that uses `parse_ident()` to imitate the actual `to_regclass()`. This may potentially replace the current compiler-backed `to_regclass()`, but I'd keep this PR small.

The `pg_database` view was broken, fix that too.

- [x] Fix namespaced table names
- [x] Fix broken `pg_database` view
- [x] Add test

Refs #5307, #5319
Fixes #8457 