### PR TITLE
Add text search to ai extension

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_04_04_15_52
+EDGEDB_CATALOG_VERSION = 2025_04_07_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -580,6 +580,24 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         using sql expression;
     };
 
+    create function ext::ai::search(
+        object: anyobject,
+        query: str,
+    ) -> optional tuple<object: anyobject, distance: float64>
+    {
+        create annotation std::description := '
+            Search an object using its ext::ai::index index.
+            Gets an embedding for the query from the ai provider then
+            returns objects that match the specified semantic query and the
+            similarity score.
+        ';
+        set volatility := 'Stable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        set server_param_conversions := '{"query": ["ai_text_embedding", "object"]}';
+        using sql expression;
+    };
+
     create scalar type ext::ai::ChatParticipantRole
         extending enum<System, User, Assistant, Tool>;
 

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -479,6 +479,74 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                 delete Astronomy;
             ''')
 
+    async def test_ext_ai_indexing_06(self):
+        try:
+            await self.con.execute(
+                """
+                insert Astronomy {
+                    content := 'Skies on Venus are orange'
+                };
+                insert Astronomy {
+                    content := 'Skies on Mars are red'
+                };
+                insert Astronomy {
+                    content := 'Skies on Pluto are black and starry'
+                };
+                insert Astronomy {
+                    content := 'Skies on Earth are blue'
+                };
+                """,
+            )
+
+            async for tr in self.try_until_succeeds(
+                ignore=(AssertionError,),
+                timeout=30.0,
+            ):
+                async with tr:
+                    await self.assert_query_result(
+                        r'''
+                        with
+                            result := ext::ai::search(
+                                Astronomy, <str>$qv)
+                        select
+                            result.object {
+                                content,
+                                distance := result.distance,
+                            }
+                        order by
+                            result.distance asc empty last
+                            then result.object.content
+                        ''',
+                        [
+                            {
+                                'content': 'Skies on Earth are blue',
+                                'distance': 0.09861218113400261,
+                            },
+                            {
+                                'content': 'Skies on Venus are orange',
+                                'distance': 0.11303140601637596,
+                            },
+                            {
+                                'content': 'Skies on Mars are red',
+                                'distance': 0.14066215115268055,
+                            },
+                            {
+                                'content': (
+                                    'Skies on Pluto are black and starry'
+                                ),
+                                'distance': 0.32063377951324246,
+                            },
+                        ],
+                        variables={
+                            "qv": "Nice weather",
+                        }
+                    )
+
+        finally:
+            await self.con.execute('''
+                delete Astronomy;
+            ''')
+
     async def test_ext_ai_index_custom_dimensions(self):
         await self.assert_query_result(
             """


### PR DESCRIPTION
Followup to #8554

Implement ai text search so that users can do `ext::ai::search(Astronomy, "cool planet")`.

- Adds `"ai_text_embedding"` parameter conversion
- Adds some internal utility functions to ai_ext