### PR TITLE
Add server side parameter conversions

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -351,6 +351,8 @@ def compile_ast_fragment_to_ir(
         views={},
         params=[],
         globals=[],
+        server_param_conversions=[],
+        server_param_conversion_params=[],
         # These values are nonsensical, but ideally the caller does not care
         cardinality=qltypes.Cardinality.UNKNOWN,
         multiplicity=qltypes.Multiplicity.EMPTY,

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 from typing import (
+    Any,
     Callable,
     Literal,
     Optional,
@@ -141,6 +142,9 @@ class ServerParamConversion:
     ir_param: irast.Param
     additional_info: tuple[str, ...]
 
+    # If the parameter is a constant value, pass to directly to the server.
+    constant_value: Optional[Any] = None
+
 
 class Environment:
     """Compilation environment."""
@@ -183,6 +187,9 @@ class Environment:
 
     Used by ext::ai:search to get embeddings from text before running a query.
     """
+
+    server_param_conversion_calls: list[tuple[str, Optional[parsing.Span]]]
+    """Used to generate errors related to server param conversions."""
 
     set_types: dict[irast.Set, s_types.Type]
     """A dictionary of all Set instances and their schema types."""
@@ -321,6 +328,7 @@ class Environment:
         self.query_parameters = {}
         self.query_globals = {}
         self.server_param_conversions = {}
+        self.server_param_conversion_calls = []
         self.set_types = {}
         self.type_origins = {}
         self.inferred_volatility = {}

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -142,6 +142,8 @@ class ServerParamConversion:
     ir_param: irast.Param
     additional_info: tuple[str, ...]
 
+    volatility: qltypes.Volatility
+
     # If the parameter is a constant value, pass to directly to the server.
     constant_value: Optional[Any] = None
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -135,6 +135,13 @@ InferredVolatility = (
 )
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ServerParamConversion:
+    path_id: irast.PathId
+    ir_param: irast.Param
+    additional_info: tuple[str, ...]
+
+
 class Environment:
     """Compilation environment."""
 
@@ -166,7 +173,7 @@ class Environment:
 
     server_param_conversions: dict[
         str,
-        dict[str, tuple[irast.PathId, irast.Param, list[str]]],
+        dict[str, ServerParamConversion],
     ]
     """A mapping of query parameters and the server param conversions which are
     needed by the query.

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -164,6 +164,19 @@ class Environment:
     """A mapping of query globals.  Gets populated during
     the compilation."""
 
+    server_param_conversions: dict[
+        str,
+        dict[str, tuple[irast.PathId, irast.Param, list[str]]],
+    ]
+    """A mapping of query parameters and the server param conversions which are
+    needed by the query.
+
+    This is indicates that the server will compute and provide an additional
+    parameter based on a user provided parameter.
+
+    Used by ext::ai:search to get embeddings from text before running a query.
+    """
+
     set_types: dict[irast.Set, s_types.Type]
     """A dictionary of all Set instances and their schema types."""
 
@@ -300,6 +313,7 @@ class Environment:
         self.schema_view_cache = {}
         self.query_parameters = {}
         self.query_globals = {}
+        self.server_param_conversions = {}
         self.set_types = {}
         self.type_origins = {}
         self.inferred_volatility = {}

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -184,7 +184,7 @@ class Environment:
     """A mapping of query parameters and the server param conversions which are
     needed by the query.
 
-    This is indicates that the server will compute and provide an additional
+    This indicates that the server will compute and provide an additional
     parameter based on a user provided parameter.
 
     Used by ext::ai:search to get embeddings from text before running a query.

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -353,6 +353,22 @@ def compile_FunctionCall(
             expr, matched_call, candidates=funcs, ctx=ctx
         )
 
+    volatility = (
+        # Incorporate the volatility of any server param conversions
+        max([
+            func.get_volatility(env.schema),
+            *(
+                conversion.volatility
+                for conversions in (
+                    matched_call.server_param_conversions.values()
+                )
+                for conversion in conversions.values()
+            )
+        ])
+        if matched_call.server_param_conversions else
+        func.get_volatility(env.schema)
+    )
+
     fcall = irast.FunctionCall(
         args=final_args,
         func_shortname=func_name,
@@ -361,7 +377,7 @@ def compile_FunctionCall(
         func_sql_function=func.get_from_function(env.schema),
         func_sql_expr=func.get_from_expr(env.schema),
         force_return_cast=func.get_force_return_cast(env.schema),
-        volatility=func.get_volatility(env.schema),
+        volatility=volatility,
         sql_func_has_out_params=func.get_sql_func_has_out_params(env.schema),
         error_on_null_result=func.get_error_on_null_result(env.schema),
         preserves_optionality=func.get_preserves_optionality(env.schema),

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -195,6 +195,20 @@ def compile_FunctionCall(
     func = matched_call.func
     assert isinstance(func, s_func.Function)
 
+    if matched_call.server_param_conversions:
+        for param_name, conversions in (
+            matched_call.server_param_conversions.items()
+        ):
+            if param_name not in ctx.env.server_param_conversions:
+                ctx.env.server_param_conversions[param_name] = {}
+            ctx.env.server_param_conversions[param_name].update(
+                conversions
+            )
+        ctx.env.server_param_conversion_calls.append((
+            func.get_signature_as_str(env.schema),
+            expr.span,
+        ))
+
     inline_func = None
     if (
         func.get_language(ctx.env.schema) == qlast.Language.EdgeQL

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -764,15 +764,24 @@ def _check_server_arg_conversion(
             # Get info about the conversion
             converted_type: s_types.Type
             additional_info: tuple[str, ...] = tuple()
+            conversion_volatility: ft.Volatility
             if conversion_name == 'cast_int64_to_str':
                 converted_type = schema.get(
                     'std::str', type=s_scalars.ScalarType
                 )
+                conversion_volatility = ft.Volatility.Immutable
+
+            elif conversion_name == 'cast_int64_to_str_volatile':
+                converted_type = schema.get(
+                    'std::str', type=s_scalars.ScalarType
+                )
+                conversion_volatility = ft.Volatility.Volatile
 
             elif conversion_name == 'cast_int64_to_float64':
                 converted_type = schema.get(
                     'std::float64', type=s_scalars.ScalarType
                 )
+                conversion_volatility = ft.Volatility.Immutable
 
             elif conversion_name == 'join_str_array':
                 assert isinstance(conversion_info, list)
@@ -782,6 +791,7 @@ def _check_server_arg_conversion(
                     'std::str', type=s_scalars.ScalarType
                 )
                 additional_info = (separator,)
+                conversion_volatility = ft.Volatility.Immutable
 
             else:
                 raise RuntimeError(
@@ -876,6 +886,7 @@ def _check_server_arg_conversion(
                             sub_params=sub_params,
                         ),
                         additional_info=additional_info,
+                        volatility=conversion_volatility,
                         constant_value=constant_value,
                     )
                 )

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -388,6 +388,11 @@ def collect_server_param_conversions(
     list[irast.ServerParamConversion],
     list[irast.Param],
 ]:
+    """Gather converted parameters for use in the ir Statement.
+
+    Returns ServerParamConversion which will eventually be sent to the server
+    as well as the irast.Params which should be used to generate the pgast.
+    """
     lparams = [
         (
             param_name,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -778,6 +778,9 @@ class ServerParamConversion:
     conversion_name: str
     additional_info: tuple[str, ...]
 
+    # If the parameter is a constant value, pass to directly to the server.
+    constant_value: typing.Optional[typing.Any] = None
+
 
 class Statement(Command):
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -772,13 +772,20 @@ class ComputableInfo(typing.NamedTuple):
     should_materialize: typing.Sequence[MaterializeReason]
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ServerParamConversion:
+    param_name: str
+    conversion_name: str
+    additional_info: tuple[str, ...]
+
+
 class Statement(Command):
 
     expr: Set
     views: dict[sn.Name, s_types.Type]
     params: list[Param]
     globals: list[Global]
-    server_param_conversions: list[tuple[str, str, list[str]]]
+    server_param_conversions: list[ServerParamConversion]
     server_param_conversion_params: list[Param]
     cardinality: qltypes.Cardinality
     volatility: qltypes.Volatility

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -778,6 +778,8 @@ class Statement(Command):
     views: dict[sn.Name, s_types.Type]
     params: list[Param]
     globals: list[Global]
+    server_param_conversions: list[tuple[str, str, list[str]]]
+    server_param_conversion_params: list[Param]
     cardinality: qltypes.Cardinality
     volatility: qltypes.Volatility
     multiplicity: qltypes.Multiplicity

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -94,6 +94,7 @@ def compile_ir_to_sql_tree(
         # Transform to sql tree
         query_params = []
         query_globals = []
+        server_param_conversion_params = []
         type_rewrites = {}
         triggers: tuple[tuple[irast.Trigger, ...], ...] = ()
 
@@ -102,6 +103,9 @@ def compile_ir_to_sql_tree(
             scope_tree = ir_expr.scope_tree
             query_params = list(ir_expr.params)
             query_globals = list(ir_expr.globals)
+            server_param_conversion_params = list(
+                ir_expr.server_param_conversion_params
+            )
             type_rewrites = ir_expr.type_rewrites
             singletons = ir_expr.singletons
             triggers = ir_expr.triggers
@@ -156,7 +160,9 @@ def compile_ir_to_sql_tree(
             ctx.path_scope[sing] = ctx.rel
         if external_rels:
             ctx.external_rels = external_rels
-        clauses.populate_argmap(query_params, query_globals, ctx=ctx)
+        clauses.populate_argmap(
+            query_params, query_globals, server_param_conversion_params, ctx=ctx
+        )
 
         qtree = dispatch.compile(ir_expr, ctx=ctx)
         dml.compile_triggers(triggers, qtree, ctx=ctx)

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -103,7 +103,7 @@ def compile_ir_to_sql_tree(
             scope_tree = ir_expr.scope_tree
             query_params = list(ir_expr.params)
             query_globals = list(ir_expr.globals)
-            server_param_conversion_params = list(
+            server_param_conversion_params = (
                 ir_expr.server_param_conversion_params
             )
             type_rewrites = ir_expr.type_rewrites

--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -555,6 +555,7 @@ def fini_toplevel(
 def populate_argmap(
     params: list[irast.Param],
     globals: list[irast.Global],
+    server_param_conversion_params: list[irast.Param],
     *,
     ctx: context.CompilerContextLevel,
 ) -> None:
@@ -593,3 +594,13 @@ def populate_argmap(
                 logical_index=-1,
             )
             physical_index += 1
+    for param in server_param_conversion_params:
+        ctx.argmap[param.name] = pgast.Param(
+            index=physical_index,
+            logical_index=logical_index,
+            required=param.required,
+        )
+        if not param.sub_params:
+            physical_index += 1
+        if not param.is_sub_param:
+            logical_index += 1

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1327,6 +1327,10 @@ class Function(
 
     is_inlined = so.SchemaField(bool, default=False)
 
+    server_param_conversions = so.SchemaField(
+        str, default=None, compcoef=0.0
+    )
+
     def has_inlined_defaults(self, schema: s_schema.Schema) -> bool:
         # This can be relaxed to just `language is EdgeQL` when we
         # support non-constant defaults.

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -1327,6 +1327,16 @@ class Function(
 
     is_inlined = so.SchemaField(bool, default=False)
 
+    # A json string which describes any server param conversions to apply.
+    #
+    # The data should take the form: dict[str, str | list[str]]
+    #
+    # The key should be the names of the converted params.
+    # The value should be either: the conversion name, or a list of strings
+    # where the first item is the name of the conversion.
+    #
+    # If the value is a list, the additional items act as parameters to the
+    # conversion.
     server_param_conversions = so.SchemaField(
         str, default=None, compcoef=0.0
     )

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1918,6 +1918,27 @@ def _compile_ql_query(
         ctx, ir, sql_res.argmap, script_info
     )
 
+    server_param_conversions: Optional[
+        list[dbstate.ServerParamConversion]
+    ] = None
+    if isinstance(ir, irast.Statement) and ir.server_param_conversions:
+        source_variables = (
+            ctx.source.variables() if ctx.source else {}
+        )
+        server_param_conversions = [
+            dbstate.ServerParamConversion(
+                param_name=p.param_name,
+                conversion_name=p.conversion_name,
+                additional_info=p.additional_info,
+                source_value=(
+                    source_variables[p.param_name]
+                    if p.param_name in source_variables else
+                    None
+                )
+            )
+            for p in ir.server_param_conversions
+        ]
+
     sql_hash = _hash_sql(
         sql_text.encode(defines.EDGEDB_ENCODING),
         mode=str(ctx.output_format).encode(),
@@ -1961,6 +1982,7 @@ def _compile_ql_query(
         in_type_args=in_type_args,
         out_type_id=out_type_id.bytes,
         out_type_data=out_type_data,
+        server_param_conversions=server_param_conversions,
         cacheable=cacheable,
         has_dml=bool(ir.dml_exprs),
         query_asts=query_asts,
@@ -2997,6 +3019,8 @@ def _make_query_unit(
         unit.out_type_id = comp.out_type_id
         unit.in_type_data = comp.in_type_data
         unit.in_type_id = comp.in_type_id
+
+        unit.server_param_conversions = comp.server_param_conversions
 
         unit.cacheable = comp.cacheable
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1931,6 +1931,8 @@ def _compile_ql_query(
                 conversion_name=p.conversion_name,
                 additional_info=p.additional_info,
                 source_value=(
+                    p.constant_value
+                    if p.constant_value is not None else
                     source_variables[p.param_name]
                     if p.param_name in source_variables else
                     None

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -97,6 +97,21 @@ class NullQuery(BaseQuery):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
+class ServerParamConversion:
+    param_name: str
+    conversion_name: str
+    additional_info: tuple[str, ...]
+
+    # Explicitly store the value if it is a literal which was turned into a
+    # parameter during normalization.
+    #
+    # Normalized constants are passed to the backend as a blob of bytes.
+    # Since no encode/decode information is associated with this blob, the
+    # value to be converted needs to be passed in separately.
+    source_value: Optional[Any] = None
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class Query(BaseQuery):
     sql_hash: bytes
 
@@ -109,6 +124,8 @@ class Query(BaseQuery):
     in_type_args: Optional[list[Param]] = None
 
     globals: Optional[list[tuple[str, bool]]] = None
+
+    server_param_conversions: Optional[list[ServerParamConversion]] = None
 
     cacheable: bool = True
     is_explain: bool = False
@@ -296,6 +313,8 @@ class QueryUnit:
     in_type_args_real_count: int = 0
     globals: Optional[list[tuple[str, bool]]] = None
 
+    server_param_conversions: Optional[list[ServerParamConversion]] = None
+
     warnings: tuple[errors.EdgeDBError, ...] = ()
 
     # Set only when this unit contains a CONFIGURE INSTANCE command.
@@ -407,6 +426,9 @@ class QueryUnitGroup:
     in_type_args_real_count: int = 0
     globals: Optional[list[tuple[str, bool]]] = None
 
+    server_param_conversions: Optional[list[ServerParamConversion]] = None
+    unit_converted_param_indexes: Optional[dict[int, list[int]]] = None
+
     warnings: Optional[list[errors.EdgeDBError]] = None
 
     # Cacheable QueryUnit is serialized in the compiler, so that the I/O server
@@ -470,6 +492,32 @@ class QueryUnitGroup:
             if self.globals is None:
                 self.globals = []
             self.globals.extend(query_unit.globals)
+        if query_unit.server_param_conversions is not None:
+            if self.server_param_conversions is None:
+                self.server_param_conversions = []
+            if self.unit_converted_param_indexes is None:
+                self.unit_converted_param_indexes = {}
+
+            # De-duplicate param conversions and store information about which
+            # units access which converted params.
+            # If two units request the same conversion on the same parameter,
+            # we should assume the conversion is stable and only do it once.
+            unit_index = len(self._units)
+            converted_param_indexes: list[int] = []
+            for spc in query_unit.server_param_conversions:
+                if spc in self.server_param_conversions:
+                    converted_param_indexes.append(
+                        self.server_param_conversions.index(spc)
+                    )
+                else:
+                    converted_param_indexes.append(
+                        len(self.server_param_conversions)
+                    )
+                    self.server_param_conversions.append(spc)
+            self.unit_converted_param_indexes[unit_index] = (
+                converted_param_indexes
+            )
+
         if query_unit.warnings is not None:
             if self.warnings is None:
                 self.warnings = []

--- a/edb/server/protocol/args_ser.pxd
+++ b/edb/server/protocol/args_ser.pxd
@@ -67,19 +67,29 @@ cdef list[ParamConversion] get_param_conversions(
 )
 
 cdef class ConvertedArg:
-    pass
+    cdef:
+        int bind_format_code
 
 @cython.final
 cdef class ConvertedArgStr(ConvertedArg):
     cdef:
         str data
 
+    @staticmethod
+    cdef ConvertedArgStr new(str data)
+
 @cython.final
 cdef class ConvertedArgFloat64(ConvertedArg):
     cdef:
         float data
 
+    @staticmethod
+    cdef ConvertedArgFloat64 new(float data)
+
 @cython.final
 cdef class ConvertedArgListFloat32(ConvertedArg):
     cdef:
         list data
+
+    @staticmethod
+    cdef ConvertedArgListFloat32 new(list data)

--- a/edb/server/protocol/args_ser.pxd
+++ b/edb/server/protocol/args_ser.pxd
@@ -17,6 +17,8 @@
 #
 
 
+cimport cython
+
 from edb.server.dbview cimport dbview
 from edb.server.pgproto.pgproto cimport WriteBuffer
 
@@ -25,6 +27,7 @@ cdef WriteBuffer recode_bind_args(
     dbview.DatabaseConnectionView dbv,
     dbview.CompiledQuery compiled,
     bytes bind_args,
+    list converted_args,
     list positions = ?,
     list data_types = ?,
 )
@@ -34,6 +37,7 @@ cdef recode_bind_args_for_script(
     dbview.DatabaseConnectionView dbv,
     dbview.CompiledQuery compiled,
     bytes bind_args,
+    list converted_args,
     ssize_t start,
     ssize_t end,
 )
@@ -45,3 +49,37 @@ cdef bytes recode_global(
 )
 
 cdef WriteBuffer combine_raw_args(object args = ?)
+
+@cython.final
+cdef class ParamConversion:
+    cdef:
+        str param_name
+        str conversion_name
+        tuple additional_info
+        bytes data
+        object source_value
+
+cdef list[ParamConversion] get_param_conversions(
+    dbview.DatabaseConnectionView dbv,
+    list server_param_conversions,
+    list in_type_args,
+    bytes bind_args,
+)
+
+cdef class ConvertedArg:
+    pass
+
+@cython.final
+cdef class ConvertedArgStr(ConvertedArg):
+    cdef:
+        str data
+
+@cython.final
+cdef class ConvertedArgFloat64(ConvertedArg):
+    cdef:
+        float data
+
+@cython.final
+cdef class ConvertedArgListFloat32(ConvertedArg):
+    cdef:
+        list data

--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+cimport cython
 cimport cpython
 
 from libc.stdint cimport int8_t, uint8_t, int16_t, uint16_t, \
@@ -24,6 +25,7 @@ from libc.stdint cimport int8_t, uint8_t, int16_t, uint16_t, \
 from edb import errors
 from edb.server.compiler import sertypes
 from edb.server.compiler import enums
+from edb.server.compiler import dbstate
 from edb.server.dbview cimport dbview
 
 from edb.server.pgproto cimport hton
@@ -46,6 +48,7 @@ cdef recode_bind_args_for_script(
     dbview.DatabaseConnectionView dbv,
     dbview.CompiledQuery compiled,
     bytes bind_args,
+    list converted_args,
     ssize_t start,
     ssize_t end,
 ):
@@ -60,7 +63,7 @@ cdef recode_bind_args_for_script(
     # TODO: just do the simple thing if it is only one!
 
     positions = []
-    recoded_buf = recode_bind_args(dbv, compiled, bind_args, positions)
+    recoded_buf = recode_bind_args(dbv, compiled, bind_args, None, positions)
     # TODO: something with less copies
     recoded = bytes(memoryview(recoded_buf))
 
@@ -76,6 +79,9 @@ cdef recode_bind_args_for_script(
         if compiled.first_extra is not None:
             num_args += compiled.extra_counts[i]
 
+        if query_unit.server_param_conversions is not None:
+            num_args += len(query_unit.server_param_conversions)
+
         bind_data.write_int16(<int16_t>num_args)
 
         if query_unit.in_type_args:
@@ -89,6 +95,16 @@ cdef recode_bind_args_for_script(
 
         _inject_globals(dbv, query_unit, bind_data)
 
+        if (
+            unit_group.server_param_conversions
+            and i in unit_group.unit_converted_param_indexes
+        ):
+            # Inject any converted params for this unit
+            for converted_params_index in unit_group.unit_converted_param_indexes[i]:
+                arg = converted_args[converted_params_index]
+                assert isinstance(arg, ConvertedArg)
+                arg.encode(bind_data)
+
         bind_data.write_int32(0x00010001)
 
         bind_array.append(bind_data)
@@ -100,6 +116,7 @@ cdef WriteBuffer recode_bind_args(
     dbview.DatabaseConnectionView dbv,
     dbview.CompiledQuery compiled,
     bytes bind_args,
+    list converted_args,
     # XXX do something better?!?
     list positions = None,
     list data_types = None,
@@ -155,6 +172,9 @@ cdef WriteBuffer recode_bind_args(
     num_globals = _count_globals(qug)
     num_args += num_globals
 
+    if converted_args is not None:
+        num_args += len(converted_args)
+
     if live:
         if not compiled.extra_formatted_as_text:
             # all parameter values are in binary
@@ -175,6 +195,13 @@ cdef WriteBuffer recode_bind_args(
             # and injected globals are binary again
             for _ in range(num_globals):
                 out_buf.write_int16(0x0001)
+            # and converted args depend on the conversion
+            if converted_args:
+                for arg in converted_args:
+                    if isinstance(arg, ConvertedArgStr):
+                        out_buf.write_int16(0x0000)
+                    else:
+                        out_buf.write_int16(0x0001)
 
         out_buf.write_int16(<int16_t>num_args)
 
@@ -229,6 +256,11 @@ cdef WriteBuffer recode_bind_args(
 
         # Inject any globals variables into the argument stream.
         _inject_globals(dbv, qug, out_buf)
+
+        if converted_args:
+            for arg in converted_args:
+                assert isinstance(arg, ConvertedArg)
+                arg.encode(out_buf)
 
         # All columns are in binary format
         out_buf.write_int32(0x00010001)
@@ -597,3 +629,165 @@ cdef WriteBuffer combine_raw_args(
     bind_data.write_int32(0x00010001)
 
     return bind_data
+
+
+@cython.final
+cdef class ParamConversion:
+    def __init__(
+        self,
+        *,
+        param_name,
+        conversion_name,
+        additional_info,
+        data,
+        source_value,
+    ):
+        self.param_name = param_name
+        self.conversion_name = conversion_name
+        self.additional_info = additional_info
+        self.data = data
+        self.source_value = source_value
+
+    def get_param_name(self):
+        return self.param_name
+
+    def get_conversion_name(self):
+        return self.conversion_name
+
+    def get_additional_info(self):
+        return self.additional_info
+
+    def get_data(self):
+        return self.data
+
+    def get_source_value(self):
+        return self.source_value
+
+
+cdef list[ParamConversion] get_param_conversions(
+    dbview.DatabaseConnectionView dbv,
+    list server_param_conversions,
+    list in_type_args,
+    bytes bind_args,
+):
+    cdef:
+        FRBuffer in_buf
+        ssize_t in_len
+        const char *data_str
+
+    assert cpython.PyBytes_CheckExact(bind_args)
+    frb_init(
+        &in_buf,
+        cpython.PyBytes_AS_STRING(bind_args),
+        cpython.Py_SIZE(bind_args)
+    )
+
+    if frb_get_len(&in_buf) == 0:
+        pass
+    else:
+        hton.unpack_int32(frb_read(&in_buf, 4))
+
+    # First check which parameters' data we need to get
+    param_names = set(
+        param_conversion.param_name
+        for param_conversion in server_param_conversions
+    )
+
+    # Next extract bytes from the bind_args
+    param_datas: dict[str, bytes] = {}
+    for param in in_type_args:
+        assert isinstance(param, dbstate.Param)
+        frb_read(&in_buf, 4)  # reserved
+        in_len = hton.unpack_int32(frb_read(&in_buf, 4))
+        data_str = frb_read(&in_buf, in_len)
+
+        if param.name in param_names:
+            data = cpython.PyBytes_FromStringAndSize(data_str, in_len)
+            param_datas[param.name] = data
+
+    if frb_get_len(&in_buf):
+        raise errors.InputDataError('unexpected trailing data in buffer')
+
+    # Finally, pack it with the resulting ParamConversion
+    result: list[ParamConversion] = []
+    for param_conversion in server_param_conversions:
+        assert isinstance(param_conversion, dbstate.ServerParamConversion)
+        param_name = param_conversion.param_name
+
+        if param_name in param_datas:
+            if param_conversion.source_value is not None:
+                raise RuntimeError(
+                    f"Parameter '{param_name}' has both a source and a bind args value"
+                )
+
+            result.append(ParamConversion(
+                param_name=param_name,
+                conversion_name=param_conversion.conversion_name,
+                additional_info=param_conversion.additional_info,
+                data=param_datas[param_name],
+                source_value=None,
+            ))
+
+        elif param_conversion.source_value:
+            result.append(ParamConversion(
+                param_name=param_name,
+                conversion_name=param_conversion.conversion_name,
+                additional_info=param_conversion.additional_info,
+                data=None,
+                source_value=param_conversion.source_value,
+            ))
+
+        else:
+            raise RuntimeError(
+                f"Parameter '{param_name}' has no source or bind args value"
+            )
+
+    return result
+
+
+# After param conversions, we need to re-encode the converted
+# arg before putting it into the recoded bind args
+cdef class ConvertedArg:
+    def encode(self, buffer: WriteBuffer):
+        raise NotImplementedError
+
+
+@cython.final
+cdef class ConvertedArgStr(ConvertedArg):
+    def __init__(self, data: str):
+        self.data = data
+
+    def encode(self, buffer: WriteBuffer):
+        encoded = self.data.encode()
+        buffer.write_int32(len(encoded))
+        buffer.write_bytes(encoded)
+
+
+@cython.final
+cdef class ConvertedArgFloat64(ConvertedArg):
+    def __init__(self, data: float):
+        self.data = data
+
+    def encode(self, buffer: WriteBuffer):
+        buffer.write_int32(8) # elem size
+        buffer.write_double(self.data)
+
+
+@cython.final
+cdef class ConvertedArgListFloat32(ConvertedArg):
+    def __init__(self, data: list[str]):
+        self.data = data
+
+    def encode(self, buffer: WriteBuffer):
+        elem_count = len(self.data)
+        buffer.write_int32(12 + 8 + elem_count * 8)  # buffer length
+        buffer.write_int32(1)  # number of dimensions
+        buffer.write_int32(0)  # flags
+        buffer.write_int32(700)  # array_tid for "real"
+
+        buffer.write_int32(elem_count) # count
+        buffer.write_int32(1) # bound
+
+        for elem in self.data:
+            buffer.write_int32(4) # elem size
+            buffer.write_float(elem)

--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -695,15 +695,16 @@ cdef list[ParamConversion] get_param_conversions(
 
     # Next extract bytes from the bind_args
     param_datas: dict[str, bytes] = {}
-    for param in in_type_args:
-        assert isinstance(param, dbstate.Param)
-        frb_read(&in_buf, 4)  # reserved
-        in_len = hton.unpack_int32(frb_read(&in_buf, 4))
-        data_str = frb_read(&in_buf, in_len)
+    if in_type_args is not None:
+        for param in in_type_args:
+            assert isinstance(param, dbstate.Param)
+            frb_read(&in_buf, 4)  # reserved
+            in_len = hton.unpack_int32(frb_read(&in_buf, 4))
+            data_str = frb_read(&in_buf, in_len)
 
-        if param.name in param_names:
-            data = cpython.PyBytes_FromStringAndSize(data_str, in_len)
-            param_datas[param.name] = data
+            if param.name in param_names:
+                data = cpython.PyBytes_FromStringAndSize(data_str, in_len)
+                param_datas[param.name] = data
 
     if frb_get_len(&in_buf):
         raise errors.InputDataError('unexpected trailing data in buffer')

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -491,7 +491,10 @@ async def _convert_parameters(
             conversion.get_additional_info()
         )
 
-        if conversion_name == 'cast_int64_to_str':
+        if (
+            conversion_name == 'cast_int64_to_str'
+            or conversion_name == 'cast_int64_to_str_volatile'
+        ):
             decoded_param_data = (
                 decode_int(conversion.get_data())
                 if conversion.get_source_value() is None

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -50,7 +50,6 @@ from edb.server.compiler import errormech
 from edb.server.compiler cimport rpc
 from edb.server.compiler import sertypes
 from edb.server.dbview cimport dbview
-from edb.server.protocol import ai_ext
 from edb.server.protocol cimport args_ser
 from edb.server.protocol cimport frontend
 from edb.server.pgcon cimport pgcon
@@ -455,9 +454,10 @@ async def _convert_parameters(
     in_type_args: Optional[list[dbstate.Param]],
     bind_args: bytes,
 ) -> Optional[list[args_ser.ConvertedArg]]:
-    # If there are server param conversions, compute them now so that they are
-    # injected into the recoded bind args later.
-    tenant = dbv.tenant
+    """
+    If there are server param conversions, compute them now so that they are
+    injected into the recoded bind args later.
+    """
 
     # We receive the encoded param data from the bind_args
     # and decode it manually.
@@ -468,6 +468,7 @@ async def _convert_parameters(
         return data.decode("utf-8")
 
     def decode_array_of_str(data: bytes) -> list[str]:
+        # See gel-python for more details on array encoding
         texts = []
         text_count = int.from_bytes(data[12:16])
         data = data[20:]
@@ -501,7 +502,7 @@ async def _convert_parameters(
                 else conversion.get_source_value()
             )
             converted_args.append(
-                args_ser.ConvertedArgStr(
+                args_ser.ConvertedArgStr.new(
                     str(decoded_param_data)
                 )
             )
@@ -513,7 +514,7 @@ async def _convert_parameters(
                 else conversion.get_source_value()
             )
             converted_args.append(
-                args_ser.ConvertedArgFloat64(
+                args_ser.ConvertedArgFloat64.new(
                     float(decoded_param_data)
                 )
             )
@@ -529,7 +530,7 @@ async def _convert_parameters(
 
             separator = additional_info[0]
             converted_args.append(
-                args_ser.ConvertedArgStr(
+                args_ser.ConvertedArgStr.new(
                     separator.join(decoded_param_data)
                 )
             )

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -50,6 +50,7 @@ from edb.server.compiler import errormech
 from edb.server.compiler cimport rpc
 from edb.server.compiler import sertypes
 from edb.server.dbview cimport dbview
+from edb.server.protocol import ai_ext
 from edb.server.protocol cimport args_ser
 from edb.server.protocol cimport frontend
 from edb.server.pgcon cimport pgcon
@@ -295,9 +296,19 @@ async def execute(
                         if ddl_ret and ddl_ret['new_types']:
                             new_types = ddl_ret['new_types']
                 else:
+                    converted_args: Optional[list[args_ser.ConvertedArg]] = None
+                    if query_unit.server_param_conversions:
+                        converted_args = await _convert_parameters(
+                            dbv,
+                            query_unit.server_param_conversions,
+                            query_unit.in_type_args,
+                            bind_args,
+                        )
+
                     data_types = []
                     bound_args_buf = args_ser.recode_bind_args(
-                        dbv, compiled, bind_args, None, data_types)
+                        dbv, compiled, bind_args, converted_args, None, data_types,
+                    )
 
                     assert not (query_unit.database_config
                                 and query_unit.needs_readback), (
@@ -438,6 +449,96 @@ async def execute(
     return data
 
 
+async def _convert_parameters(
+    dbv: dbview.DatabaseConnectionView,
+    server_param_conversions: list[dbstate.ServerParamConversion],
+    in_type_args: Optional[list[dbstate.Param]],
+    bind_args: bytes,
+) -> Optional[list[args_ser.ConvertedArg]]:
+    # If there are server param conversions, compute them now so that they are
+    # injected into the recoded bind args later.
+    tenant = dbv.tenant
+
+    # We receive the encoded param data from the bind_args
+    # and decode it manually.
+    def decode_int(data: bytes) -> int:
+        return int.from_bytes(data)
+
+    def decode_str(data: bytes) -> str:
+        return data.decode("utf-8")
+
+    def decode_array_of_str(data: bytes) -> list[str]:
+        texts = []
+        text_count = int.from_bytes(data[12:16])
+        data = data[20:]
+        for _ in range(text_count):
+            text_length = int.from_bytes(data[:4])
+            data = data[4:]
+            texts.append(data[:(text_length)].decode("utf-8"))
+            data = data[text_length:]
+        return texts
+
+    param_conversions: list[args_ser.ParamConversion] = (
+        args_ser.get_param_conversions(
+            dbv, server_param_conversions, in_type_args, bind_args,
+        )
+    )
+
+    converted_args = []
+    for conversion in param_conversions:
+        conversion_name: str = conversion.get_conversion_name()
+        additional_info: tuple[str, ...] = (
+            conversion.get_additional_info()
+        )
+
+        if conversion_name == 'cast_int64_to_str':
+            decoded_param_data = (
+                decode_int(conversion.get_data())
+                if conversion.get_source_value() is None
+                else conversion.get_source_value()
+            )
+            converted_args.append(
+                args_ser.ConvertedArgStr(
+                    str(decoded_param_data)
+                )
+            )
+
+        elif conversion_name == 'cast_int64_to_float64':
+            decoded_param_data = (
+                decode_int(conversion.get_data())
+                if conversion.get_source_value() is None
+                else conversion.get_source_value()
+            )
+            converted_args.append(
+                args_ser.ConvertedArgFloat64(
+                    float(decoded_param_data)
+                )
+            )
+
+        elif conversion_name == 'join_str_array':
+            decoded_param_data = (
+                decode_array_of_str(
+                    conversion.get_data()
+                )
+                if conversion.get_source_value() is None
+                else conversion.get_source_value()
+            )
+
+            separator = additional_info[0]
+            converted_args.append(
+                args_ser.ConvertedArgStr(
+                    separator.join(decoded_param_data)
+                )
+            )
+
+        else:
+            raise errors.QueryError(
+                f'unknown param conversion: {conversion_name}'
+            )
+
+    return converted_args
+
+
 async def execute_script(
     conn: pgcon.PGConnection,
     dbv: dbview.DatabaseConnectionView,
@@ -478,6 +579,16 @@ async def execute_script(
             # state restoring
             state = None
         async with conn.parse_execute_script_context():
+            
+            converted_args: Optional[list[args_ser.ConvertedArg]] = None
+            if unit_group.server_param_conversions:
+                converted_args = await _convert_parameters(
+                    dbv,
+                    unit_group.server_param_conversions,
+                    unit_group.in_type_args,
+                    bind_args,
+                )
+
             parse_array = [False] * len(unit_group)
             for idx, query_unit in enumerate(unit_group):
                 if fe_conn is not None and fe_conn.cancelled:
@@ -508,8 +619,10 @@ async def execute_script(
                         sent = len(unit_group)
 
                     sync = sent == len(unit_group) and not no_sync
+
                     bind_array = args_ser.recode_bind_args_for_script(
-                        dbv, compiled, bind_args, idx, sent)
+                        dbv, compiled, bind_args, converted_args, idx, sent)
+
                     dbver = dbv.dbver
                     conn.send_query_unit_group(
                         unit_group,

--- a/tests/test_server_param_conversions.py
+++ b/tests/test_server_param_conversions.py
@@ -1,0 +1,628 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2019-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import edgedb
+
+from edb.testbase import server as tb
+
+
+class TestServerParamConversions(tb.QueryTestCase):
+
+    SETUP = '''
+        create type Result {
+            create property n: int64;
+            create property val: str;
+        };
+
+        create function simple_to_str(val: str) -> str
+        {
+            using (val);
+        };
+        create function simple_to_str(val: int64) -> str
+        {
+            set server_param_conversions := (
+                '{"val": "cast_int64_to_str"}'
+            );
+            using sql expression;
+        };
+
+        create function simple_from_array(val: str) -> str
+        {
+            using (val)
+        };
+        create function simple_from_array(val: array<str>) -> str
+        {
+            set server_param_conversions := (
+                '{"val": ["join_str_array", " - "]}'
+            );
+            using sql expression;
+        };
+
+        create function multi_to_str(a: str, b: str) -> tuple<str, str>
+        {
+            using ((a, b))
+        };
+        create function multi_to_str(a: int64, b: int64) -> tuple<str, str>
+        {
+            set server_param_conversions := (
+                '{"a": "cast_int64_to_str", "b": "cast_int64_to_str"}'
+            );
+            using sql expression;
+        };
+
+        create function multi_to_str_and_float(
+            a: str, b: float64
+        ) -> tuple<str, float64> {
+            using ((a, b))
+        };
+        create function multi_to_str_and_float(
+            a: int64, b: int64
+        ) -> tuple<str, float64>
+        {
+            set server_param_conversions := (
+                '{"a": "cast_int64_to_str", "b": "cast_int64_to_float64"}'
+            );
+            using sql expression;
+        };
+
+        create function volatile_to_str(val: str) -> str
+        {
+            using (val);
+        };
+        create function volatile_to_str(val: int64) -> str
+        {
+            set server_param_conversions := (
+                '{"val": "cast_int64_to_str_volatile"}'
+            );
+            using sql expression;
+        };
+    '''
+
+    async def test_server_param_conversions_simple_01(self):
+        # Scalar query param
+        await self.assert_query_result(
+            'select simple_to_str(<str>$0)',
+            ["hello"],
+            variables=("hello",),
+        )
+
+        await self.assert_query_result(
+            'select simple_to_str(<int64>$0)',
+            ["123"],
+            variables=(123,),
+        )
+
+    async def test_server_param_conversions_simple_02(self):
+        # Scalar literal
+        await self.assert_query_result(
+            'select simple_to_str(123)',
+            ["123"],
+        )
+
+    async def test_server_param_conversions_simple_03(self):
+        # Scalar expression
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a constant or query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_to_str(1 + 2)',
+                ["3"],
+            )
+
+    async def test_server_param_conversions_simple_04(self):
+        # Scalar computed global
+        await self.con.execute('''
+            create global foo := 123 + 456;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a constant or query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_to_str(global foo)',
+                ["123"],
+            )
+
+    async def test_server_param_conversions_simple_05(self):
+        # Scalar non-computed global
+        await self.con.execute('''
+            create global foo: int64;
+        ''')
+        await self.con.execute('''
+            set global foo := 123;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a constant or query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_to_str(global foo)',
+                ["123"],
+            )
+
+    async def test_server_param_conversions_simple_06(self):
+        # Scalar alias
+        await self.con.execute('''
+            create alias foo := 123;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a constant or query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_to_str(foo)',
+                ["123"],
+            )
+
+    async def test_server_param_conversions_simple_07(self):
+        # Array query param
+        await self.assert_query_result(
+            'select simple_from_array(<str>$0)',
+            ["hello"],
+            variables=("hello",),
+        )
+        await self.assert_query_result(
+            'select simple_from_array(<array<str>>$0)',
+            ["hello - world - !"],
+            variables=(["hello", "world", "!"],),
+        )
+
+    async def test_server_param_conversions_simple_08(self):
+        # Array literal
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_from_array(["hello", "world", "!"])',
+                ["hello - world - !"],
+            )
+
+    async def test_server_param_conversions_simple_09(self):
+        # Array expression
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_from_array(array_agg({"hello", "world", "!"}))',
+                ["hello - world - !"],
+            )
+
+    async def test_server_param_conversions_simple_10(self):
+        # Array computed global
+        await self.con.execute('''
+            create global foo := ["hello", "world", "!"];
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_from_array(global foo)',
+                ["hello - world - !"],
+            )
+
+    async def test_server_param_conversions_simple_11(self):
+        # Array non-computed global
+        await self.con.execute('''
+            create global foo: array<str>;
+        ''')
+        await self.con.execute('''
+            set global foo := ["hello", "world", "!"];
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_from_array(global foo)',
+                ["hello - world - !"],
+            )
+
+    async def test_server_param_conversions_simple_12(self):
+        # Array alias
+        await self.con.execute('''
+            create alias foo := ["hello", "world", "!"];
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "Argument 'val' must be a query parameter"
+        ):
+            await self.assert_query_result(
+                'select simple_from_array(foo)',
+                ["hello - world - !"],
+            )
+
+    async def test_server_param_conversions_multi_01(self):
+        # Multiple calls to the same function in a query
+
+        # Server param conversion call and normal call in same query
+        await self.assert_query_result(
+            '''
+            select (
+                simple_to_str(<int64>$0),
+                simple_to_str(<str>$1),
+            )
+            ''',
+            [("123", "hello")],
+            variables=(123, "hello"),
+        )
+
+        # Same function with the same argument
+        await self.assert_query_result(
+            '''
+            select (
+                simple_to_str(<int64>$0),
+                simple_to_str(<int64>$0),
+                simple_to_str(<int64>$0),
+            )
+            ''',
+            [("123", "123", "123")],
+            variables=(123,),
+        )
+        await self.assert_query_result(
+            '''
+            with
+                x := simple_to_str(<int64>$0),
+                y := simple_to_str(<int64>$0),
+                z := simple_to_str(<int64>$0),
+            select (x, y, z)
+            ''',
+            [("123", "123", "123")],
+            variables=(123,),
+        )
+
+        # Same function with different argument
+        await self.assert_query_result(
+            '''
+            select (
+                simple_to_str(<int64>$0),
+                simple_to_str(<int64>$1),
+                simple_to_str(<int64>$2),
+            )
+            ''',
+            [("123", "456", "789")],
+            variables=(123, 456, 789),
+        )
+
+        await self.assert_query_result(
+            '''
+            with
+                x := simple_to_str(<int64>$0),
+                y := simple_to_str(<int64>$1),
+                z := simple_to_str(<int64>$2),
+            select (x, y, z)
+            ''',
+            [("123", "456", "789")],
+            variables=(123, 456, 789),
+        )
+
+        # Check that order of args is maintained
+        await self.assert_query_result(
+            '''
+            with
+                x := simple_to_str(<int64>$2),
+                y := simple_to_str(<int64>$1),
+                z := simple_to_str(<int64>$0),
+            select (x, y, z)
+            ''',
+            [("789", "456", "123")],
+            variables=(123, 456, 789),
+        )
+
+        # Check parameters with str names
+        await self.assert_query_result(
+            '''
+            with
+                x := simple_to_str(<int64>$foo),
+                y := simple_to_str(<int64>$bar),
+                z := simple_to_str(<int64>$baz),
+            select (x, y, z)
+            ''',
+            [("123", "456", "789")],
+            variables={'foo': 123, 'bar': 456, 'baz': 789},
+        )
+
+    async def test_server_param_conversions_multi_02(self):
+        # Call different functions with param conversions
+        await self.assert_query_result(
+            '''
+            with
+                x := simple_to_str(<int64>$0),
+                y := simple_from_array(<array<str>>$1),
+            select (x, y)
+            ''',
+            [("123", "hello - world - !")],
+            variables=(123, ["hello", "world", "!"]),
+        )
+
+    async def test_server_param_conversions_multi_03(self):
+        # Param is used as both converted and non-converted
+        await self.assert_query_result(
+            'select (simple_to_str(<int64>$0), <int64>$0 + 1)',
+            [("123", 124)],
+            variables=(123,),
+        )
+
+        await self.assert_query_result(
+            '''
+            select (
+                simple_to_str(<int64>$0),
+                <int64>$0,
+                simple_from_array(<array<str>>$1),
+                <array<str>>$1,
+            )
+            ''',
+            [("123", 123, "hello - world - !", ["hello", "world", "!"])],
+            variables=(123, ["hello", "world", "!"]),
+        )
+
+    async def test_server_param_conversions_multi_04(self):
+        # A function with the same conversion multiple times
+        await self.assert_query_result(
+            'select multi_to_str(<str>$0, <str>$1)',
+            [("hello", "world")],
+            variables=("hello", "world"),
+        )
+
+        await self.assert_query_result(
+            'select multi_to_str(<int64>$0, <int64>$1)',
+            [("123", "456")],
+            variables=(123, 456),
+        )
+
+    async def test_server_param_conversions_multi_05(self):
+        # A function with some different conversions
+        await self.assert_query_result(
+            'select multi_to_str_and_float(<str>$0, <float64>$1)',
+            [("hello", 1.5)],
+            variables=("hello", 1.5),
+        )
+
+        await self.assert_query_result(
+            'select multi_to_str_and_float(<int64>$0, <int64>$1)',
+            [("1", 2.0)],
+            variables=(1, 2),
+        )
+
+    async def test_server_param_conversions_multi_06(self):
+        # Can cast param and match the non-conversion version
+        await self.assert_query_result(
+            'select multi_to_str_and_float(<str>$0, <int64>$1)',
+            [("hello", 1.0)],
+            variables=("hello", 1),
+        )
+
+    async def test_server_param_conversions_multi_07(self):
+        # Function called only if all param conversions applied
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r'function .* does not exist'
+        ):
+            await self.assert_query_result(
+                'select multi_to_str_and_float(<int64>$0, <float64>$1)',
+                [("1", 2.3)],
+                variables=(1, 2.3),
+            )
+
+    async def test_server_param_conversions_globals_01(self):
+        # Check that the parameters are properly encoded in the presence of
+        # non-computed globals
+        await self.con.execute('''
+            create global curr_user: str;
+        ''')
+
+        await self.assert_query_result(
+            'select simple_to_str(<int64>$0)',
+            ["123"],
+            variables=(123,),
+        )
+
+        await self.con.execute('''
+            set global curr_user := "Bob";
+        ''')
+
+        await self.assert_query_result(
+            'select simple_to_str(<int64>$0)',
+            ["123"],
+            variables=(123,),
+        )
+
+        await self.assert_query_result(
+            '''
+            select (
+                global curr_user,
+                simple_to_str(<int64>$0),
+                <int64>$0,
+            )
+            ''',
+            [("Bob", "123", 123)],
+            variables=(123,),
+        )
+
+    async def test_server_param_conversions_globals_02(self):
+        # Check that the non converted function works in a computed global.
+        await self.con.execute('''
+            create global foo := simple_to_str("123");
+        ''')
+
+        await self.assert_query_result(
+            'select global foo',
+            ["123"],
+        )
+
+    async def test_server_param_conversions_globals_03(self):
+        # Check that the parameter conversion is disallowed in a computed global
+        await self.con.execute('''
+            create global foo := simple_to_str(123);
+        ''')
+
+        await self.assert_query_result(
+            'select global foo',
+            ["123"],
+        )
+
+    async def test_server_param_conversions_globals_04(self):
+        # Check that the parameter conversion is disallowed in non-computed
+        # global.
+        await self.con.execute('''
+            create global foo -> str;
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            r"Function 'default::simple_to_str\(val: std::str\)' "
+            r"is not allowed in a config statement."
+        ):
+            await self.con.execute('''
+                set global foo := simple_to_str(123);
+            ''')
+
+    async def test_server_param_conversions_alias_01(self):
+        # Check that the parameter conversion works in an alias.
+        await self.con.execute('''
+            create alias foo := simple_to_str(123);
+        ''')
+
+        await self.assert_query_result(
+            'select foo',
+            ["123"],
+        )
+
+    async def test_server_param_conversions_pointer_01(self):
+        # Param conversion is ok in a computed pointer
+        await self.con.execute("""
+            CREATE TYPE Foo {
+                CREATE PROPERTY out := simple_to_str("123");
+            };
+            CREATE TYPE Bar {
+                CREATE PROPERTY out := simple_to_str(456);
+            };
+        """)
+        await self.con.execute('''
+            insert Foo;
+            insert Bar;
+        ''')
+
+        await self.assert_query_result(
+            'select Foo.out',
+            ["123"],
+        )
+        await self.assert_query_result(
+            'select Bar.out',
+            ["456"],
+        )
+
+    async def test_server_param_conversions_pointer_02(self):
+        # Volatile param conversion disallowed as usual
+        await self.con.execute("""
+            CREATE TYPE Foo {
+                CREATE PROPERTY out := volatile_to_str("123");
+            };
+        """)
+
+        async with self.assertRaisesRegexTx(
+            edgedb.QueryError,
+            "volatile functions are not permitted in schema-defined "
+            "computed expressions",
+        ):
+            await self.con.execute("""
+                CREATE TYPE Bar {
+                    CREATE PROPERTY out := volatile_to_str(456);
+                };
+            """)
+
+    async def test_server_param_conversions_script_01(self):
+        # Simple script
+        await self.con.execute(
+            '''
+            insert Result { n := 1, val := simple_to_str(<int64>$0) };
+            insert Result { n := 2, val := "456" };
+            ''',
+            123
+        )
+
+        await self.assert_query_result(
+            'select Result { n, val } order by .n',
+            [
+                {'n': 1, 'val': "123"},
+                {'n': 2, 'val': "456"},
+            ],
+        )
+
+    async def test_server_param_conversions_script_02(self):
+        # Script where statements share the same converted parameter
+        await self.con.execute(
+            '''
+            insert Result { n := 1, val := simple_to_str(<int64>$0) };
+            insert Result { n := 2, val := simple_to_str(<int64>$0) };
+            ''',
+            123
+        )
+
+        await self.assert_query_result(
+            'select Result { n, val } order by .n',
+            [
+                {'n': 1, 'val': "123"},
+                {'n': 2, 'val': "123"},
+            ],
+        )
+
+    async def test_server_param_conversions_script_03(self):
+        # Script with different converted parameters
+        await self.con.execute(
+            '''
+            insert Result { n := 1, val := simple_to_str(<int64>$0) };
+            insert Result { n := 2, val := simple_to_str(<int64>$1) };
+            ''',
+            123,
+            456,
+        )
+
+        await self.assert_query_result(
+            'select Result { n, val } order by .n',
+            [
+                {'n': 1, 'val': "123"},
+                {'n': 2, 'val': "456"},
+            ],
+        )
+
+    async def test_server_param_conversions_script_04(self):
+        # Script where the parameter is both converted and not converted
+        await self.con.execute(
+            '''
+            insert Result { n := 1, val := <str><int64>$0 ++ "!" };
+            insert Result { n := 2, val := simple_to_str(<int64>$0) };
+            ''',
+            123,
+        )
+
+        await self.assert_query_result(
+            'select Result { n, val } order by .n',
+            [
+                {'n': 1, 'val': "123!"},
+                {'n': 2, 'val': "123"},
+            ],
+        )


### PR DESCRIPTION
Allows functions to specify a set of conversions to parameters by the server. The converted parameters must be either a constant or a query parameter.

This is useful for implementing ai text search, which will apply a conversion to a text param and convert it into an embedding.

Example param conversion:
```
    create function my_to_str(val: str) -> str
    {
        using (val);
    };
    create function my_to_str(val: int64) -> str
    {
        set server_param_conversions := (
            '{"val": "cast_int64_to_str"}'
        );
        using sql expression;
    };
```

Given the query `select simple_to_str(123)`, returns `"123"`

Functions can set `server_param_conversions` as a json string of the form `dict[str, str | list[str]]`.

## Flow of information

 In function resolution during `polyres.find_callable`:
- the conversions are parsed
- parameters will be substituted for converted parameters
  - in the example, `val: int64` becomes `val~cast_int64_to_str: str`
- gather any `additional_info`, a string tuple which is passed to the server
- another version of the function will be matched

Extra information for the server:
- converted parameters are specified as coming after globals during `clauses.populate_argmap`
- Each query unit can get conversions specified during `_compile_ql_query`

Doing the actual conversion during `execute.execute`:
- Gather the conversions and the encoded arg in `args_ser.get_param_conversions`
- Decode the arg and apply the conversion in `execute._convert_parameters`
- Pass the converted params into `args_ser.recode_bind_args`

For scripts, the unit group has an additional `unit_converted_param_indexes` parameter which tracks which parameters apply to which unit. If multiple units have the same conversion, it will only be performed once.

## Adding more conversions

To add a new conversion, the following locations should be updated:
- `edgeql.compiler.polyres._check_server_arg_conversion`
  - `conversion_name`: name of conversion to set in schema
  - `converted_type`: the resulting type of the conversion
  - `additional_info`: a string tuple which can be passed to the server
  - `conversion_volatility`: the volatility of the conversion, included in the compiled function's volatility
- `server.protocol.execute._convert_parameters`
  - implement the conversion

See #8521 for how this will used.