### PR TITLE
Expand LS testing framework and cases

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_04_01_00_00
+EDGEDB_CATALOG_VERSION = 2025_04_04_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -28,9 +28,7 @@ import contextlib
 
 
 __all__ = (
-    "EdgeDBError",
-    "EdgeDBMessage",
-    "ensure_span",
+    'EdgeDBError', 'EdgeDBMessage', 'ensure_span',
 )
 
 
@@ -44,7 +42,7 @@ class EdgeDBErrorMeta(type):
         assert name not in mcls._name_map
         mcls._name_map[name] = cls
 
-        code = dct.get("_code")
+        code = dct.get('_code')
         if code is not None:
             mcls._error_map[code] = cls
 
@@ -55,9 +53,8 @@ class EdgeDBErrorMeta(type):
             # We don't want any EdgeDBError subclasses to not
             # have a code.
             raise RuntimeError(
-                "direct subclassing of EdgeDBError is prohibited; "
-                "subclass one of its subclasses in edb.errors"
-            )
+                'direct subclassing of EdgeDBError is prohibited; '
+                'subclass one of its subclasses in edb.errors')
 
     @classmethod
     def get_error_class_from_code(mcls, code: int) -> type[EdgeDBError]:
@@ -69,18 +66,19 @@ class EdgeDBErrorMeta(type):
 
 
 class EdgeDBMessage(Warning):
+
     _code: Optional[int] = None
 
     @classmethod
     def get_code(cls):
         if cls._code is None:
             raise RuntimeError(
-                f"EdgeDB message code is not set (type: {cls.__name__})"
-            )
+                f'EdgeDB message code is not set (type: {cls.__name__})')
         return cls._code
 
 
 class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
+
     _code: Optional[int] = None
     _attrs: dict[int, str]
     _pgext_code: Optional[str] = None
@@ -98,8 +96,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     ):
         if type(self) is EdgeDBError:
             raise RuntimeError(
-                "EdgeDBError is not supposed to be instantiated directly"
-            )
+                'EdgeDBError is not supposed to be instantiated directly')
 
         self._attrs = {}
         self._pgext_code = pgext_code
@@ -121,15 +118,14 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def get_code(cls):
         if cls._code is None:
             raise RuntimeError(
-                f"Gel message code is not set (type: {cls.__name__})"
-            )
+                f'Gel message code is not set (type: {cls.__name__})')
         return cls._code
 
     def to_json(self):
         err_dct = {
-            "message": str(self),
-            "type": str(type(self).__name__),
-            "code": self.get_code(),
+            'message': str(self),
+            'type': str(type(self).__name__),
+            'code': self.get_code(),
         }
         for name, field in _JSON_FIELDS.items():
             if field in self._attrs:
@@ -171,8 +167,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def set_hint_and_details(self, hint, details=None):
         ex.replace_context(
-            self, ex.DefaultExceptionContext(hint=hint, details=details)
-        )
+            self, ex.DefaultExceptionContext(hint=hint, details=details))
 
         if hint is not None:
             self._attrs[FIELD_HINT] = hint
@@ -212,7 +207,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         self._attrs[FIELD_LINE_END] = str(end.line)
         self._attrs[FIELD_COLUMN_END] = str(end.column)
         self._attrs[FIELD_UTF16_COLUMN_END] = str(end.utf16column)
-        if span.filename and span.filename != "<string>":
+        if span.filename and span.filename != '<string>':
             self._attrs[FIELD_FILENAME] = span.filename
 
     def set_position(
@@ -306,11 +301,11 @@ _INT_FIELDS = {
 
 # Fields to include in the json dump of the type
 _JSON_FIELDS = {
-    "filename": FIELD_FILENAME,
-    "hint": FIELD_HINT,
-    "details": FIELD_DETAILS,
-    "start": FIELD_CHARACTER_START,
-    "end": FIELD_CHARACTER_END,
-    "line": FIELD_LINE_START,
-    "col": FIELD_COLUMN_START,
+    'filename': FIELD_FILENAME,
+    'hint': FIELD_HINT,
+    'details': FIELD_DETAILS,
+    'start': FIELD_CHARACTER_START,
+    'end': FIELD_CHARACTER_END,
+    'line': FIELD_LINE_START,
+    'col': FIELD_COLUMN_START,
 }

--- a/edb/errors/base.py
+++ b/edb/errors/base.py
@@ -28,7 +28,9 @@ import contextlib
 
 
 __all__ = (
-    'EdgeDBError', 'EdgeDBMessage', 'ensure_span',
+    "EdgeDBError",
+    "EdgeDBMessage",
+    "ensure_span",
 )
 
 
@@ -42,7 +44,7 @@ class EdgeDBErrorMeta(type):
         assert name not in mcls._name_map
         mcls._name_map[name] = cls
 
-        code = dct.get('_code')
+        code = dct.get("_code")
         if code is not None:
             mcls._error_map[code] = cls
 
@@ -53,8 +55,9 @@ class EdgeDBErrorMeta(type):
             # We don't want any EdgeDBError subclasses to not
             # have a code.
             raise RuntimeError(
-                'direct subclassing of EdgeDBError is prohibited; '
-                'subclass one of its subclasses in edb.errors')
+                "direct subclassing of EdgeDBError is prohibited; "
+                "subclass one of its subclasses in edb.errors"
+            )
 
     @classmethod
     def get_error_class_from_code(mcls, code: int) -> type[EdgeDBError]:
@@ -66,19 +69,18 @@ class EdgeDBErrorMeta(type):
 
 
 class EdgeDBMessage(Warning):
-
     _code: Optional[int] = None
 
     @classmethod
     def get_code(cls):
         if cls._code is None:
             raise RuntimeError(
-                f'EdgeDB message code is not set (type: {cls.__name__})')
+                f"EdgeDB message code is not set (type: {cls.__name__})"
+            )
         return cls._code
 
 
 class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
-
     _code: Optional[int] = None
     _attrs: dict[int, str]
     _pgext_code: Optional[str] = None
@@ -96,7 +98,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     ):
         if type(self) is EdgeDBError:
             raise RuntimeError(
-                'EdgeDBError is not supposed to be instantiated directly')
+                "EdgeDBError is not supposed to be instantiated directly"
+            )
 
         self._attrs = {}
         self._pgext_code = pgext_code
@@ -118,14 +121,15 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
     def get_code(cls):
         if cls._code is None:
             raise RuntimeError(
-                f'Gel message code is not set (type: {cls.__name__})')
+                f"Gel message code is not set (type: {cls.__name__})"
+            )
         return cls._code
 
     def to_json(self):
         err_dct = {
-            'message': str(self),
-            'type': str(type(self).__name__),
-            'code': self.get_code(),
+            "message": str(self),
+            "type": str(type(self).__name__),
+            "code": self.get_code(),
         }
         for name, field in _JSON_FIELDS.items():
             if field in self._attrs:
@@ -167,7 +171,8 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def set_hint_and_details(self, hint, details=None):
         ex.replace_context(
-            self, ex.DefaultExceptionContext(hint=hint, details=details))
+            self, ex.DefaultExceptionContext(hint=hint, details=details)
+        )
 
         if hint is not None:
             self._attrs[FIELD_HINT] = hint
@@ -176,6 +181,18 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
 
     def has_span(self):
         return FIELD_POSITION_START in self._attrs
+
+    def get_span(self) -> tuple[int, int | None] | None:
+        if FIELD_POSITION_START not in self._attrs:
+            return None
+        return (
+            int(self._attrs[FIELD_POSITION_START]),
+            (
+                int(self._attrs[FIELD_POSITION_END])
+                if FIELD_POSITION_END in self._attrs
+                else None
+            ),
+        )
 
     def set_span(self, span: Optional[edb_span.Span]):
         if not span:
@@ -195,7 +212,7 @@ class EdgeDBError(Exception, metaclass=EdgeDBErrorMeta):
         self._attrs[FIELD_LINE_END] = str(end.line)
         self._attrs[FIELD_COLUMN_END] = str(end.column)
         self._attrs[FIELD_UTF16_COLUMN_END] = str(end.utf16column)
-        if span.filename and span.filename != '<string>':
+        if span.filename and span.filename != "<string>":
             self._attrs[FIELD_FILENAME] = span.filename
 
     def set_position(
@@ -289,11 +306,11 @@ _INT_FIELDS = {
 
 # Fields to include in the json dump of the type
 _JSON_FIELDS = {
-    'filename': FIELD_FILENAME,
-    'hint': FIELD_HINT,
-    'details': FIELD_DETAILS,
-    'start': FIELD_CHARACTER_START,
-    'end': FIELD_CHARACTER_END,
-    'line': FIELD_LINE_START,
-    'col': FIELD_COLUMN_START,
+    "filename": FIELD_FILENAME,
+    "hint": FIELD_HINT,
+    "details": FIELD_DETAILS,
+    "start": FIELD_CHARACTER_START,
+    "end": FIELD_CHARACTER_END,
+    "line": FIELD_LINE_START,
+    "col": FIELD_COLUMN_START,
 }

--- a/edb/language_server/main.py
+++ b/edb/language_server/main.py
@@ -119,8 +119,12 @@ def document_updated(ls: ls_server.GelLanguageServer, doc_uri: str):
 
             # recompile schema
             ls.state.schema = None
-            _schema, diagnostic_set = ls_server.get_schema(ls)
+            _schema, diagnostic_set, err_msg = ls_server.get_schema(ls)
             diagnostic_set.extend(document, diagnostics)
+
+            if err_msg:
+                ls.show_message(f'Error: {err_msg}')
+
         elif is_edgeql_file(doc_uri):
             # query file
             ql_ast_res = ls_parsing.parse(document, ls)

--- a/edb/language_server/utils.py
+++ b/edb/language_server/utils.py
@@ -4,17 +4,30 @@ from edb.edgeql import tokenizer
 
 
 # Convert a Span to LSP Range
-def span_to_lsp(source: str, span: tuple[int, int | None]) -> lsp_types.Range:
-    (start, end) = tokenizer.inflate_span(source, span)
+def span_to_lsp(
+    source: str, span: tuple[int, int | None] | None
+) -> lsp_types.Range:
+    if span:
+        (start, end) = tokenizer.inflate_span(source, span)
+    else:
+        (start, end) = (None, None)
     assert end
 
     return lsp_types.Range(
-        start=lsp_types.Position(
-            line=start.line - 1,
-            character=start.column - 1,
+        start=(
+            lsp_types.Position(
+                line=start.line - 1,
+                character=start.column - 1,
+            )
+            if start
+            else lsp_types.Position(line=0, character=0)
         ),
-        end=lsp_types.Position(
-            line=end.line - 1,
-            character=end.column - 1,
+        end=(
+            lsp_types.Position(
+                line=end.line - 1,
+                character=end.column - 1,
+            )
+            if end
+            else lsp_types.Position(line=0, character=0)
         ),
     )

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -23,6 +23,9 @@ import unittest
 import time
 import typing
 import json
+import tempfile
+import pathlib
+import os
 
 try:
     from edb.language_server import main as ls_main
@@ -36,12 +39,17 @@ class LspReader:
         self.stream = stream
         self.offset = 0
 
-    def get_next(self) -> dict:
-        val = self.try_get_next()
-        while val is None:
-            time.sleep(1)
+    def get_next(self, timeout_sec: float = 1.0) -> dict:
+        started_at = time.monotonic()
+        while True:
             val = self.try_get_next()
-        return val
+            if val:
+                return val
+            if time.monotonic() - started_at > timeout_sec:
+                raise TimeoutError(
+                    "timeout while waiting for server to respond"
+                )
+            time.sleep(0.1)
 
     def try_get_next(self) -> dict | None:
         headers = {}
@@ -73,52 +81,95 @@ class LspReader:
 
 
 class LspRunner:
-    def __init__(
-        self,
-    ):
-        stream_in = io.BytesIO()
-        stream_out = io.BytesIO()
+    logs: list[str]
 
-        self.stream_in = stream_in
+    def __init__(self):
+        self.logs = []
+        self.project_dir = tempfile.TemporaryDirectory()
+
+        stream_out = io.BytesIO()
+        stream_in_r, stream_in_w = os.pipe()
+
+        self.stream_in = io.FileIO(stream_in_w, "w")
         self.stream_reader = LspReader(stream_out)
-        self.ls = ls_main.init(None)
+
+        self.ls = ls_main.init(
+            '{"project_dir": "' + str(self.project_dir.name) + '"}'
+        )
 
         def run_server():
             try:
-                print(len(self.stream_in.getvalue()) - self.stream_in.tell())
-                self.ls.start_io(stdin=stream_in, stdout=stream_out)
+                stream_in = io.FileIO(stream_in_r, "r")
+                self.ls.start_io(
+                    stdin=stream_in,
+                    stdout=stream_out,
+                )
+                stream_in.close()
             except ValueError as e:
                 if str(e) != "I/O operation on closed file.":
                     raise
 
         self.runner_thread = threading.Thread(target=run_server)
-        self.send({
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 1,
-            "params": {
-                "processId": None,
-                "rootUri": None,
-                "capabilities": {}
-            }
-        })
-
         self.runner_thread.start()
 
     def send(self, request: typing.Any):
-        body = json.dumps(request).encode('utf-8')
-        head = bytes(f"Content-Length: {len(body)}\r\n\r\n", encoding="ascii")
+        body = json.dumps(request)
+        self.stream_in.write(
+            f"Content-Length: {len(body)}\r\n\r\n{body}".encode("utf-8")
+        )
+        self.stream_in.flush()
 
-        current_pos = self.stream_in.tell()
-        self.stream_in.write(head + body)
-        self.stream_in.seek(current_pos)
+    def recv(self, timeout_sec=5) -> dict:
+        while True:
+            msg = self.stream_reader.get_next(timeout_sec)
+            if msg.get("method", None) == "window/logMessage":
+                self.logs.append(msg["params"]["message"])
+                continue
+            return msg
 
-    def recv(self) -> typing.Any:
-        return self.stream_reader.get_next()
+    def add_file(self, path: str | pathlib.Path, contents: str) -> typing.Any:
+        if isinstance(path, str):
+            path = pathlib.Path(path)
+        assert not path.is_absolute()
 
-    def stop(self):
+        abs_path: pathlib.Path = self.project_dir.name / path
+
+        if not abs_path.parent.exists():
+            abs_path.parent.mkdir(parents=True)
+        with open(abs_path, "w") as f:
+            f.write(contents)
+
+    def get_uri(self, path: str) -> str:
+        return f"file://{self.project_dir.name}/{path}"
+
+    def finish(self):
+        # stop the server
         self.stream_in.close()
         self.runner_thread.join()
+
+        # remove the tmp project dir
+        self.project_dir.cleanup()
+
+    def send_init(self):
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "id": 1,
+                "params": {
+                    "processId": None,
+                    "rootUri": None,
+                    "capabilities": {},
+                    "workspaceFolders": [
+                        {
+                            "uri": f"file://{self.project_dir.name}",
+                            "name": "main workspace",
+                        }
+                    ],
+                },
+            }
+        )
+        self.recv()  # Init response
 
 
 @unittest.skipIf(ls_main is None, "edgedb-ls dependencies are missing")
@@ -128,22 +179,17 @@ class TestLanguageServer(unittest.TestCase):
     def test_language_server_01(self):
         runner = LspRunner()
 
-        self.assertEqual(
-            runner.recv(),
+        runner.send(
             {
-                "params": {"type": 4, "message": "Starting"},
-                "method": "window/logMessage",
                 "jsonrpc": "2.0",
-            },
-        )
-
-        self.assertEqual(
-            runner.recv(),
-            {
-                "params": {"type": 4, "message": "Started"},
-                "method": "window/logMessage",
-                "jsonrpc": "2.0",
-            },
+                "method": "initialize",
+                "id": 1,
+                "params": {
+                    "processId": None,
+                    "rootUri": None,
+                    "capabilities": {},
+                },
+            }
         )
 
         self.assertEqual(
@@ -178,4 +224,221 @@ class TestLanguageServer(unittest.TestCase):
             },
         )
 
-        runner.stop()
+        runner.finish()
+
+    def test_language_server_02(self):
+        # syntax error
+        runner = LspRunner()
+        try:
+            runner.send_init()
+
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": "file://myquery.edgeql",
+                            "languageId": "edgeql",
+                            "version": 1,
+                            "text": """
+                                select Hello world }
+                            """,
+                        }
+                    },
+                }
+            )
+            self.assertEqual(
+                runner.recv(),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": "file://myquery.edgeql",
+                        "version": 1,
+                        "diagnostics": [
+                            {
+                                "message": "Missing '{'",
+                                "range": {
+                                    "start": {"character": 44, "line": 1},
+                                    "end": {"character": 45, "line": 1},
+                                },
+                                "severity": 1,
+                            }
+                        ],
+                    },
+                },
+            )
+        finally:
+            runner.finish()
+
+    def test_language_server_03(self):
+        # name error
+        runner = LspRunner()
+        try:
+            runner.add_file(
+                "dbschema/default.gel",
+                """
+                type default::Hello {
+                    property world: str;
+                }
+                """,
+            )
+            runner.add_file(
+                "gel.toml",
+                "",
+            )
+            runner.send_init()
+
+            runner.send(
+                {
+                    "id": 2,
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": "file://myquery.edgeql",
+                            "languageId": "edgeql",
+                            "version": 1,
+                            "text": """
+                                select Hello { worl }
+                            """,
+                        }
+                    },
+                }
+            )
+
+            self.assertEqual(
+                runner.recv(timeout_sec=5),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": runner.get_uri("dbschema/default.gel"),
+                        "diagnostics": [],
+                    },
+                },
+            )
+
+            self.assertEqual(
+                runner.recv(timeout_sec=5),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "diagnostics": [
+                            {
+                                "message": (
+                                    "object type 'default::Hello' "
+                                    "has no link or property 'worl'"
+                                ),
+                                "range": {
+                                    "start": {"character": 47, "line": 1},
+                                    "end": {"character": 51, "line": 1},
+                                },
+                                "severity": 1,
+                            }
+                        ],
+                        "uri": "file://myquery.edgeql",
+                        "version": 1,
+                    },
+                },
+            )
+        finally:
+            runner.finish()
+
+    def test_language_server_04(self):
+        # get definition
+        runner = LspRunner()
+        try:
+            runner.add_file(
+                "gel.toml",
+                "",
+            )
+            runner.add_file(
+                "dbschema/default.gel",
+                """
+                type default::Hello {
+                    property world: str;
+                }
+                """,
+            )
+            runner.send_init()
+
+            runner.send(
+                {
+                    "id": 2,
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": "file://myquery.edgeql",
+                            "languageId": "edgeql",
+                            "version": 1,
+                            "text": """
+                                select Hello { world }
+                            """,
+                        }
+                    },
+                }
+            )
+            self.assertEqual(
+                runner.recv(timeout_sec=5),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": runner.get_uri("dbschema/default.gel"),
+                        "diagnostics": [],
+                    },
+                },
+            )
+            self.assertEqual(
+                runner.recv(timeout_sec=5),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "diagnostics": [],
+                        "uri": "file://myquery.edgeql",
+                        "version": 1,
+                    },
+                },
+            )
+
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "textDocument/definition",
+                    "params": {
+                        "textDocument": {"uri": "file://myquery.edgeql"},
+                        "position": {
+                            "line": 1,
+                            "character": 50,  # falls on "world"
+                        },
+                    },
+                }
+            )
+            self.assertEqual(
+                runner.recv(timeout_sec=0.1),
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "result": {
+                        "uri": runner.get_uri("dbschema/default.gel"),
+                        "range": {
+                            "start": {
+                                "line": 2,
+                                "character": 20,
+                            },
+                            "end": {
+                                "line": 2,
+                                "character": 40,
+                            },
+                        },
+                    },
+                },
+            )
+        finally:
+            runner.finish()

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -309,7 +309,7 @@ class TestLanguageServer(unittest.TestCase):
             )
 
             self.assertEqual(
-                runner.recv(timeout_sec=5),
+                runner.recv(timeout_sec=50),
                 {
                     "jsonrpc": "2.0",
                     "method": "textDocument/publishDiagnostics",
@@ -383,7 +383,7 @@ class TestLanguageServer(unittest.TestCase):
                 }
             )
             self.assertEqual(
-                runner.recv(timeout_sec=5),
+                runner.recv(timeout_sec=50),
                 {
                     "jsonrpc": "2.0",
                     "method": "textDocument/publishDiagnostics",
@@ -421,7 +421,7 @@ class TestLanguageServer(unittest.TestCase):
                 }
             )
             self.assertEqual(
-                runner.recv(timeout_sec=0.1),
+                runner.recv(timeout_sec=1),
                 {
                     "jsonrpc": "2.0",
                     "id": 3,


### PR DESCRIPTION
Reopen of #8558, I've accidentally closed that.

---

Language server test previously included only a basic test
that started the server and compared output to
expected string of data.

Now, we can startup a LspRunner, give it files in the workspace,
send it init messages that bring up the server, send requests
and recieve responses.

Tests for:
- basic init,
- syntax err,
- name err,
- get definition.

