### PR TITLE
Cleanup Span name and filename

### DIFF
--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -33,7 +33,7 @@ contexts through the AST structure.
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Optional
 import re
 import bisect
 
@@ -54,30 +54,28 @@ class Span(markup.MarkupExceptionContext):
 
     def __init__(
         self,
-        name,
-        buffer,
+        filename: Optional[str],
+        buffer: str,
         start: int,
         end: int,
-        document=None,
         *,
-        filename=None,
         context_lines=1,
     ):
-        self.name = name
+        assert start is not None
+        assert end is not None
+
+        self.filename = filename
         self.buffer = buffer
         self.start = start
         self.end = end
-        self.document = document
-        self.filename = filename
         self.context_lines = context_lines
+
         self._points = None
-        assert start is not None
-        assert end is not None
 
     @classmethod
     def empty(cls) -> Span:
         return Span(
-            name='<empty>',
+            filename=None,
             buffer='',
             start=0,
             end=0,
@@ -154,7 +152,7 @@ class Span(markup.MarkupExceptionContext):
         return me.lang.ExceptionContext(title=self.title, body=[tbp])
 
 
-def _get_span(items, *, reverse=False):
+def _get_span(items, *, reverse=False) -> Optional[Span]:
     ctx = None
 
     items = reversed(items) if reverse else items
@@ -177,11 +175,11 @@ def get_span(*kids: list[ast.AST]):
     start_ctx = _get_span(kids)
     end_ctx = _get_span(kids, reverse=True)
 
-    if not start_ctx:
+    if not start_ctx or not end_ctx:
         return None
 
     return Span(
-        name=start_ctx.name,
+        filename=start_ctx.filename,
         buffer=start_ctx.buffer,
         start=start_ctx.start,
         end=end_ctx.end,
@@ -198,7 +196,7 @@ def merge_spans(spans: Iterable[Span]) -> Span | None:
     # assume same name and buffer apply to all
     #
     return Span(
-        name=span_list[0].name,
+        filename=span_list[0].filename,
         buffer=span_list[0].buffer,
         start=span_list[0].start,
         end=span_list[-1].end,

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -203,7 +203,7 @@ def _cst_to_ast(
             if terminal := node.terminal:
                 # Terminal is simple: just convert to parsing.Token
                 span = parsing.Span(
-                    name=filename,
+                    filename=filename,
                     buffer=source.text(),
                     start=terminal.start,
                     end=terminal.end,

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -195,8 +195,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         self._attrs[FIELD_LINE_END] = str(end.line)
         self._attrs[FIELD_COLUMN_END] = str(end.column)
         self._attrs[FIELD_UTF16_COLUMN_END] = str(end.utf16column)
-        if span.name and span.name != '<string>':
-            self._attrs[FIELD_FILENAME] = span.name
+        if span.filename and span.filename != '<string>':
+            self._attrs[FIELD_FILENAME] = span.filename
 
     def set_position(
         self,

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -197,7 +197,7 @@ def get_span_as_json(
             # TODO(tailhook) should we add offset, utf16column here?
             'line': expr.span.start_point.line,
             'column': expr.span.start_point.column,
-            'name': expr.span.name,
+            'name': expr.span.filename,
             'code': exctype.get_code(),
         })
 

--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -8976,10 +8976,11 @@ async def execute_sql_script(
         elif pl_func_line:
             point = ql_parser.offset_of_line(sql_text, pl_func_line)
             text = sql_text
+        assert text
 
         if point is not None:
             span = qlast.Span(
-                'query', text, start=point, end=point, context_lines=30
+                None, text, start=point, end=point, context_lines=30
             )
             exceptions.replace_context(e, span)
 

--- a/edb/pgsql/parser/ast_builder.py
+++ b/edb/pgsql/parser/ast_builder.py
@@ -217,7 +217,7 @@ def _build_span(n: Node, c: Context) -> Optional[Span]:
         return None
 
     return Span(
-        name="<string>",
+        filename=None,
         buffer=c.source_sql,
         start=n["location"],
         end=n["location"],

--- a/edb/server/compiler/explain/ir_analyze.py
+++ b/edb/server/compiler/explain/ir_analyze.py
@@ -70,7 +70,7 @@ class ShapeInfo(to_json.ToJson):
 @dataclasses.dataclass
 class AnalysisInfo(to_json.ToJson):
     alias_info: dict[str, AliasInfo]
-    buffers: list[tuple[str, str]]
+    buffers: list[str]
     shape_tree: ShapeInfo
 
 
@@ -131,12 +131,12 @@ def analyze_queries(
     debug_spew = debug.flags.edgeql_explain
 
     assert ql.span
-    contexts = {(ql.span.buffer, ql.span.name): 0}
+    contexts = {(ql.span.buffer, ql.span.filename): 0}
 
     def get_context(node: irast.Set) -> ContextDesc:
         assert node.span, node
         span = node.span
-        key = span.buffer, span.name
+        key = span.buffer, span.filename
         if (idx := contexts.get(key)) is None:
             idx = len(contexts)
             contexts[key] = idx
@@ -237,6 +237,6 @@ def analyze_queries(
 
     return AnalysisInfo(
         alias_info=alias_info,
-        buffers=[text for text, _id in contexts.keys()],
+        buffers=[text for text, _filename in contexts.keys()],
         shape_tree=shape_tree,
     )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2221,7 +2221,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         asdf = obj.getptr(schema, s_name.UnqualName('asdf'))
         expr_ast = asdf.get_expr(schema).parse()
         self.assertEqual(
-            expr_ast.span.name,
+            expr_ast.span.filename,
             f'<{asdf.id} expr>'
         )
 
@@ -2233,7 +2233,7 @@ class TestSchema(tb.BaseSchemaLoadTest):
         x = obj.getptr(schema, s_name.UnqualName('x'))
         default_ast = x.get_default(schema).parse()
         self.assertEqual(
-            default_ast.span.name,
+            default_ast.span.filename,
             f'<{x.id} default>'
         )
 


### PR DESCRIPTION
Our `Span` contained following fields: name, filename, document, buffer.

- `document` was never used and never set, so I removed it,
- `name` and `filename` were both used as "the name of the buffer that contains this span", so I consolidated them both to `filename`,
- `buffer` names sense, but I added type annotation that caused mypy to complain about it somewhere else,
- for ad-hoc queries, we were setting filename to `<string>` or `<empty>`, which seemed hacky. Especially, because we were later checking if filename is `<string>` so we would not pass that to clients. So I've removed that and now it is `None` not things that do not come from files.