### PR TITLE
Allow DML in REPEATABLE READ transactions but perform safety checks

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -44,6 +44,7 @@
 0x_03_04_00_00   CapabilityError
 0x_03_04_01_00   UnsupportedCapabilityError
 0x_03_04_02_00   DisabledCapabilityError
+0x_03_04_03_00   UnsafeIsolationLevelError
 
 
 ####

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -366,6 +366,7 @@ def compile_ast_fragment_to_ir(
         singletons=[],
         triggers=(),
         warnings=tuple(ctx.env.warnings),
+        unsafe_isolation_dangers=tuple(ctx.env.unsafe_isolation_dangers),
     )
 
 

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -308,6 +308,9 @@ class Environment:
     warnings: list[errors.EdgeDBError]
     """List of warnings to emit"""
 
+    unsafe_isolation_dangers: list[errors.UnsafeIsolationLevelError]
+    """List of repeatable read DML dangers"""
+
     def __init__(
         self,
         *,
@@ -358,6 +361,7 @@ class Environment:
         self.path_scope_map = {}
         self.dml_rewrites = {}
         self.warnings = []
+        self.unsafe_isolation_dangers = []
 
     def add_schema_ref(
         self, sobj: s_obj.Object, expr: Optional[qlast.Base]
@@ -835,6 +839,11 @@ class ContextLevel(compiler.ContextLevel):
 
     def log_warning(self, warning: errors.EdgeDBError) -> None:
         self.env.warnings.append(warning)
+
+    def log_repeatable_read_danger(
+        self, d: errors.UnsafeIsolationLevelError
+    ) -> None:
+        self.env.unsafe_isolation_dangers.append(d)
 
     def allow_factoring(self) -> None:
         self.no_factoring = self.warn_factoring = False

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -544,6 +544,9 @@ def compile_InsertQuery(
                 stmt.on_conflict = conflicts.compile_insert_unless_conflict(
                     stmt, stmt_subject_stype, ctx=ictx)
 
+        conflicts.check_for_isolation_conflicts(
+            stmt, stmt_subject_stype, ctx=ictx)
+
         mat_stype = schemactx.get_material_type(stmt_subject_stype, ctx=ctx)
         result = setgen.class_set(
             mat_stype, path_id=stmt.subject.path_id, ctx=ctx
@@ -701,6 +704,9 @@ def compile_UpdateQuery(
                 dtype, result, mode=qltypes.AccessKind.UpdateWrite, ctx=ictx
             ):
                 stmt.write_policies[dtype.id] = write_pol
+
+            conflicts.check_for_isolation_conflicts(
+                stmt, dtype, mat_stype, ctx=ictx)
 
         stmt.conflict_checks = conflicts.compile_inheritance_conflict_checks(
             stmt, mat_stype, ctx=ictx)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -360,6 +360,7 @@ def fini_expression(
         singletons=ctx.env.singletons,
         triggers=ir_triggers,
         warnings=tuple(ctx.env.warnings),
+        unsafe_isolation_dangers=tuple(ctx.env.unsafe_isolation_dangers),
     )
     return result
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -23,6 +23,7 @@ __all__ = base.__all__ + (  # type: ignore
     'CapabilityError',
     'UnsupportedCapabilityError',
     'DisabledCapabilityError',
+    'UnsafeIsolationLevelError',
     'QueryError',
     'InvalidSyntaxError',
     'EdgeQLSyntaxError',
@@ -156,6 +157,10 @@ class UnsupportedCapabilityError(CapabilityError):
 
 class DisabledCapabilityError(CapabilityError):
     _code = 0x_03_04_02_00
+
+
+class UnsafeIsolationLevelError(CapabilityError):
+    _code = 0x_03_04_03_00
 
 
 class QueryError(EdgeDBError):

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -806,6 +806,7 @@ class Statement(Command):
     singletons: list[PathId]
     triggers: tuple[tuple[Trigger, ...], ...]
     warnings: tuple[errors.EdgeDBError, ...]
+    unsafe_isolation_dangers: tuple[errors.UnsafeIsolationLevelError, ...]
 
 
 class TypeIntrospection(ImmutableExpr):

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2189,13 +2189,10 @@ def _compile_ql_transaction(
         # Compute the effective access mode
         access = ql.access
         if access is None:
-            if default_iso is qltypes.TransactionIsolationLevel.SERIALIZABLE:
-                access_mode: statypes.TransactionAccessMode = _get_config_val(
-                    ctx, "default_transaction_access_mode"
-                )
-                access = access_mode.to_qltypes()
-            else:
-                access = qltypes.TransactionAccessMode.READ_ONLY
+            access_mode: statypes.TransactionAccessMode = _get_config_val(
+                ctx, "default_transaction_access_mode"
+            )
+            access = access_mode.to_qltypes()
 
         sqls = f'START TRANSACTION ISOLATION LEVEL {iso.value} {access.value}'
         if ql.deferrable is not None:

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -89,6 +89,9 @@ class BaseQuery:
     warnings: tuple[errors.EdgeDBError, ...] = dataclasses.field(
         kw_only=True, default=()
     )
+    unsafe_isolation_dangers: tuple[errors.UnsafeIsolationLevelError, ...] = (
+        dataclasses.field(kw_only=True, default=())
+    )
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -179,6 +182,8 @@ class TxControlQuery(BaseQuery):
 
     modaliases: Optional[immutables.Map[Optional[str], str]]
 
+    isolation_level: Optional[qltypes.TransactionIsolationLevel] = None
+
     user_schema: Optional[s_schema.Schema] = None
     global_schema: Optional[s_schema.Schema] = None
     cached_reflection: Any = None
@@ -255,6 +260,9 @@ class QueryUnit:
     # starts a new transaction.
     tx_id: Optional[int] = None
 
+    # If this is the start of the transaction, the isolation level of it.
+    tx_isolation_level: Optional[qltypes.TransactionIsolationLevel] = None
+
     # True if this unit is single 'COMMIT' command.
     # 'COMMIT' is always compiled to a separate QueryUnit.
     tx_commit: bool = False
@@ -316,6 +324,7 @@ class QueryUnit:
     server_param_conversions: Optional[list[ServerParamConversion]] = None
 
     warnings: tuple[errors.EdgeDBError, ...] = ()
+    unsafe_isolation_dangers: tuple[errors.UnsafeIsolationLevelError, ...] = ()
 
     # Set only when this unit contains a CONFIGURE INSTANCE command.
     system_config: bool = False
@@ -430,6 +439,9 @@ class QueryUnitGroup:
     unit_converted_param_indexes: Optional[dict[int, list[int]]] = None
 
     warnings: Optional[list[errors.EdgeDBError]] = None
+    unsafe_isolation_dangers: (
+        Optional[list[errors.UnsafeIsolationLevelError]]
+    ) = None
 
     # Cacheable QueryUnit is serialized in the compiler, so that the I/O server
     # doesn't need to serialize it again for persistence.
@@ -522,6 +534,11 @@ class QueryUnitGroup:
             if self.warnings is None:
                 self.warnings = []
             self.warnings.extend(query_unit.warnings)
+        if query_unit.unsafe_isolation_dangers is not None:
+            if self.unsafe_isolation_dangers is None:
+                self.unsafe_isolation_dangers = []
+            self.unsafe_isolation_dangers.extend(
+                query_unit.unsafe_isolation_dangers)
 
         if not serialize or query_unit.cache_sql is None:
             self._units.append(query_unit)

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -178,6 +178,7 @@ cdef class DatabaseConnectionView:
         bint _in_tx_with_set
         bint _tx_error
         uint64_t _in_tx_seq
+        object _in_tx_isolation_level
 
         uint64_t _capability_mask
 
@@ -256,4 +257,5 @@ cdef class DatabaseConnectionView:
         allowed_capabilities,
         error_constructor,
         reason,
+        unsafe_isolation_dangers,
     )

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -194,6 +194,7 @@ async def execute(db, tenant, queries: list):
                         ALLOWED_CAPABILITIES,
                         errors.UnsupportedCapabilityError,
                         "disallowed in notebook",
+                        query_unit_group.unsafe_isolation_dangers,
                     )
                     try:
                         if query_unit.in_type_args:

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -265,3 +265,12 @@ type ExceptTest {
     constraint exclusive on (.name) except (.deleted);
 };
 type ExceptTestSub extending ExceptTest;
+
+type ConflictA {
+  name: str;
+}
+type ConflictB {
+  name: str { constraint exclusive };
+  whatever: str;
+}
+type ConflictAB extending ConflictA, ConflictB;

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -7947,3 +7947,125 @@ class TestInsert(tb.DDLTestCase):
             """,
             [{'l2': 0, 'subordinates': [{'name': 'hi', '@comment': 'a'}]}],
         )
+
+
+class TestRepeatableReadInsert(tb.QueryTestCase):
+    '''The scope of the tests is testing various modes of Object creation.'''
+    NO_FACTOR = True
+    INTERNAL_TESTMODE = False
+
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
+                          'insert.esdl')
+
+    # Override setUp and tearDown to we run in RepeatableRead mode
+    def setUp(self):
+        self.loop.run_until_complete(
+            self.con.execute(
+                "configure session set default_transaction_isolation := "
+                "'RepeatableRead'"
+            )
+        )
+
+        super().setUp()
+
+    def tearDown(self):
+        super().tearDown()
+
+        self.loop.run_until_complete(
+            self.con.execute(
+                "configure session reset default_transaction_isolation"
+            )
+        )
+
+    async def test_edgeql_rr_insert_01(self):
+        # insert on A is ok, since A itself has no conflicts
+        await self.con.execute("""
+            insert ConflictA {
+                name := "test"
+            };
+        """)
+
+    async def test_edgeql_rr_insert_02(self):
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            "INSERT to object type 'default::ConflictB' affects an "
+            "exclusive constraint on property 'name' of object type "
+            "'default::ConflictB' that is shared with descendant types: "
+            "'default::ConflictAB'"
+        ):
+            await self.con.execute("""
+                insert ConflictB {
+                    name := "test"
+                };
+            """)
+
+    async def test_edgeql_rr_insert_03(self):
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            "INSERT to object type 'default::ConflictAB' affects an "
+            "exclusive constraint on property 'name' of object type "
+            "'default::ConflictAB' that is defined in ancestor object "
+            "type 'default::ConflictB'"
+        ):
+            await self.con.execute("""
+                insert ConflictAB {
+                    name := "test"
+                };
+            """)
+
+    async def test_edgeql_rr_insert_04(self):
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            r"an exclusive constraint on object type 'default::Person2a' "
+            r"with expression '\(\.first, \.bff\)'"
+        ):
+            await self.con.execute("""
+                INSERT Person2a {
+                    first := "Emmanuel",
+                    last := "Villip",
+                }
+            """)
+
+    async def test_edgeql_rr_update_01(self):
+        # *update* on A is not ok, since it hits AB which has a constraint
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            # XXX: Should this be ConflictA
+            "UPDATE to object type 'default::ConflictAB' affects an "
+            "exclusive constraint on property 'name' of object type "
+            "'default::ConflictAB' that is defined in ancestor object "
+            "type 'default::ConflictB'"
+        ):
+            await self.con.execute("""
+                update ConflictA set {
+                    name := "test"
+                };
+            """)
+
+    async def test_edgeql_rr_update_02(self):
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            "UPDATE to object type 'default::ConflictB' affects an "
+            "exclusive constraint on property 'name' of object type "
+            "'default::ConflictB' that is shared with descendant types: "
+            "'default::ConflictAB'"
+        ):
+            await self.con.execute("""
+                update ConflictB set {
+                    name := "test"
+                };
+            """)
+
+    async def test_edgeql_rr_update_03(self):
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            "UPDATE to object type 'default::ConflictAB' affects an "
+            "exclusive constraint on property 'name' of object type "
+            "'default::ConflictAB' that is defined in ancestor object "
+            "type 'default::ConflictB'"
+        ):
+            await self.con.execute("""
+                update ConflictAB set {
+                    name := "test"
+                };
+            """)

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -44,6 +44,14 @@ class TestServerProto(tb.QueryTestCase):
             CREATE REQUIRED PROPERTY tmp -> std::str;
         };
 
+        CREATE TYPE Parent {
+            CREATE REQUIRED PROPERTY tmp -> std::str {
+                CREATE CONSTRAINT exclusive;
+            }
+        };
+        CREATE TYPE Child EXTENDING Parent;
+
+
         CREATE MODULE test;
         CREATE TYPE test::Tmp2 {
             CREATE REQUIRED PROPERTY tmp -> std::str;
@@ -1596,12 +1604,9 @@ class TestServerProto(tb.QueryTestCase):
 
     async def test_server_proto_tx_09(self):
         try:
-            with self.assertRaisesRegex(
-                    edgedb.TransactionError,
-                    'only supported in read-only transactions'):
-                await self.con.query('''
-                    START TRANSACTION ISOLATION REPEATABLE READ;
-                ''')
+            await self.con.query('''
+                START TRANSACTION ISOLATION REPEATABLE READ;
+            ''')
         finally:
             await self.con.query(f'''
                 ROLLBACK;
@@ -2109,6 +2114,27 @@ class TestServerProto(tb.QueryTestCase):
                 };
             ''')
 
+    async def assert_no_isolation_dangers(self):
+        with self.assertRaisesRegex(
+            edgedb.CapabilityError,
+            "with transaction isolation level REPEATABLE READ",
+        ):
+            await self.con.query('''
+                INSERT Parent {
+                    tmp := 'aaa'
+                };
+            ''')
+        if not self.con.is_in_transaction():
+            with self.assertRaisesRegex(
+                edgedb.CapabilityError,
+                "with transaction isolation level REPEATABLE READ",
+            ):
+                await self.con.query('''
+                    INSERT Child {
+                        tmp := 'aaa'
+                    };
+                ''')
+
     async def test_server_proto_tx_23(self):
         # Test that default_transaction_isolation is respected
 
@@ -2134,10 +2160,7 @@ class TestServerProto(tb.QueryTestCase):
         ''')
 
         try:
-            await self.assert_read_only_and_default(
-                "cannot execute.*RepeatableRead",
-                default='ReadWrite',
-            )
+            await self.assert_no_isolation_dangers()
         finally:
             await self.con.query('''
                 CONFIGURE SESSION
@@ -2161,10 +2184,7 @@ class TestServerProto(tb.QueryTestCase):
                     SET default_transaction_access_mode := 'ReadWrite';
             ''')
 
-            await self.assert_read_only_and_default(
-                "cannot execute.*RepeatableRead",
-                default='ReadWrite',
-            )
+            await self.assert_no_isolation_dangers()
         finally:
             await self.con.query('''
                 CONFIGURE SESSION
@@ -2290,13 +2310,11 @@ class TestServerProto(tb.QueryTestCase):
                 CONFIGURE SESSION
                     SET default_transaction_isolation := 'RepeatableRead';
             ''')
-            with self.assertRaisesRegex(
-                edgedb.TransactionError,
-                'only supported in read-only transactions',
-            ):
-                await self.con.query('''
-                    START TRANSACTION READ WRITE;
-                ''')
+            await self.con.query('''
+                START TRANSACTION READ WRITE;
+            ''')
+
+            await self.assert_no_isolation_dangers()
 
         finally:
             await self.con.query(f'''

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2248,7 +2248,8 @@ class TestServerProto(tb.QueryTestCase):
             [42])
 
     async def test_server_proto_tx_28(self):
-        # Test that non-serializable START TRANSACTION enforces read-only
+        # Test that non-serializable START TRANSACTION does *not*
+        # enforce read-only, because we changed that behavior.
 
         try:
             await self.con.query('''
@@ -2259,9 +2260,7 @@ class TestServerProto(tb.QueryTestCase):
                 START TRANSACTION;
             ''')
 
-            await self.assert_read_only_and_default(
-                'read-only transaction', default='ReadWrite'
-            )
+            await self.assert_no_isolation_dangers()
         finally:
             await self.con.query(f'''
                 ROLLBACK;


### PR DESCRIPTION
- In conflicts.py, implement analysis for what inserts and updates
   affect a cross-table constraint
 - Plumb that information out into the QueryUnit and to the server
 - Report the conflicts as part of CommandDataDescription in an
   annotation called `unsafe_isolation_dangers`, so clients can
   potentially make proactive decisions.
 - Raise an error when attempting to execute something with isolation
   dangers in REPEATABLE READ mode.

There are still a few follow-ups before I can merge, but this is
reviewable now:
 - [x] Write tests
 - [x] Follow-up on some possible bugs I found in the conflict mechanism
       that might have wider scope once this is implemented.
 - [x] Improve some documentation

Advances #8458.