### PR TITLE
Use `COPY ... FREEZE` when restoring dumps

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1347,7 +1347,7 @@ class Compiler:
             stmt = (
                 f'COPY {table_name} '
                 f'({", ".join(col_list)})'
-                f'FROM STDIN WITH BINARY'
+                f'FROM STDIN WITH (FORMAT binary, FREEZE true)'
             ).encode()
 
             restore_blocks.append(


### PR DESCRIPTION
Dumps in Gel are always restored into new tables, so this is safe and
should result in better restore performance.
