### PR TITLE
Fix MacOS build by installing sentencepiece

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -149,7 +149,7 @@
     - name: Install dependencies
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -149,7 +149,8 @@
     - name: Install dependencies
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1152,7 +1152,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:
@@ -1224,7 +1224,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1152,7 +1152,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:
@@ -1224,7 +1225,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1157,7 +1157,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:
@@ -1229,7 +1230,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1157,7 +1157,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:
@@ -1229,7 +1229,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,7 +527,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:
@@ -597,7 +597,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,7 +527,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:
@@ -597,7 +598,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -547,7 +547,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:
@@ -618,7 +619,8 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
+        libmagic sentencepiece protobuf
 
     - name: Build
       env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -547,7 +547,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:
@@ -618,7 +618,7 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic sentencepiece
 
     - name: Build
       env:


### PR DESCRIPTION
It started failing recently with the following
error message:

```
Package sentencepiece was not found in the pkg-config search path.
Perhaps you should add the directory containing `sentencepiece.pc'
to the PKG_CONFIG_PATH environment variable
Package 'sentencepiece' not found
CMake Error at CMakeLists.txt:15 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Configuring incomplete, errors occurred!
./build_bundled.sh: line 22: nproc: command not found
Error: could not find CMAKE_PROJECT_NAME in Cache
```

If missing sentencepiece is the problem, installing
it with brew should fix the build.
