### PR TITLE
Fix backlinks in computeds over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/expr.py
+++ b/edb/pgsql/resolver/expr.py
@@ -244,11 +244,18 @@ def resolve_column_kind(
             compiled = expr.compiled(ctx.schema, options=options, context=None)
 
             subject_rel = pgast.Relation(name=table.reference_as)
-            subject_rel.path_outputs = {
-                (source_id, pgce.PathAspect.IDENTITY): pgast.ColumnRef(
-                    name=('source',)
-                )
-            }
+            if isinstance(source, s_types.Type):
+                subject_rel.path_outputs = {
+                    (source_id, pgce.PathAspect.IDENTITY): pgast.ColumnRef(
+                        name=('id',)
+                    )
+                }
+            else:
+                subject_rel.path_outputs = {
+                    (source_id, pgce.PathAspect.IDENTITY): pgast.ColumnRef(
+                        name=('source',)
+                    )
+                }
             subject_rel_var = pgast.RelRangeVar(
                 alias=pgast.Alias(aliasname=table.reference_as),
                 relation=subject_rel,

--- a/tests/schemas/movies.esdl
+++ b/tests/schemas/movies.esdl
@@ -24,6 +24,7 @@ type Person {
 
     full_name := __source__.first_name ++ ((' ' ++ .last_name) ?? '');
     favorite_genre := (select Genre filter .name = 'Drama' limit 1);
+    directed_movie := (select .<director[is Movie] limit 1);
     username := (global username_prefix ?? 'u_') ++ str_lower(.first_name);
 }
 

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1285,11 +1285,12 @@ class TestSQLQuery(tb.SQLQueryTestCase):
                 ['Movie.director', 'bar', 'YES', 3],
                 ['Person', 'id', 'NO', 1],
                 ['Person', '__type__', 'NO', 2],
-                ['Person', 'favorite_genre_id', 'YES', 3],
-                ['Person', 'first_name', 'NO', 4],
-                ['Person', 'full_name', 'NO', 5],
-                ['Person', 'last_name', 'YES', 6],
-                ['Person', 'username', 'NO', 7],
+                ['Person', 'directed_movie_id', 'YES', 3],
+                ['Person', 'favorite_genre_id', 'YES', 4],
+                ['Person', 'first_name', 'NO', 5],
+                ['Person', 'full_name', 'NO', 6],
+                ['Person', 'last_name', 'YES', 7],
+                ['Person', 'username', 'NO', 8],
                 ['novel', 'id', 'NO', 1],
                 ['novel', '__type__', 'NO', 2],
                 ['novel', 'foo', 'YES', 3],
@@ -2285,6 +2286,19 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         self.assertEqual(await query_glob_bool("'ON'"), True)
         self.assertEqual(await query_glob_bool("'OFF'"), False)
         self.assertEqual(await query_glob_bool("'HELLO'"), None)
+
+    async def test_sql_query_computed_14(self):
+        # single link, using a backlink
+
+        res = await self.squery_values(
+            """
+            SELECT first_name, directed_movie_id IS NOT NULL FROM "Person"
+            ORDER BY first_name
+            """
+        )
+        self.assertEqual(
+            res, [["Robin", False], ["Steven", True], ["Tom", False]]
+        )
 
     async def test_sql_query_access_policy_01(self):
         # no access policies


### PR DESCRIPTION
Closes https://github.com/geldata/gel/issues/8284

When compiling expressions of computed pointers
for SQL adapter, we provide it with an external
rvars of the current table.

We manually populate path_namespace which can be
used by the pgcompiler. For link tables, we
provide column `source` and for object type tables
we should have provided `id`.

But we didn't, which only broke when compiling
computeds that contained backlinks.
