### PR TITLE
Fix removal of path factoring breaking ai embedding views.

### DIFF
--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -1023,7 +1023,8 @@ async def _update_embeddings_in_db(
     embeddings: bytes,
     offset: int,
 ) -> int:
-    id_array = '", "'.join(id.hex for id in ids)
+
+    id_array = '{' + ', '.join(f'"{id.hex}"' for id in ids) + '}'
     entries = await pgconn.sql_fetch_val(
         f"""
         WITH upd AS (
@@ -1056,7 +1057,7 @@ async def _update_embeddings_in_db(
         """.encode(),
         args=(
             embeddings,
-            f'{{"{id_array}"}}'.encode(),
+            id_array.encode(),
             str(offset).encode(),
         ),
         tx_isolation=edbdef.TxIsolationLevel.RepeatableRead,


### PR DESCRIPTION
The embeddings source views were previously implemented as
```
SELECT (
    Object.id,
    eval(get_index_expr(Object, 'ext::ai::index')),
)
WHERE
    ... # some conditions
```

However, with the removal of path factoring, this resulted in the tuple becoming a cross join between the object id and index.

This PR updates the source views to be
```
FOR obj in Object (
    SELECT (
        obj.id,
        eval(get_index_expr(obj, 'ext::ai::index')),
    WHERE
        ... # some conditions
)
```