### PR TITLE
Refactor sourcectx in schema to span

### DIFF
--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1519,7 +1519,7 @@ TRACER_TO_REAL_TYPE_MAP = {
 def _get_local_obj(
     refname: s_name.QualName,
     tracer_type: type[qltracer.NamedObject],
-    sourcectx: Optional[parsing.Span],
+    span: Optional[parsing.Span],
     *,
     ctx: LayoutTraceContext | DepTraceContext,
 ) -> Optional[qltracer.NamedObject]:
@@ -1530,7 +1530,7 @@ def _get_local_obj(
         raise errors.SchemaError(
             f'invalid type: {obj.get_verbosename(ctx.schema)} is a generic '
             f'type and they are not supported in user-defined schema',
-            span=sourcectx,
+            span=span,
         )
 
     elif obj is not None and not isinstance(obj, tracer_type):
@@ -1540,7 +1540,7 @@ def _get_local_obj(
             f'{str(refname)!r} exists, but is '
             f'{english.add_a(obj_type.get_schema_class_displayname())}, '
             f'not {english.add_a(real_type.get_schema_class_displayname())}',
-            span=sourcectx,
+            span=span,
         )
 
     return obj

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1635,7 +1635,7 @@ def _resolve_schema_ref(
 ) -> s_obj.SubclassableObject:
     real_type = TRACER_TO_REAL_TYPE_MAP[type]
     try:
-        return ctx.schema.get(name, type=real_type, sourcectx=span)
+        return ctx.schema.get(name, type=real_type, span=span)
     except errors.InvalidReferenceError as e:
         s_utils.enrich_schema_lookup_error(
             e,

--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -687,7 +687,7 @@ def trace_Global(
         ctx.refs.add(refname)
         tip = ctx.objects[refname]
     else:
-        tip = ctx.schema.get(refname, sourcectx=node.span)
+        tip = ctx.schema.get(refname, span=node.span)
     return tip
 
 
@@ -703,7 +703,7 @@ def check_type_exists(
 
     try:
         # Check if the typename is already in the schema
-        ctx.schema.get(typename, type=s_types.Type, sourcectx=span)
+        ctx.schema.get(typename, type=s_types.Type, span=span)
     except errors.InvalidReferenceError as e:
         if hint and not e.hint:
             e.set_hint_and_details(hint, e.details)
@@ -814,7 +814,7 @@ def trace_Path(
                     ctx.refs.add(refname)
                     tip = ctx.objects[refname]
                 else:
-                    tip = ctx.schema.get(refname, sourcectx=step.span)
+                    tip = ctx.schema.get(refname, span=step.span)
 
         elif isinstance(step, qlast.Ptr):
             pname = sn.UnqualName(step.name)
@@ -1007,7 +1007,7 @@ def _resolve_type_expr(
             obj: TypeLike
             if local_obj is None:
                 obj = ctx.schema.get(
-                    refname, type=s_types.Type, sourcectx=texpr.span)
+                    refname, type=s_types.Type, span=texpr.span)
             else:
                 assert isinstance(local_obj, Type)
                 obj = local_obj

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -326,8 +326,7 @@ def _compile_schema(
     try:
         schema, _warnings = s_ddl.apply_sdl(
             sdl,
-            base_schema=std_schema,
-            current_schema=std_schema,
+            base_schema=std_schema
         )
         ls.show_message_log('.. done')
     except errors.EdgeDBError as error:

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -739,7 +739,7 @@ class ConstraintCommand(
         name: sn.QualName,
         subjectexpr: Optional[s_expr.Expression] = None,
         subjectexpr_inherited: bool = False,
-        sourcectx: Optional[c_parsing.Span] = None,
+        span: Optional[c_parsing.Span] = None,
         args: Optional[Iterable[s_expr.Expression]] = None,
         **kwargs: Any
     ) -> None:
@@ -777,7 +777,7 @@ class ConstraintCommand(
                 and subjectexpr.text != base_subjectexpr.text):
                 raise errors.InvalidConstraintDefinitionError(
                     f'subjectexpr is already defined for {name}',
-                    span=sourcectx,
+                    span=span,
                 )
 
             base_subjectexpr = constr_base.get_subjectexpr(schema)
@@ -790,7 +790,7 @@ class ConstraintCommand(
             raise errors.InvalidConstraintDefinitionError(
                 f'{constr_base.get_verbosename(schema)} may not '
                 f'be used on scalar types',
-                span=sourcectx,
+                span=span,
             )
 
         if (
@@ -799,7 +799,7 @@ class ConstraintCommand(
         ):
             raise errors.InvalidConstraintDefinitionError(
                 "constraints on object types must have an 'on' clause",
-                span=sourcectx,
+                span=span,
             )
 
         expr: s_expr.Expression = constr_base.get_field_value(schema, 'expr')
@@ -860,7 +860,7 @@ class ConstraintCommand(
                 f'{name} constraint expression expected '
                 f'to return a bool value, got '
                 f'{expr_type.get_verbosename(expr_schema)}',
-                span=sourcectx
+                span=span
             )
 
         except_expr: s_expr.Expression | None = attrs.get('except_expr')
@@ -916,13 +916,13 @@ class ConstraintCommand(
                             raise errors.InvalidConstraintDefinitionError(
                                 "link constraints may not access "
                                 "the link target",
-                                span=sourcectx
+                                span=span
                             )
                         else:
                             raise errors.InvalidConstraintDefinitionError(
                                 "constraints cannot contain paths with more "
                                 "than one hop",
-                                span=sourcectx
+                                span=span
                             )
 
                     ref = rptr.source
@@ -931,7 +931,7 @@ class ConstraintCommand(
                 raise errors.InvalidConstraintDefinitionError(
                     "cannot reference multiple links or properties in a "
                     "constraint where at least one link or property is MULTI",
-                    span=sourcectx
+                    span=span
                 )
 
             if set_of_op := ir_utils.find_set_of_op(
@@ -972,7 +972,7 @@ class ConstraintCommand(
         if final_expr.irast.volatility != qltypes.Volatility.Immutable:
             raise errors.InvalidConstraintDefinitionError(
                 f'constraint expressions must be immutable',
-                span=sourcectx,
+                span=span,
             )
 
         attrs['finalexpr'] = final_expr
@@ -1164,7 +1164,7 @@ class CreateConstraint(
                 name=shortname,
                 subjectexpr_inherited=self.is_attribute_inherited(
                     'subjectexpr'),
-                sourcectx=self.span,
+                span=self.span,
                 **props,
             )
 
@@ -1454,7 +1454,7 @@ class AlterConstraint(
                 subjectexpr=subjectexpr,
                 subjectexpr_inherited=subjectexpr_inherited,
                 args=args,
-                sourcectx=self.span,
+                span=self.span,
                 **props,
             )
 

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -454,7 +454,6 @@ def apply_sdl(
     sdl_document: qlast.Schema,
     *,
     base_schema: s_schema.Schema,
-    current_schema: s_schema.Schema,
     stdmode: bool = False,
     testmode: bool = False,
 ) -> tuple[s_schema.Schema, list[errors.EdgeDBError]]:

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -2586,7 +2586,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: so.Object_T | so.NoDefaultT = so.NoDefault,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> so.Object_T:
         ...
 
@@ -2598,7 +2598,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.Object_T]:
         ...
 
@@ -2609,7 +2609,7 @@ class ObjectCommand(Command, Generic[so.Object_T]):
         *,
         name: Optional[sn.Name] = None,
         default: so.Object_T | so.NoDefaultT | None = so.NoDefault,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.Object_T]:
         metaclass = self.get_schema_metaclass()
         if name is None:
@@ -2958,7 +2958,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         *,
         name: Optional[sn.Name] = None,
         default: so.QualifiedObject_T | so.NoDefaultT = so.NoDefault,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> so.QualifiedObject_T:
         ...
 
@@ -2970,7 +2970,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.QualifiedObject_T]:
         ...
 
@@ -2981,7 +2981,7 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
         *,
         name: Optional[sn.Name] = None,
         default: so.QualifiedObject_T | so.NoDefaultT | None = so.NoDefault,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.QualifiedObject_T]:
         if name is None:
             name = self.classname
@@ -2989,10 +2989,10 @@ class QualifiedObjectCommand(ObjectCommand[so.QualifiedObject_T]):
             if rename is not None:
                 name = rename
         metaclass = self.get_schema_metaclass()
-        if sourcectx is None:
-            sourcectx = self.span
+        if span is None:
+            span = self.span
         return schema.get(
-            name, type=metaclass, default=default, sourcectx=sourcectx)
+            name, type=metaclass, default=default, span=span)
 
 
 class GlobalObjectCommand(ObjectCommand[so.GlobalObject_T]):

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -584,7 +584,7 @@ def _create_alias_types(
         name=classname,
         origname=classname,
         schemaclass=type_cmd.get_schema_metaclass(),
-        sourcectx=span,
+        span=span,
     )
     return result, type_shell, created_type_shells
 

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -667,7 +667,7 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: Index | so.NoDefaultT = so.NoDefault,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Index:
         ...
 
@@ -679,7 +679,7 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[Index]:
         ...
 
@@ -690,12 +690,12 @@ class IndexCommand(
         *,
         name: Optional[sn.Name] = None,
         default: Index | so.NoDefaultT | None = so.NoDefault,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[Index]:
         try:
             return super().get_object(
                 schema, context, name=name,
-                default=default, sourcectx=sourcectx,
+                default=default, span=span,
             )
         except errors.InvalidReferenceError:
             referrer_ctx = self.get_referrer_context_or_die(context)

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -812,7 +812,7 @@ class CreateInheritingObject(
 
         assert isinstance(astnode, qlast.ObjectDDL)
         bases = cls._classbases_from_ast(schema, astnode, context)
-        spans = [b.sourcectx for b in bases if b.sourcectx is not None]
+        spans = [b.span for b in bases if b.span is not None]
         if spans:
             span = edb_span.merge_spans(spans)
         else:
@@ -1292,7 +1292,7 @@ class RebaseInheritingObject(
 
             bases[idx:idx] = [
                 self.get_object(
-                    schema, context, name=b.name, span=b.sourcectx)
+                    schema, context, name=b.name, span=b.span)
                 for b in new_bases if b.name not in existing_bases
             ]
             index = {b.get_name(schema): i for i, b in enumerate(bases)}

--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -1292,7 +1292,7 @@ class RebaseInheritingObject(
 
             bases[idx:idx] = [
                 self.get_object(
-                    schema, context, name=b.name, sourcectx=b.sourcectx)
+                    schema, context, name=b.name, span=b.sourcectx)
                 for b in new_bases if b.name not in existing_bases
             ]
             index = {b.get_name(schema): i for i, b in enumerate(bases)}

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2209,13 +2209,13 @@ class ObjectShell(Shell, Generic[Object_T_co]):
         schemaclass: type[Object_T_co],
         displayname: Optional[str] = None,
         origname: Optional[sn.Name] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> None:
         self.name = name
         self.origname = origname
         self.displayname = displayname
         self.schemaclass = schemaclass
-        self.sourcectx = sourcectx
+        self.span = span
 
     def get_id(self, schema: s_schema.Schema) -> uuid.UUID:
         return self.resolve(schema).get_id(schema)
@@ -2228,7 +2228,7 @@ class ObjectShell(Shell, Generic[Object_T_co]):
 
         if isinstance(self.name, sn.QualName):
             return schema.get(
-                self.name, type=self.schemaclass, span=self.sourcectx,
+                self.name, type=self.schemaclass, span=self.span,
             )
         else:
             return schema.get_global(self.schemaclass, self.name)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -2228,7 +2228,7 @@ class ObjectShell(Shell, Generic[Object_T_co]):
 
         if isinstance(self.name, sn.QualName):
             return schema.get(
-                self.name, type=self.schemaclass, sourcectx=self.sourcectx,
+                self.name, type=self.schemaclass, span=self.sourcectx,
             )
         else:
             return schema.get_global(self.schemaclass, self.name)

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1025,16 +1025,6 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         inheritable=False,
     )
 
-    # Schema source context for this object
-    sourcectx = SchemaField(
-        parsing.Span,
-        default=None,
-        compcoef=None,
-        inheritable=False,
-        hashable=False,
-        ephemeral=True,
-    )
-
     name = SchemaField(
         sn.Name,
         inheritable=False,

--- a/edb/schema/pseudo.py
+++ b/edb/schema/pseudo.py
@@ -153,10 +153,11 @@ class PseudoTypeShell(s_types.TypeShell[PseudoType]):
         self,
         *,
         name: sn.Name,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> None:
         super().__init__(
-            name=name, schemaclass=PseudoType, sourcectx=sourcectx)
+            name=name, schemaclass=PseudoType, span=span
+        )
 
     def is_polymorphic(self, schema: s_schema.Schema) -> bool:
         return True

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -204,7 +204,7 @@ class AlterRole(RoleCommand, inheriting.AlterInheritingObject[Role]):
         *,
         name: Optional[sn.Name] = None,
         default: Role | so.NoDefaultT = so.NoDefault,
-        sourcectx: Optional[qlast.Span] = None,
+        span: Optional[qlast.Span] = None,
     ) -> Role:
         ...
 
@@ -216,7 +216,7 @@ class AlterRole(RoleCommand, inheriting.AlterInheritingObject[Role]):
         *,
         name: Optional[sn.Name] = None,
         default: None = None,
-        sourcectx: Optional[qlast.Span] = None,
+        span: Optional[qlast.Span] = None,
     ) -> Optional[Role]:
         ...
 
@@ -227,7 +227,7 @@ class AlterRole(RoleCommand, inheriting.AlterInheritingObject[Role]):
         *,
         name: Optional[sn.Name] = None,
         default: Role | so.NoDefaultT | None = so.NoDefault,
-        sourcectx: Optional[qlast.Span] = None,
+        span: Optional[qlast.Span] = None,
     ) -> Optional[Role]:
         # On an ALTER ROLE edgedb, if 'edgedb' doesn't exist, fall
         # back to 'admin'. This mirrors what we do for login and
@@ -237,7 +237,7 @@ class AlterRole(RoleCommand, inheriting.AlterInheritingObject[Role]):
                 return super().get_object(
                     schema,
                     context,
-                    sourcectx=sourcectx,
+                    span=span,
                 )
             except errors.InvalidReferenceError:
                 name = sn.UnqualName('admin')
@@ -247,7 +247,7 @@ class AlterRole(RoleCommand, inheriting.AlterInheritingObject[Role]):
             context,
             name=name,
             default=default,
-            sourcectx=sourcectx,
+            span=span,
         )
 
     @classmethod

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -361,7 +361,7 @@ class Schema(abc.ABC):
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> so.Object:
         ...
 
@@ -374,7 +374,7 @@ class Schema(abc.ABC):
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.Object]:
         ...
 
@@ -388,7 +388,7 @@ class Schema(abc.ABC):
         type: type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> so.Object_T:
         ...
 
@@ -402,7 +402,7 @@ class Schema(abc.ABC):
         type: type[so.Object_T],
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.Object_T]:
         ...
 
@@ -416,7 +416,7 @@ class Schema(abc.ABC):
         type: Optional[type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.Object]:
         ...
 
@@ -429,7 +429,7 @@ class Schema(abc.ABC):
         type: Optional[type[so.Object_T]] = None,
         condition: Optional[Callable[[so.Object], bool]] = None,
         label: Optional[str] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> Optional[so.Object]:
         return self._get(
             name,
@@ -438,7 +438,7 @@ class Schema(abc.ABC):
             type=type,
             condition=condition,
             label=label,
-            sourcectx=sourcectx,
+            span=span,
         )
 
     @abc.abstractmethod
@@ -451,7 +451,7 @@ class Schema(abc.ABC):
         type: Optional[type[so.Object_T]],
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
-        sourcectx: Optional[parsing.Span],
+        span: Optional[parsing.Span],
         disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
         raise NotImplementedError
@@ -1389,7 +1389,7 @@ class FlatSchema(Schema):
         type: Optional[type[so.Object_T]],
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
-        sourcectx: Optional[parsing.Span],
+        span: Optional[parsing.Span],
         disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
         def getter(schema: FlatSchema, name: sn.Name) -> Optional[so.Object]:
@@ -1421,7 +1421,7 @@ class FlatSchema(Schema):
                 raise errors.InvalidReferenceError(
                     f'{refname!r} exists, but is {english.add_a(got_name)}, '
                     f'not {english.add_a(exp_name)}',
-                    span=sourcectx,
+                    span=span,
                 )
 
             return obj  # type: ignore
@@ -1430,7 +1430,7 @@ class FlatSchema(Schema):
                 name=name,
                 label=label,
                 module_aliases=module_aliases,
-                sourcectx=sourcectx,
+                span=span,
                 type=type,
             )
 
@@ -1440,7 +1440,7 @@ class FlatSchema(Schema):
         *,
         label: Optional[str] = None,
         module_aliases: Optional[Mapping[Optional[str], str]] = None,
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
         type: Optional[type[so.Object]] = None,
     ) -> NoReturn:
         refname = str(name)
@@ -1469,7 +1469,7 @@ class FlatSchema(Schema):
 
         raise errors.InvalidReferenceError(
             f'{label} {refname!r} does not exist',
-            span=sourcectx,
+            span=span,
         )
 
     def has_object(self, object_id: uuid.UUID) -> bool:
@@ -2073,7 +2073,7 @@ class ChainedSchema(Schema):
         type: Optional[type[so.Object_T]],
         condition: Optional[Callable[[so.Object], bool]],
         label: Optional[str],
-        sourcectx: Optional[parsing.Span],
+        span: Optional[parsing.Span],
         disallow_module: Optional[Callable[[str], bool]] = None,
     ) -> Optional[so.Object]:
         obj = self._top_schema._get(
@@ -2083,7 +2083,7 @@ class ChainedSchema(Schema):
             default=None,
             condition=condition,
             label=label,
-            sourcectx=sourcectx,
+            span=span,
             disallow_module=disallow_module,
         )
         if obj is None:
@@ -2100,7 +2100,7 @@ class ChainedSchema(Schema):
                 type=type,
                 condition=condition,
                 label=label,
-                sourcectx=sourcectx,
+                span=span,
                 disallow_module=disallow_module,
             )
         else:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -603,7 +603,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         displayname: Optional[str] = None,
         expr: Optional[str] = None,
         schemaclass: type[TypeT_co],
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
         extra_args: tuple[qlast.Expr] | None = None,
     ) -> None:
         super().__init__(
@@ -611,7 +611,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
             origname=origname,
             displayname=displayname,
             schemaclass=schemaclass,
-            sourcectx=sourcectx,
+            span=span,
         )
 
         self.expr = expr
@@ -631,7 +631,7 @@ class TypeShell(so.ObjectShell[TypeT_co]):
             f'unsupported type intersection in schema {str(view_name)}',
             hint=f'Type intersections are currently '
                  f'unsupported as valid link targets.',
-            span=self.sourcectx,
+            span=self.span,
         )
 
 
@@ -645,12 +645,12 @@ class TypeExprShell(TypeShell[TypeT_co]):
         name: s_name.Name,
         components: Iterable[TypeShell[TypeT_co]],
         schemaclass: type[TypeT_co],
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> None:
         super().__init__(
             name=name,
             schemaclass=schemaclass,
-            sourcectx=sourcectx,
+            span=span,
         )
         self.components = tuple(components)
 
@@ -676,7 +676,7 @@ class UnionTypeShell(TypeExprShell[TypeT_co]):
         components: Iterable[TypeShell[TypeT_co]],
         opaque: bool = False,
         schemaclass: type[TypeT_co],
-        sourcectx: Optional[parsing.Span] = None,
+        span: Optional[parsing.Span] = None,
     ) -> None:
         name = get_union_type_name(
             (c.name for c in components),
@@ -687,7 +687,7 @@ class UnionTypeShell(TypeExprShell[TypeT_co]):
             name=name,
             components=components,
             schemaclass=schemaclass,
-            sourcectx=sourcectx,
+            span=span,
         )
         self.opaque = opaque
 
@@ -703,7 +703,7 @@ class UnionTypeShell(TypeExprShell[TypeT_co]):
         cmd.set_attribute_value('name', self.name)
         cmd.set_attribute_value('components', tuple(self.components))
         cmd.set_attribute_value('is_opaque_union', self.opaque)
-        cmd.set_attribute_value('span', self.sourcectx)
+        cmd.set_attribute_value('span', self.span)
         return cmd
 
     def __repr__(self) -> str:
@@ -933,7 +933,7 @@ class IntersectionTypeShell(TypeExprShell[TypeT_co]):
         module: str,
         components: Iterable[TypeShell[TypeT_co]],
         schemaclass: type[TypeT_co],
-        sourcectx: parsing.Span | None = None,
+        span: parsing.Span | None = None,
     ) -> None:
         name = get_intersection_type_name(
             (c.name for c in components),
@@ -944,7 +944,7 @@ class IntersectionTypeShell(TypeExprShell[TypeT_co]):
             name=name,
             components=components,
             schemaclass=schemaclass,
-            sourcectx=sourcectx
+            span=span
         )
 
 
@@ -3036,7 +3036,7 @@ class InheritingTypeCommand(
                 shell = shells.get(base.get_name(schema))
                 raise errors.SchemaError(
                     f"{base_type_name!r} cannot be a parent type",
-                    span=shell.sourcectx if shell is not None else None,
+                    span=shell.span if shell is not None else None,
                 )
 
 

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -87,7 +87,7 @@ def resolve_name(
     lname: sn.Name,
     *,
     metaclass: Optional[type[so.Object]] = None,
-    sourcectx: Optional[parsing.Span] = None,
+    span: Optional[parsing.Span] = None,
     modaliases: Mapping[Optional[str], str],
     schema: s_schema.Schema,
 ) -> sn.Name:
@@ -96,7 +96,7 @@ def resolve_name(
         type=metaclass,
         module_aliases=modaliases,
         default=None,
-        sourcectx=sourcectx,
+        span=span,
     )
     if obj is not None:
         name = obj.get_name(schema)
@@ -132,7 +132,7 @@ def ast_objref_to_object_shell(
         metaclass=metaclass,
         modaliases=modaliases,
         schema=schema,
-        sourcectx=ref.span,
+        span=ref.span,
     )
 
     return so.ObjectShell(
@@ -163,7 +163,7 @@ def ast_objref_to_type_shell(
         metaclass=mcls,
         modaliases=modaliases,
         schema=schema,
-        sourcectx=ref.span,
+        span=ref.span,
     )
 
     return s_types.TypeShell(

--- a/edb/schema/utils.py
+++ b/edb/schema/utils.py
@@ -139,7 +139,7 @@ def ast_objref_to_object_shell(
         name=name,
         origname=lname,
         schemaclass=metaclass,
-        sourcectx=ref.span,
+        span=ref.span,
     )
 
 
@@ -170,7 +170,7 @@ def ast_objref_to_type_shell(
         name=name,
         origname=lname,
         schemaclass=mcls,
-        sourcectx=ref.span,
+        span=ref.span,
     )
 
 
@@ -384,7 +384,7 @@ def ast_to_type_shell(
         from . import pseudo as s_pseudo
         return s_pseudo.PseudoTypeShell(
             name=sn.UnqualName(node.maintype.name),
-            sourcectx=node.maintype.span,
+            span=node.maintype.span,
         )  # type: ignore
 
     assert isinstance(node.maintype, qlast.ObjectRef)
@@ -444,14 +444,14 @@ def type_op_ast_to_type_shell(
                 components=left.components + right.components,
                 module=module,
                 schemaclass=metaclass,
-                sourcectx=node.span,
+                span=node.span,
             )
         else:
             return s_types.UnionTypeShell(
                 components=left.components + (right,),
                 module=module,
                 schemaclass=metaclass,
-                sourcectx=node.span,
+                span=node.span,
             )
     else:
         if isinstance(right, s_types.UnionTypeShell):
@@ -459,14 +459,14 @@ def type_op_ast_to_type_shell(
                 components=(left,) + right.components,
                 schemaclass=metaclass,
                 module=module,
-                sourcectx=node.span,
+                span=node.span,
             )
         else:
             return s_types.UnionTypeShell(
                 components=(left, right),
                 module=module,
                 schemaclass=metaclass,
-                sourcectx=node.span,
+                span=node.span,
             )
 
 

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -528,7 +528,6 @@ def _start_migration(
         target_schema, warnings = s_ddl.apply_sdl(
             ql.target,
             base_schema=base_schema,
-            current_schema=schema,
             testmode=ctx.is_testmode(),
         )
         query = dataclasses.replace(query, warnings=tuple(warnings))
@@ -1029,7 +1028,6 @@ def _start_migration_rewrite(
             ]
         ),
         base_schema=base_schema,
-        current_schema=base_schema,
     )
 
     # Set our current schema to be the empty one
@@ -1178,7 +1176,6 @@ def _reset_schema(
             ]
         ),
         base_schema=empty_schema,
-        current_schema=empty_schema,
     )
 
     # diff and create migration that drops all objects

--- a/edb/testbase/lang.py
+++ b/edb/testbase/lang.py
@@ -316,7 +316,6 @@ class BaseSchemaTest(BaseDocTest):
                 migration_target, _ = s_ddl.apply_sdl(
                     stmt.target,
                     base_schema=target_schema,
-                    current_schema=current_schema,
                     testmode=True,
                 )
 
@@ -447,7 +446,6 @@ class BaseSchemaTest(BaseDocTest):
         return s_ddl.apply_sdl(
             sdl_schema,
             base_schema=schema,
-            current_schema=schema,
         )[0]
 
     @classmethod

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10099,7 +10099,6 @@ class BaseDescribeTest(tb.BaseSchemaLoadTest):
             schema, _ = s_ddl.apply_sdl(
                 sdl_schema,
                 base_schema=schema,
-                current_schema=schema,
             )
         else:
             schema = self.load_schema(schema_text, modname=default_module)
@@ -12206,7 +12205,6 @@ class TestSDLTextFromSchema(BaseDescribeTest):
             schema, _ = s_ddl.apply_sdl(
                 sdl_schema,
                 base_schema=schema,
-                current_schema=schema,
             )
         else:
             schema = self.load_schema(schema_text, modname=default_module)


### PR DESCRIPTION
Extracted from #8513. I suggest review commit by commit.

Renames sourcectx to span in schema:
- **rename sourcectx to span in schema**
- **rename sourcectx to span in type shells**
- **remove Object.sourcectx (since it was empheral anyway)**
- **rename one last `sourcectx` in declarative.py**

Also:
- **remove unnecessary apply_sdl arg**

