### PR TITLE
HTTP requests should delay the auto shutdown

### DIFF
--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -139,6 +139,7 @@ cdef class HttpProtocol:
         )
         self.transport = None
         self.unprocessed = None
+        self.server.maybe_auto_shutdown()
 
     def get_tenant_label(self):
         if self.tenant is None:

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -324,11 +324,6 @@ class BaseServer:
 
     def on_binary_client_created(self) -> str:
         self._binary_proto_id_counter += 1
-
-        if self._auto_shutdown_handler:
-            self._auto_shutdown_handler.cancel()
-            self._auto_shutdown_handler = None
-
         return str(self._binary_proto_id_counter)
 
     def on_binary_client_connected(self, conn):
@@ -361,6 +356,11 @@ class BaseServer:
             1.0, conn.get_tenant_label()
         )
         self.maybe_auto_shutdown()
+
+    def maybe_delay_auto_shutdown(self):
+        if self._auto_shutdown_handler:
+            self._auto_shutdown_handler.cancel()
+            self._auto_shutdown_handler = None
 
     def maybe_auto_shutdown(self):
         if (
@@ -728,13 +728,9 @@ class BaseServer:
         # CONFIGURE INSTANCE RESET setting_name;
         pass
 
-    async def _start_server(
-        self,
-        host: str,
-        port: int,
-        sock: Optional[socket.socket] = None,
-    ) -> Optional[asyncio.base_events.Server]:
-        proto_factory = lambda: protocol.HttpProtocol(
+    def _make_protocol(self):
+        self.maybe_delay_auto_shutdown()
+        return protocol.HttpProtocol(
             self,
             self._sslctx,
             self._sslctx_pgext,
@@ -742,13 +738,19 @@ class BaseServer:
             http_endpoint_security=self._http_endpoint_security,
         )
 
+    async def _start_server(
+        self,
+        host: str,
+        port: int,
+        sock: Optional[socket.socket] = None,
+    ) -> Optional[asyncio.base_events.Server]:
         try:
             kwargs: dict[str, Any]
             if sock is not None:
                 kwargs = {"sock": sock}
             else:
                 kwargs = {"host": host, "port": port}
-            return await self.__loop.create_server(proto_factory, **kwargs)
+            return await self.__loop.create_server(self._make_protocol, **kwargs)
         except Exception as e:
             logger.warning(
                 f"could not create listen socket for '{host}:{port}': {e}"

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -750,7 +750,9 @@ class BaseServer:
                 kwargs = {"sock": sock}
             else:
                 kwargs = {"host": host, "port": port}
-            return await self.__loop.create_server(self._make_protocol, **kwargs)
+            return await self.__loop.create_server(
+                self._make_protocol, **kwargs
+            )
         except Exception as e:
             logger.warning(
                 f"could not create listen socket for '{host}:{port}': {e}"

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -112,7 +112,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
                 # and the cluster to be shutdown soon.
                 await sd.connect(wait_until_available=0)
 
-    async def test_server_ops_auto_shutdown_after_one(self):
+    async def test_server_ops_auto_shutdown_after_one_1(self):
         async with tb.start_edgedb_server(
             auto_shutdown_after=1,
         ) as sd:
@@ -120,6 +120,27 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
 
             with self.assertRaises(
                     (ConnectionError, edgedb.ClientConnectionError)):
+                await sd.connect(wait_until_available=0)
+
+    async def test_server_ops_auto_shutdown_after_one_2(self):
+        async with tb.start_edgedb_server(
+            auto_shutdown_after=1,
+            http_endpoint_security=(
+                args.ServerEndpointSecurityMode.Optional
+            ),
+        ) as sd:
+            await asyncio.sleep(0.5)
+            self.assertEqual(sd.call_system_api('/server/status/ready'), 'OK')
+            await asyncio.sleep(0.5)
+            self.assertEqual(sd.call_system_api('/server/status/ready'), 'OK')
+            await asyncio.sleep(0.5)
+            self.assertEqual(sd.call_system_api('/server/status/ready'), 'OK')
+            await asyncio.sleep(0.5)
+            self.assertEqual(sd.call_system_api('/server/status/ready'), 'OK')
+            await asyncio.sleep(2)
+
+            with self.assertRaises(
+                (ConnectionError, edgedb.ClientConnectionError)):
                 await sd.connect(wait_until_available=0)
 
     @unittest.skipIf(


### PR DESCRIPTION
Before this PR, local CLI-managed instances was shutdown automatically in 10 minutes even when the server has been interacted through HTTP (and HTTP only).

See the added test for repro/fix.