### PR TITLE
Cleanup a hack for DML on inherited links over SQL adapter

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -599,8 +599,6 @@ class UpdateQuery(Query):
 
     where: typing.Optional[Expr] = None
 
-    sql_mode_link_only: bool = False
-
 
 class DeleteQuery(Query):
     subject: Expr

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -621,10 +621,7 @@ def compile_UpdateQuery(
     ctx.env.dml_exprs.append(expr)
 
     with ctx.subquery() as ictx:
-        stmt = irast.UpdateStmt(
-            span=expr.span,
-            sql_mode_link_only=expr.sql_mode_link_only,
-        )
+        stmt = irast.UpdateStmt(span=expr.span)
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
         with ictx.new() as ectx:
@@ -680,12 +677,6 @@ def compile_UpdateQuery(
                 ctx=bodyctx,
                 span=expr.span,
             )
-            # If we are doing a SQL-mode link only update (that is,
-            # we are doing a SQL INSERT or DELETE to a link table),
-            # disable rewrites.
-            # HACK: This is a really ass-backwards way to accomplish that.
-            if stmt.sql_mode_link_only:
-                ctx.env.dml_rewrites.pop(stmt.subject, None)
 
         result = setgen.class_set(
             mat_stype, path_id=stmt.subject.path_id, ctx=ctx,

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1315,8 +1315,6 @@ class UpdateStmt(MutatingStmt, FilteredStmt):
         assert self._material_type
         return self._material_type
 
-    sql_mode_link_only: bool = False
-
 
 class DeleteStmt(MutatingStmt, FilteredStmt):
     _material_type: TypeRef | None = None

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -1908,9 +1908,10 @@ def process_update_rewrites(
         )
 
         # pull in table_relation for __old__
-        table_rel.path_outputs[
-            (old_path_id, pgce.PathAspect.VALUE)
-        ] = table_rel.path_outputs[(subject_path_id, pgce.PathAspect.VALUE)]
+        subject_value = pathctx.get_path_value_output(
+            table_rel, subject_path_id, env=ctx.env
+        )
+        pathctx.put_path_value_var(table_rel, old_path_id, subject_value)
         relctx.include_rvar(
             rewrites_stmt, table_relation, old_path_id, ctx=ctx
         )

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -245,12 +245,12 @@ def gen_dml_cte(
     ctx: context.CompilerContextLevel,
 ) -> tuple[pgast.CommonTableExpr, pgast.PathRangeVar]:
 
-    target_ir_set = ir_stmt.subject
-    target_path_id = target_ir_set.path_id
+    subject_ir_set = ir_stmt.subject
+    subject_path_id = subject_ir_set.path_id
 
     relation = relctx.range_for_typeref(
         typeref,
-        target_path_id,
+        subject_path_id,
         for_mutation=True,
         ctx=ctx,
     )
@@ -273,12 +273,20 @@ def gen_dml_cte(
     else:
         raise AssertionError(f'unexpected DML IR: {ir_stmt!r}')
 
-    pathctx.put_path_value_rvar(dml_stmt, target_path_id, relation)
-    pathctx.put_path_source_rvar(dml_stmt, target_path_id, relation)
+    subject_rvar: pgast.PathRangeVar
+    if isinstance(ir_stmt, irast.UpdateStmt):
+        assert range_rvar is not None
+        subject_rvar = range_rvar
+    else:
+        subject_rvar = relation
+
+    pathctx.put_path_value_rvar(dml_stmt, subject_path_id, subject_rvar)
+    pathctx.put_path_source_rvar(dml_stmt, subject_path_id, subject_rvar)
+
     # Skip the path bond for inserts, since it doesn't help and
     # interferes when inserting in an UNLESS CONFLICT ELSE
     if not isinstance(ir_stmt, irast.InsertStmt):
-        pathctx.put_path_bond(dml_stmt, target_path_id)
+        pathctx.put_path_bond(dml_stmt, subject_path_id)
 
     dml_cte = pgast.CommonTableExpr(
         query=dml_stmt,
@@ -293,32 +301,59 @@ def gen_dml_cte(
     # need them.
     ctx.path_scope.maps.clear()
 
-    skip_rel = (
-        isinstance(ir_stmt, irast.UpdateStmt) and ir_stmt.sql_mode_link_only
-    )
-
     if range_rvar is not None:
-        relctx.pull_path_namespace(
-            target=dml_stmt, source=range_rvar, ctx=ctx)
-
-        # Auxiliary relations are always joined via the WHERE
-        # clause due to the structure of the UPDATE/DELETE SQL statements.
         assert isinstance(dml_stmt, (pgast.SelectStmt, pgast.DeleteStmt))
-        if not skip_rel:
+
+        relctx.pull_path_namespace(
+            target=dml_stmt, source=range_rvar, ctx=ctx
+        )
+
+        if isinstance(dml_stmt, pgast.DeleteStmt):
+            # Limit DELETE on rows produced by range CTE
             dml_stmt.where_clause = astutils.new_binop(
-                lexpr=pgast.ColumnRef(name=[
-                    relation.alias.aliasname, 'id'
-                ]),
+                lexpr=pgast.ColumnRef(name=[relation.alias.aliasname, 'id']),
                 op='=',
                 rexpr=pathctx.get_rvar_path_identity_var(
-                    range_rvar, target_ir_set.path_id, env=ctx.env)
+                    range_rvar, subject_ir_set.path_id, env=ctx.env
+                )
             )
+        else:
+            # For SELECT (irast.UpdateStmt) we filter the range CTE to only
+            # the actual type of the object we are updating
+            # (this makes a difference when updating objects with subtypes)
+
+            # Make up a ptrref for the __type__ link on our actual target type
+            # and make up a new path_id to access it.
+            el_name = sn.QualName('__', '__type__')
+            # std_type = ctx.env.sc
+            actual_type_ptrref = irast.SpecialPointerRef(
+                name=el_name,
+                shortname=el_name,
+                out_source=ir_stmt.subject.typeref,
+                # HACK: This is obviously not the right target type, but we
+                # don't need it for anything and the pathid never escapes this
+                # function.
+                out_target=typeref,
+                out_cardinality=qltypes.Cardinality.AT_MOST_ONE,
+            )
+            type_pathid = subject_path_id.extend(ptrref=actual_type_ptrref)
+
+            dml_stmt.where_clause = astutils.new_binop(
+                lexpr=dispatch.compile(typeref, ctx=ctx),
+                op='=',
+                rexpr=pathctx.get_rvar_path_identity_var(
+                    range_rvar, type_pathid, env=ctx.env
+                )
+            )
+
         # Do any read-side filtering
         if pol_expr := ir_stmt.read_policies.get(typeref.id):
             with ctx.newrel() as sctx:
-                pathctx.put_path_value_rvar(sctx.rel, target_path_id, relation)
+                pathctx.put_path_value_rvar(
+                    sctx.rel, subject_path_id, subject_rvar
+                )
                 pathctx.put_path_source_rvar(
-                    sctx.rel, target_path_id, relation
+                    sctx.rel, subject_path_id, subject_rvar
                 )
 
                 val = clauses.compile_filter_clause(
@@ -331,8 +366,6 @@ def gen_dml_cte(
 
         # SELECT has "FROM", while DELETE has "USING".
         if isinstance(dml_stmt, pgast.SelectStmt):
-            if not skip_rel:
-                dml_stmt.from_clause.append(relation)
             dml_stmt.from_clause.append(range_rvar)
         elif isinstance(dml_stmt, pgast.DeleteStmt):
             dml_stmt.using_clause.append(range_rvar)
@@ -539,6 +572,8 @@ def get_dml_range(
 
         range_stmt.path_id_mask.discard(target_ir_set.path_id)
         pathctx.put_path_bond(range_stmt, target_ir_set.path_id)
+
+        relgen.ensure_source_rvar(target_ir_set, range_stmt, ctx=subctx)
 
         range_cte = pgast.CommonTableExpr(
             query=range_stmt,
@@ -1747,9 +1782,15 @@ def process_update_body(
             ctx.env.check_ctes.append(check_cte)
 
     if not no_update:
-        table_relation = contents_select.from_clause[0]
+        table_relation = relctx.range_for_typeref(
+            typeref,
+            ir_stmt.subject.path_id,
+            for_mutation=True,
+            ctx=ctx,
+        )
         assert isinstance(table_relation, pgast.RelRangeVar)
-        range_relation = contents_select.from_clause[1]
+
+        range_relation = contents_select.from_clause[0]
         assert isinstance(range_relation, pgast.PathRangeVar)
 
         contents_rvar = relctx.rvar_for_rel(contents_cte, ctx=ctx)
@@ -1908,7 +1949,9 @@ def process_update_rewrites(
         # pull in table_relation for __old__
         table_rel.path_outputs[
             (old_path_id, pgce.PathAspect.VALUE)
-        ] = table_rel.path_outputs[(subject_path_id, pgce.PathAspect.VALUE)]
+        ] = pathctx.get_path_value_output(
+            table_rel, subject_path_id, env=ctx.env
+        )
         relctx.include_rvar(
             rewrites_stmt, table_relation, old_path_id, ctx=ctx
         )
@@ -2090,7 +2133,9 @@ def process_update_shape(
                     val = pgast.FuncCall(
                         name=("nullif",),
                         args=[
-                            pgast.ColumnRef(name=[ptr_info.column_name]),
+                            pathctx.get_path_value_var(
+                                rel, element.path_id, env=ctx.env
+                            ),
                             val,
                         ],
                     )
@@ -2109,7 +2154,7 @@ def process_update_shape(
                 # it.
                 # XXX: Maybe this suggests a rework of the
                 # DynamicRangeVar mechanism would be a good idea.
-                pathctx.put_path_var(
+                pathctx.put_path_var_if_not_exists(
                     rel,
                     element.path_id,
                     aspect=pgce.PathAspect.VALUE,

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -248,19 +248,22 @@ def gen_dml_cte(
     subject_ir_set = ir_stmt.subject
     subject_path_id = subject_ir_set.path_id
 
-    relation = relctx.range_for_typeref(
-        typeref,
-        subject_path_id,
-        for_mutation=True,
-        ctx=ctx,
-    )
-    assert isinstance(relation, pgast.RelRangeVar), (
-        "spurious overlay on DML target"
-    )
-
     dml_stmt: pgast.InsertStmt | pgast.SelectStmt | pgast.DeleteStmt
+    subject_rvar: pgast.BaseRangeVar
     if isinstance(ir_stmt, irast.InsertStmt):
+        relation = relctx.range_for_typeref(
+            typeref,
+            subject_path_id,
+            for_mutation=True,
+            ctx=ctx,
+        )
+        assert isinstance(relation, pgast.RelRangeVar), (
+            "spurious overlay on DML target"
+        )
+
         dml_stmt = pgast.InsertStmt(relation=relation)
+        subject_rvar = relation
+
     elif isinstance(ir_stmt, irast.UpdateStmt):
         # We generate a Select as the initial statement for an update,
         # since the contents select is the query that needs to join
@@ -268,13 +271,38 @@ def gen_dml_cte(
         # sometimes end up not needing an UPDATE anyway (if it only
         # touches link tables).
         dml_stmt = pgast.SelectStmt()
+
+        subject_rel_overlayed = relctx.range_for_typeref(
+            typeref,
+            subject_path_id,
+            for_mutation=False,
+            include_descendants=False,
+            dml_source=[
+                k for k in ctx.dml_stmts.keys()
+                if isinstance(k, irast.MutatingLikeStmt)
+            ],
+            ctx=ctx,
+        )
+        dml_stmt.from_clause.append(subject_rel_overlayed)
+        subject_rvar = subject_rel_overlayed
+
     elif isinstance(ir_stmt, irast.DeleteStmt):
+        relation = relctx.range_for_typeref(
+            typeref,
+            subject_path_id,
+            for_mutation=True,
+            ctx=ctx,
+        )
+        assert isinstance(relation, pgast.RelRangeVar), (
+            "spurious overlay on DML target"
+        )
         dml_stmt = pgast.DeleteStmt(relation=relation)
+        subject_rvar = relation
     else:
         raise AssertionError(f'unexpected DML IR: {ir_stmt!r}')
 
-    pathctx.put_path_value_rvar(dml_stmt, subject_path_id, relation)
-    pathctx.put_path_source_rvar(dml_stmt, subject_path_id, relation)
+    pathctx.put_path_value_rvar(dml_stmt, subject_path_id, subject_rvar)
+    pathctx.put_path_source_rvar(dml_stmt, subject_path_id, subject_rvar)
     # Skip the path bond for inserts, since it doesn't help and
     # interferes when inserting in an UNLESS CONFLICT ELSE
     if not isinstance(ir_stmt, irast.InsertStmt):
@@ -306,25 +334,27 @@ def gen_dml_cte(
         assert isinstance(dml_stmt, (pgast.SelectStmt, pgast.DeleteStmt))
         if not skip_rel:
             dml_stmt.where_clause = astutils.new_binop(
-                lexpr=pgast.ColumnRef(name=[
-                    relation.alias.aliasname, 'id'
-                ]),
+                lexpr=pathctx.get_rvar_path_identity_var(
+                    subject_rvar, subject_path_id, env=ctx.env
+                ),
                 op='=',
                 rexpr=pathctx.get_rvar_path_identity_var(
-                    range_rvar, subject_ir_set.path_id, env=ctx.env)
+                    range_rvar, subject_path_id, env=ctx.env
+                )
             )
         # Do any read-side filtering
         if pol_expr := ir_stmt.read_policies.get(typeref.id):
             with ctx.newrel() as sctx:
                 pathctx.put_path_value_rvar(
-                    sctx.rel, subject_path_id, relation
+                    sctx.rel, subject_path_id, subject_rvar
                 )
                 pathctx.put_path_source_rvar(
-                    sctx.rel, subject_path_id, relation
+                    sctx.rel, subject_path_id, subject_rvar
                 )
 
                 val = clauses.compile_filter_clause(
-                    pol_expr.expr, pol_expr.cardinality, ctx=sctx)
+                    pol_expr.expr, pol_expr.cardinality, ctx=sctx
+                )
             sctx.rel.target_list.append(pgast.ResTarget(val=val))
 
             dml_stmt.where_clause = astutils.extend_binop(
@@ -333,8 +363,6 @@ def gen_dml_cte(
 
         # SELECT has "FROM", while DELETE has "USING".
         if isinstance(dml_stmt, pgast.SelectStmt):
-            if not skip_rel:
-                dml_stmt.from_clause.append(relation)
             dml_stmt.from_clause.append(range_rvar)
         elif isinstance(dml_stmt, pgast.DeleteStmt):
             dml_stmt.using_clause.append(range_rvar)
@@ -1749,7 +1777,12 @@ def process_update_body(
             ctx.env.check_ctes.append(check_cte)
 
     if not no_update:
-        table_relation = contents_select.from_clause[0]
+        table_relation = relctx.range_for_typeref(
+            typeref,
+            ir_stmt.subject.path_id,
+            for_mutation=True,
+            ctx=ctx,
+        )
         assert isinstance(table_relation, pgast.RelRangeVar)
         range_relation = contents_select.from_clause[1]
         assert isinstance(range_relation, pgast.PathRangeVar)
@@ -1908,10 +1941,11 @@ def process_update_rewrites(
         )
 
         # pull in table_relation for __old__
-        subject_value = pathctx.get_path_value_output(
+        table_rel.path_outputs[
+            (old_path_id, pgce.PathAspect.VALUE)
+        ] = pathctx.get_path_value_output(
             table_rel, subject_path_id, env=ctx.env
         )
-        pathctx.put_path_value_var(table_rel, old_path_id, subject_value)
         relctx.include_rvar(
             rewrites_stmt, table_relation, old_path_id, ctx=ctx
         )

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -272,6 +272,9 @@ def gen_dml_cte(
         # touches link tables).
         dml_stmt = pgast.SelectStmt()
 
+        # We join with the concrete table for this type, but also include
+        # overlays produced by previous DML stmts. This is needed for SQL DML
+        # support, which needs to update a link table of a newly inserted object
         subject_rel_overlayed = relctx.range_for_typeref(
             typeref,
             subject_path_id,

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1432,7 +1432,7 @@ def get_path_identity_output(
 
 
 def get_path_value_output(
-    rel: pgast.Query,
+    rel: pgast.BaseRelation,
     path_id: irast.PathId,
     *,
     env: context.Environment,

--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1432,7 +1432,7 @@ def get_path_identity_output(
 
 
 def get_path_value_output(
-    rel: pgast.BaseRelation,
+    rel: pgast.Query,
     path_id: irast.PathId,
     *,
     env: context.Environment,

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -1017,7 +1017,6 @@ def _uncompile_insert_pointer_stmt(
                 compexpr=ql_ptr_val,
             )
         ],
-        sql_mode_link_only=is_multi,
     )
     if not is_value_single:
         # value relation might contain multiple rows

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2928,10 +2928,6 @@ class TestUpdate(tb.QueryTestCase):
             [3],
         )
 
-    @test.xfail('''
-        PostgreSQL doesn't allow updating just-inserted record
-        in the same query.
-    ''')
     async def test_edgeql_update_with_self_insert_01(self):
         await self.con.execute('''
             WITH new_test := (INSERT UpdateTest { name := "new-test" })

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2928,6 +2928,10 @@ class TestUpdate(tb.QueryTestCase):
             [3],
         )
 
+    @test.xfail('''
+        PostgreSQL doesn't allow updating just-inserted record
+        in the same query.
+    ''')
     async def test_edgeql_update_with_self_insert_01(self):
         await self.con.execute('''
             WITH new_test := (INSERT UpdateTest { name := "new-test" })


### PR DESCRIPTION
For the following query:

```sql
WITH d AS (
  INSERT INTO "Document" (title) VALUES ('Report') RETURNING id
)
INSERT INTO "Document.shared_with" (source, target, can_edit)
SELECT d.id, $1, TRUE FROM d
```
... we generate an EdgeQL:
```
select {
  dml_0 :=insert Document,
  dml_1 :=update Document { shared_with += ...}
}
```

But to validate that ids inserted into `shared_with` exists in `Document`,
we have to join with `Document` prior to insertion. That is problematic,
because we cannot just use the concrete table, since it does not yet
contain the inserted `Document`.

Until now, we used a hack that just didn't join with the concrete table.

This PR makes it so we join with concrete table AND the overlay that contains
objects created during current query.

And removes the hack.

---

I've found a problem with this hack when I was trying to add a followup test 
case for #8562. The test case is not working correctly yet.
