### PR TITLE
Fix MacOS sentencepiece build

### DIFF
--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -177,6 +177,7 @@
         <%- if tgt.family == "generic" %>
         BUILD_GENERIC: true
         <%- endif %>
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -155,7 +155,7 @@
     - name: Install an alias
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -149,10 +149,11 @@
     - name: Install dependencies
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -152,6 +152,12 @@
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: << 'false' if tgt.runs_on and 'self-hosted' in tgt.runs_on else 'true' >>
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -172,7 +178,6 @@
         BUILD_GENERIC: true
         <%- endif %>
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows.src/build.inc.yml
+++ b/.github/workflows.src/build.inc.yml
@@ -172,6 +172,7 @@
         BUILD_GENERIC: true
         <%- endif %>
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1173,6 +1173,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 
@@ -1252,6 +1253,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1168,6 +1168,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -1241,6 +1242,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1152,10 +1152,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
@@ -1232,10 +1233,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1155,6 +1155,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -1168,7 +1174,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -1229,6 +1234,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -1242,7 +1253,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/dryrun.yml
+++ b/.github/workflows/dryrun.yml
@@ -1158,7 +1158,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build
@@ -1237,7 +1237,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1173,6 +1173,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -1246,6 +1247,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1160,6 +1160,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -1173,7 +1179,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -1234,6 +1239,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -1247,7 +1258,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1178,6 +1178,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 
@@ -1257,6 +1258,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1157,10 +1157,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
@@ -1237,10 +1238,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1163,7 +1163,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build
@@ -1242,7 +1242,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,10 +527,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
@@ -605,10 +606,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -548,6 +548,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 
@@ -625,6 +626,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,6 +530,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -543,7 +549,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -602,6 +607,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -615,7 +626,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -543,6 +543,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -614,6 +615,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,7 +533,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build
@@ -610,7 +610,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -564,6 +564,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -636,6 +637,7 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
+        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -547,10 +547,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
@@ -626,10 +627,11 @@ jobs:
     - name: Install dependencies
       if: true
       run: |
-        env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
-        libmagic sentencepiece protobuf
+        env HOMEBREW_NO_AUTO_UPDATE=1 brew install libmagic
 
     - name: Install an alias
+      # This is probably not strictly needed, but sentencepiece build script reports
+      # errors without it.
       if: true
       run: |
         printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -569,6 +569,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 
@@ -647,6 +648,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -550,6 +550,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -564,7 +570,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0
@@ -623,6 +628,12 @@ jobs:
         env HOMEBREW_NO_AUTO_UPDATE=1 brew install \
         libmagic sentencepiece protobuf
 
+    - name: Install an alias
+      if: true
+      run: |
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        chmod +x /usr/local/bin/nproc
+
     - name: Build
       env:
         PACKAGE: edgedbpkg.edgedb:Gel
@@ -637,7 +648,6 @@ jobs:
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
       run: |
-        alias nproc="sysctl -n hw.logicalcpu"
         edgedb-pkg/integration/macos/build.sh
 
     - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874  # v4.4.0

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -553,7 +553,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build
@@ -631,7 +631,7 @@ jobs:
     - name: Install an alias
       if: true
       run: |
-        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc 
+        printf '#!/bin/sh\n\nexec sysctl -n hw.logicalcpu' > /usr/local/bin/nproc
         chmod +x /usr/local/bin/nproc
 
     - name: Build


### PR DESCRIPTION
This PR reverts #8573, since it did not actaully solve the issue.

This PR also sets `CMAKE_POLICY_VERSION_MINIMUM` for MacOS builds
which is needed to build sentencepiece package, used by our ai deps.

While doing that, I've noticed another error in the logs about missing
`nproc`, so I've added a wrapper script that calls `sysctl`.
