### PR TITLE
Fix dropping types in some situations where the type is used in a function

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1171,6 +1171,8 @@ class FunctionCommand(MetaCommand):
                 for ptr in ctx.op.scls.get_pointers(schema).objects(schema):
                     schema = schema.delete(ptr)
                 schema = schema.delete(ctx.op.scls)
+            elif isinstance(ctx.op, s_pointers.DeletePointer):
+                schema = schema.delete(ctx.op.scls)
 
         return s_funcs.compile_function(
             schema,

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1166,6 +1166,10 @@ class FunctionCommand(MetaCommand):
         # be deleted from the schema.
         for ctx in context.stack:
             if isinstance(ctx.op, s_objtypes.DeleteObjectType):
+                # Also get the pointers, since we look at pointer descendents.
+                # This is really all a pretty bad hack.
+                for ptr in ctx.op.scls.get_pointers(schema).objects(schema):
+                    schema = schema.delete(ptr)
                 schema = schema.delete(ctx.op.scls)
 
         return s_funcs.compile_function(

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5241,6 +5241,24 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                 };
             ''')
 
+    async def test_edgeql_ddl_function_42(self):
+        await self.con.execute("""
+            create abstract type Named {
+                create required property name: str;
+            };
+            create function all_names() -> SET OF str {
+                USING (Named.name)
+            };
+            create type Z extending Named {
+                create access policy ok allow all;
+            };
+            create type T;
+        """)
+
+        await self.con.execute("""
+            drop type Z;
+        """)
+
     async def test_edgeql_ddl_function_inh_01(self):
         await self.con.execute("""
             create abstract type T;

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -1372,3 +1372,7 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             ''',
             [{}]
         )
+
+        await self.con.execute('''
+            drop type T
+        ''')


### PR DESCRIPTION
This path is kind of hacky already, and it temporarily forcibly drops
types being deleted while recompiling the function itself. Push the
hack a bit further and drop pointers too, since we look at pointer
descendents in many cases also.