### PR TITLE
Tweak how we set IR source spans

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -33,6 +33,7 @@ import textwrap
 
 from edb import errors
 from edb.common import ast
+from edb.common import span as edb_span
 from edb.common.typeutils import not_none
 
 from edb.ir import ast as irast

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -30,6 +30,7 @@ from typing import (
 
 from collections import defaultdict
 import textwrap
+import itertools
 
 from edb import errors
 from edb.common import ast
@@ -1583,6 +1584,15 @@ def compile_query_subject(
 
     if (shape is not None or view_scls is not None) and len(set.path_id) == 1:
         ctx.class_view_overrides[set.path_id.target.id] = set_stype
+
+    if shape:
+        # make sure that an applied shape expands the span of the set
+        set.span = edb_span.merge_spans(
+            itertools.chain(
+                (s.span for s in [set] if s.span),
+                (el.span for el in shape if el.span)
+            )
+        )
 
     return set
 

--- a/tests/test_edgeql_explain.py
+++ b/tests/test_edgeql_explain.py
@@ -72,7 +72,12 @@ class TestEdgeQLExplain(tb.QueryTestCase):
         ''')
         self.assert_plan(res['fine_grained'], {
             "contexts": [
-                {"buffer_idx": 0, "end": 32, "start": 28, "text": "User"}
+                {
+                    "buffer_idx": 0,
+                    "start": 28,
+                    "end": 43,
+                    "text": "User { id, name"
+                }
             ],
             "pipeline": [
                 {
@@ -356,9 +361,9 @@ class TestEdgeQLExplain(tb.QueryTestCase):
             "contexts": [
                 {
                     "start": 28,
-                    "end": 32,
+                    "end": 60,
                     "buffer_idx": 0,
-                    "text": "User",
+                    "text": "User { name, todo: {name, number",
                 },
             ],
             "pipeline": [
@@ -413,9 +418,9 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "contexts": [
                         {
                             "start": 41,
-                            "end": 45,
+                            "end": 60,
                             "buffer_idx": 0,
-                            "text": "todo",
+                            "text": "todo: {name, number",
                         },
                     ],
                     "pipeline": tb.bag([
@@ -606,9 +611,9 @@ class TestEdgeQLExplain(tb.QueryTestCase):
         shape = {
             "contexts": [{
                 "start": 28,
-                "end": 32,
+                "end": 68,
                 "buffer_idx": 0,
-                "text": "User"
+                "text": "User { name, owned_issues: {name, number"
             }],
             "pipeline": [{
                 "plan_rows": 1,
@@ -663,9 +668,9 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "text": '.<owner[is default::Issue]'
                 }, {
                     "start": 41,
-                    "end": 53,
+                    "end": 68,
                     "buffer_idx": 0,
-                    "text": "owned_issues"
+                    "text": "owned_issues: {name, number"
                 }]),
                 "pipeline": tb.bag([
                     {
@@ -1020,9 +1025,13 @@ class TestEdgeQLExplain(tb.QueryTestCase):
                     "contexts": [
                         {
                             "start": 28,
-                            "end": 32,
+                            "end": 93,
                             "buffer_idx": 0,
-                            "text": 'Text',
+                            'text': (
+                                'Text {\n'
+                                '                body,\n'
+                                '                z := [is Issue].name'
+                            )
                         },
                     ],
                     "pipeline": [


### PR DESCRIPTION
Extracted from #8513.

This is needed for language server, which looks at compiled IR to determine what's the type under the cursor.

For that to work, we need search IR for a given cursor position. For that to work, IR nodes should have the span that contains all spans of its children. This was not the case, so I've made the following changes:

- in `select Player { name }`, the resulting IR was changed:
  ```diff
    Set:
  -   span: 7..13
  +   span: 0..20
      expr: Path:
        span: 7..13
      elements: [ ... ]
  ```

- in `select Player { name }`, I've removed the span of injected `id` pointer
  ```diff
    Set:
      span: 0..20
      elements: [
         Ptr:
           name: id
  -        span: 0..20
  +        span: None
         ...
      ]
  ```

- in `select Player { name }`, I've changed the span of `name` from the span of the whole shape to just the span of `name` pointer
  ```diff
    Set:
      span: 0..20
      elements: [
         Ptr:
           name: id
         Ptr:
           name: name
  -        span: 0..20
  +        span: 16..20
         ...
      ]
  ```

---

On paper, these changes make sense, but our explain code will probably disagree. 
