### PR TITLE
pg_ext: information_schema.columns.ordinal_position should be int

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -6568,10 +6568,10 @@ def _generate_sql_information_schema(
             vt_table_schema::{sql_ident} AS table_schema,
             vt_table_name::{sql_ident} AS table_name,
             v_column_name::{sql_ident} as column_name,
-            ROW_NUMBER() OVER (
+            cast(ROW_NUMBER() OVER (
                 PARTITION BY vt_table_schema, vt_table_name
                 ORDER BY position, v_column_name
-            ) AS ordinal_position,
+            ) AS INT) AS ordinal_position,
             column_default,
             is_nullable,
             data_type,

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1437,6 +1437,28 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             ],
         )
 
+    async def test_sql_query_introspection_06(self):
+        res = await self.squery_values(
+            '''
+            SELECT column_name, col_description(
+                'public.novel'::regclass::oid, ordinal_position)
+            FROM information_schema.columns
+            WHERE table_schema = 'public' AND table_name = 'novel'
+            ORDER BY ordinal_position
+            '''
+        )
+        self.assertEqual(
+            res,
+            [
+                ['id', '__::pages'],
+                ['__type__', '__::id'],
+                ['foo', '__::title'],
+                ['genre_id', '__::genre'],
+                ['pages', '__::foo'],
+                ['title', None],
+            ]
+        )
+
     async def test_sql_query_schemas_01(self):
         await self.scon.fetch('SELECT id FROM "inventory"."Item";')
         await self.scon.fetch('SELECT id FROM "public"."Person";')


### PR DESCRIPTION
`ROW_NUMBER()` used here was returning bigint, which was found wrong when used as a parameter of `col_description()`.

Refs #8508 