### PR TITLE
Fix regression in debug dumping of spans

### DIFF
--- a/edb/common/span.py
+++ b/edb/common/span.py
@@ -138,8 +138,8 @@ class Span(markup.MarkupExceptionContext):
 
         endcol = end.column if start.line == end.line else None
         tbp = me.lang.TracebackPoint(
-            name=self.name,
-            filename=self.name,
+            name=self.filename,
+            filename=self.filename,
             lineno=start.line,
             colno=start.column,
             end_colno=endcol,


### PR DESCRIPTION
PR #8538 rationalized the names of fields in spans, but this broke its
implementation of `as_markup`, which wasn't updated.
This code isn't really typechecked, apparently, and the failure is expressed only as
```
Exception during serialization to markup: <builtins.AttributeError: 'Span' object has no attribute 'name'>
```
being spewed when errors are printed to the server log, so no tests
failed and the server still worked.