### PR TITLE
Fix access policies SELECT issue with diamond-pattern inheritance

### DIFF
--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -302,13 +302,13 @@ def try_type_rewrite(
     # TODO: caching?
     children_overlap = False
     if children_have_policies:
-        all_descs = [
+        all_child_descs = [
             x
             for child in stype.children(schema)
             for x in child.descendants(schema)
         ]
-        descs = set(all_descs)
-        if len(descs) != len(all_descs):
+        child_descs = set(all_child_descs)
+        if len(child_descs) != len(all_child_descs):
             children_overlap = True
 
     # Put a placeholder to prevent recursion.
@@ -355,7 +355,11 @@ def try_type_rewrite(
     if children_have_policies and not skip_subtypes:
         # N.B: we don't filter here, we just generate references
         # they will go in their own CTEs
-        children = stype.children(schema) if not children_overlap else descs
+        children = (
+            stype.children(schema)
+            if not children_overlap
+            else stype.descendants(schema)
+        )
         sets += [
             # We need to wrap it in a type override so that unioning
             # them all together works...

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -1350,3 +1350,25 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             ''',
             [{"s": [], "foo": None}]
         )
+
+    async def test_edgeql_policies_diamond_01(self):
+        # Verify that selecting a type with overlapping children and
+        # access policies in at least one child works
+
+        await self.con.execute('''
+            create type Base;
+            create type A extending Base;
+            create type B extending Base;
+            create type AB extending A, B;
+            create type T extending Base {
+                create access policy ok allow all;
+            };
+            insert T;
+        ''')
+
+        await self.assert_query_result(
+            r'''
+            select Base
+            ''',
+            [{}]
+        )


### PR DESCRIPTION
When a select of a type that had access policies on some descendants had
overlapping descendants, this was handled incorrectly, and direct children
were skipped when computing what to select from.

Easy fix.