### PR TITLE
Prevent server auto shutdown during building AI index

### DIFF
--- a/edb/server/connpool/pool.py
+++ b/edb/server/connpool/pool.py
@@ -388,6 +388,7 @@ class BasePool(typing.Generic[C]):
 
         self._blocks = collections.OrderedDict()
         self._is_starving = False
+        self._running = True
 
         self._failed_connects = 0
         self._failed_disconnects = 0
@@ -397,7 +398,7 @@ class BasePool(typing.Generic[C]):
         self._conntime_avg = rolavg.RollingAverage(history_size=10)
 
     async def close(self) -> None:
-        pass
+        self._running = False
 
     @property
     def max_capacity(self) -> int:
@@ -529,7 +530,7 @@ class BasePool(typing.Generic[C]):
             logger.error(
                 "Failed to establish a new connection to backend database: %s",
                 block.dbname,
-                exc_info=True,
+                exc_info=self._running,
             )
             block.connect_failures_num += 1
 

--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -293,7 +293,7 @@ async def _ext_ai_index_builder_controller_loop(
     provider_schedulers: dict[str, ProviderScheduler] = {}
 
     try:
-        while True:
+        while tenant.accept_new_tasks:
             if not db.tenant.is_database_connectable(dbname):
                 # Don't do work if the database is not connectable,
                 # e.g. being dropped
@@ -337,7 +337,13 @@ async def _ext_ai_index_builder_controller_loop(
                                     )
                                     holding_lock = False
             except Exception:
-                logger.exception(f"caught error in {task_name}")
+                logger.error(
+                    f"caught error in {task_name}",
+                    exc_info=tenant.accept_new_tasks,
+                )
+
+            if not tenant.accept_new_tasks:
+                break
 
             if not sleep_timer.is_ready_and_urgent():
                 delay = sleep_timer.remaining_time(naptime)

--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("edb.server.ai_ext")
+keepalive_token = "ai-index-builder"
 
 
 class AIExtError(Exception):
@@ -327,6 +328,13 @@ async def _ext_ai_index_builder_controller_loop(
                                 if not sleep_timer.is_ready_and_urgent():
                                     await asyncutil.deferred_shield(
                                         _ext_ai_unlock(tenant))
+                                    tenant.server.remove_keepalive_token(
+                                        (
+                                            keepalive_token,
+                                            tenant.get_instance_name(),
+                                            dbname,
+                                        )
+                                    )
                                     holding_lock = False
             except Exception:
                 logger.exception(f"caught error in {task_name}")
@@ -548,7 +556,7 @@ class ProviderScheduler(rs.Scheduler[EmbeddingsData]):
         self, context: rs.Context,
     ) -> Optional[Sequence[EmbeddingsParams]]:
         assert isinstance(context, ProviderContext)
-        return await _generate_embeddings_params(
+        rv = await _generate_embeddings_params(
             context.db,
             context.pgconn,
             context.http_client,
@@ -561,6 +569,15 @@ class ProviderScheduler(rs.Scheduler[EmbeddingsData]):
                 None
             ),
         )
+        if rv:
+            context.db.server.add_keepalive_token(
+                (
+                    keepalive_token,
+                    context.db.tenant.get_instance_name(),
+                    context.db.name,
+                )
+            )
+        return rv
 
     def finalize(self, execution_report: rs.ExecutionReport) -> None:
         task_name = _task_name.get()


### PR DESCRIPTION
The keepalive token is only added when there is actually AI indexing work to do, in order to avoid delaying the auto shutdown indefinitely. The token is only removed when the "AI lock" is released.