### PR TITLE
Redirect a few categories of links

### DIFF
--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -51,6 +51,37 @@ module.exports = [
     permanent: false,
   },
   {
+    source: "/reference/libraries/dotnet/:path*",
+    destination: "https://github.com/geldata/gel-net",
+    permanent: false,
+  },
+  {
+    source: "/reference/libraries/elixir/:path*",
+    destination: "https://hexdocs.pm/gel",
+    permanent: false,
+  },
+  {
+    source: "/reference/libraries/java/:path*",
+    destination: "https://github.com/geldata/gel-java",
+    permanent: false,
+  },
+  // Use the further redirects to get to the correct point in the consolidated docs
+  {
+    source: "/reference/libraries/js/:path*",
+    destination: "/reference/clients/js/:path*",
+    permanent: false,
+  },
+  {
+    source: "/reference/libraries/python/:path*",
+    destination: "/reference/clients/python/:path*",
+    permanent: false,
+  },
+  {
+    source: "/reference/libraries/:path*",
+    destination: "/reference/using",
+    permanent: false,
+  },
+  {
     source: "/reference/clients/js/delete#delete",
     destination: "/reference/using/js/querybuilder",
     permanent: false,

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -1,6 +1,11 @@
 // See https://nextjs.org/docs/app/api-reference/config/next-config-js/redirects
 module.exports = [
   {
+    source: "/changelog/:path*",
+    destination: "/resources/changelog/:path*",
+    permanent: false,
+  },
+  {
     source: "/guides/cheatsheet/:path*",
     destination: "/resources/cheatsheets/:path*",
     permanent: true,

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -203,7 +203,7 @@ module.exports = [
   },
   {
     source: "/reference/reference/environment",
-    destination: "/reference/running/environment",
+    destination: "/reference/running/configuration#environment-variables",
     permanent: false,
   },
   {


### PR DESCRIPTION
- Changelogs are now in `/resources/changelog`
- Client library references are now in `/reference/using` and a few of them should now point to the canonical external documentation site
- The path to the environment variables was incorrectly set in a past redirect