### PR TITLE
Improve ast span markup

### DIFF
--- a/edb/common/ast/base.py
+++ b/edb/common/ast/base.py
@@ -332,6 +332,11 @@ def serialize_to_markup(ast, *, ctx):
     include_meta = ctx.kwargs.get('_ast_include_meta', True)
     exclude_unset = ctx.kwargs.get('_ast_exclude_unset', True)
 
+    if debug.flags.ast_span:
+        s = getattr(ast, 'span', None)
+        if s:
+            node.add_child(label='span', node=markup.serialize(str(s), ctx=ctx))
+
     fields = iter_fields(
         ast, include_meta=include_meta, exclude_unset=exclude_unset)
     for fieldname, field in fields:

--- a/edb/common/debug.py
+++ b/edb/common/debug.py
@@ -183,6 +183,8 @@ class flags(metaclass=FlagsMeta):
 
     zombodb = Flag(doc="Enabled zombodb and disables postgres FTS")
 
+    ast_span = Flag(doc="Enables spans in markup of ASTs")
+
 
 @contextlib.contextmanager
 def timeit(title='block'):

--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -83,6 +83,11 @@ class Span(markup.MarkupExceptionContext):
             end=0,
         )
 
+    def __str__(self):
+        if self.filename:
+            return f'{self.filename}:{self.start}..{self.end}'
+        return f'{self.start}..{self.end}'
+
     def __getstate__(self):
         dic = self.__dict__.copy()
         dic['_points'] = None

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import typing
 
 from edb.common import enum as s_enum
-from edb.common import ast, span, markup
+from edb.common import ast, span
 
 from . import qltypes
 
@@ -97,19 +97,6 @@ class Base(ast.AST):
         from edb.common.debug import dump_edgeql
 
         dump_edgeql(self)
-
-
-@markup.serializer.serializer.register(Base)
-def _serialize_to_markup_base(base: Base, *, ctx: typing.Any) -> typing.Any:
-    node = ast.serialize_to_markup(base, ctx=ctx)
-
-    if not base.span:
-        return node
-
-    node.add_child(label='span', node=markup.serialize(str(base.span), ctx=ctx))
-    child = node.children.pop()
-    node.children.insert(1, child)
-    return node
 
 
 class GrammarEntryPoint(Base):

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import typing
 
 from edb.common import enum as s_enum
-from edb.common import ast, span
+from edb.common import ast, span, markup
 
 from . import qltypes
 
@@ -97,6 +97,19 @@ class Base(ast.AST):
         from edb.common.debug import dump_edgeql
 
         dump_edgeql(self)
+
+
+@markup.serializer.serializer.register(Base)
+def _serialize_to_markup_base(base: Base, *, ctx: typing.Any) -> typing.Any:
+    node = ast.serialize_to_markup(base, ctx=ctx)
+
+    if not base.span:
+        return node
+
+    node.add_child(label='span', node=markup.serialize(str(base.span), ctx=ctx))
+    child = node.children.pop()
+    node.children.insert(1, child)
+    return node
 
 
 class GrammarEntryPoint(Base):

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -278,7 +278,8 @@ def compile_Constant(
         ctx.env.get_schema_type_and_track(std_type),
         env=ctx.env,
     )
-    return setgen.ensure_set(node_cls(value=value, typeref=ct), ctx=ctx)
+    ir_expr = node_cls(value=value, typeref=ct, span=expr.span)
+    return setgen.ensure_set(ir_expr, ctx=ctx)
 
 
 @dispatch.compile.register(qlast.BytesConstant)

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1178,6 +1178,8 @@ def init_stmt(
 
     ctx.env.compiled_stmts[qlstmt] = irstmt
 
+    irstmt.span = qlstmt.span
+
     if isinstance(irstmt, irast.MutatingStmt):
         # This is some kind of mutation, so we need to check if it is
         # allowed.

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -108,19 +108,6 @@ class Base(ast.AST):
         )
 
 
-@markup.serializer.serializer.register(Base)
-def _serialize_to_markup_base(base: Base, *, ctx: typing.Any) -> typing.Any:
-    node = ast.serialize_to_markup(base, ctx=ctx)
-
-    if not base.span:
-        return node
-
-    node.add_child(label='span', node=markup.serialize(str(base.span), ctx=ctx))
-    child = node.children.pop()
-    node.children.insert(1, child)
-    return node
-
-
 class ImmutableBase(ast.ImmutableASTMixin, Base):
     __abstract_node__ = True
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -108,13 +108,14 @@ class Base(ast.AST):
         )
 
 
-# DEBUG: Probably don't actually keep this forever?
 @markup.serializer.serializer.register(Base)
-def _serialize_to_markup_base(ir: Base, *, ctx: typing.Any) -> typing.Any:
-    node = ast.serialize_to_markup(ir, ctx=ctx)
-    has_span = bool(ir.span)
-    node.add_child(
-        label='has_span', node=markup.serialize(has_span, ctx=ctx))
+def _serialize_to_markup_base(base: Base, *, ctx: typing.Any) -> typing.Any:
+    node = ast.serialize_to_markup(base, ctx=ctx)
+
+    if not base.span:
+        return node
+
+    node.add_child(label='span', node=markup.serialize(str(base.span), ctx=ctx))
     child = node.children.pop()
     node.children.insert(1, child)
     return node


### PR DESCRIPTION
This PR makes it so markup of ql and ir ASTs contains a simple `filename:start..end`.

Markup of span is a fully rendered source code, with the span characters underlined and arrows and such. We didn't emit that in AST markup, because it is too large.