### PR TITLE
Pin calver to 2025.03.31

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     'aiosmtplib~=3.0',
     'tiktoken~=0.7.0',
     'mistral_common~=1.2.1',
+
+    # pin because newer versions are either broken or require
+    # us to update setuptools (in gel-pkg)
+    'calver==2025.03.31',
 ]
 
 [project.scripts]


### PR DESCRIPTION
calver 2025.04.01 is broken (pyproject license)
calver 2025.04.02 requires a new version of setuptools, which are hard to upgrade. We are currently pinned on <70.2. I've tried updating that: https://github.com/geldata/gel-pkg/pull/152

Ref: https://github.com/geldata/gel-pkg/issues/153