### PR TITLE
Use `read committed` when restoring dumps

### DIFF
--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1628,7 +1628,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         async with self._with_dump_restore_pgcon() as pgcon:
             _dbview.decode_state(sertypes.NULL_TYPE_ID.bytes, b'')
             await self._execute_utility_stmt(
-                'START TRANSACTION ISOLATION READ COMMITTED',
+                'START TRANSACTION ISOLATION LEVEL READ COMMITTED',
                 pgcon,
             )
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1628,7 +1628,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         async with self._with_dump_restore_pgcon() as pgcon:
             _dbview.decode_state(sertypes.NULL_TYPE_ID.bytes, b'')
             await self._execute_utility_stmt(
-                'START TRANSACTION ISOLATION SERIALIZABLE',
+                'START TRANSACTION ISOLATION READ COMMITTED',
                 pgcon,
             )
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1628,7 +1628,7 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         async with self._with_dump_restore_pgcon() as pgcon:
             _dbview.decode_state(sertypes.NULL_TYPE_ID.bytes, b'')
             await self._execute_utility_stmt(
-                'START TRANSACTION ISOLATION LEVEL READ COMMITTED',
+                'START TRANSACTION ISOLATION REPEATABLE READ',
                 pgcon,
             )
 

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1628,13 +1628,15 @@ cdef class EdgeConnection(frontend.FrontendConnection):
         async with self._with_dump_restore_pgcon() as pgcon:
             _dbview.decode_state(sertypes.NULL_TYPE_ID.bytes, b'')
             await self._execute_utility_stmt(
-                'START TRANSACTION ISOLATION REPEATABLE READ',
+                'START TRANSACTION',
                 pgcon,
             )
 
             try:
                 await pgcon.sql_execute(
                     b'''
+                        -- Drop isolation level.
+                        SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
                         -- Disable transaction or query execution timeout
                         -- limits. Both clients and the server can be slow
                         -- during the dump/restore process.


### PR DESCRIPTION
There's no point in running in `serializable` when restoring things
because we currently restore into empty relations always.
