### PR TITLE
Import existing redirects from dotcom repo

### DIFF
--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -1,9 +1,28 @@
 // See https://nextjs.org/docs/app/api-reference/config/next-config-js/redirects
 module.exports = [
   {
-    // REMOVE ME
-    source: "/test",
-    destination: "/resources/guides",
+    source: "/guides/cheatsheet/:path*",
+    destination: "/resources/cheatsheets/:path*",
+    permanent: true,
+  },
+  {
+    source: "/guides/ai/:path*",
+    destination: "/ai/:path*",
+    permanent: true,
+  },
+  {
+    source: "/changelog/6_x",
+    destination: "/resources/changelog/6_x",
+    permanent: true,
+  },
+  {
+    source: "/database/:path*",
+    destination: "/reference/:path*",
+    permanent: false,
+  },
+  {
+    source: "/guides/:path*",
+    destination: "/resources/guides/:path*",
     permanent: false,
   },
 ];


### PR DESCRIPTION
We want these redirects to live with the documentation to make it easier
to move content while leaving a redirect in it's place.

See existing: https://github.com/geldata/edgedb.com/blob/cfe67aa2056f8b1093274b759e31b7f5d7af50fe/docs/redirects.js#L1-L27