### PR TITLE
Fix a cross-type conflict bug that can occur with rewrites

### DIFF
--- a/edb/edgeql/compiler/inference/multiplicity.py
+++ b/edb/edgeql/compiler/inference/multiplicity.py
@@ -786,7 +786,7 @@ def _infer_on_conflict_clause(
     scope_tree: irast.ScopeTreeNode,
     ctx: inf_ctx.InfCtx,
 ) -> None:
-    for part in [ir.select_ir, ir.else_ir, ir.update_query_set]:
+    for part in [ir.select_ir, ir.else_ir]:
         if part:
             infer_multiplicity(part, scope_tree=scope_tree, ctx=ctx)
 

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1279,7 +1279,7 @@ class OnConflictClause(Base):
     select_ir: Set
     always_check: bool
     else_ir: typing.Optional[Set]
-    update_query_set: typing.Optional[Set] = None
+    check_anchor: typing.Optional[PathId] = None
     else_fail: typing.Optional[MutatingStmt] = None
 
 

--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -477,7 +477,7 @@ def fini_dml_stmt(
                 stop_ref=stop_ref,
                 dml_stmts=dml_stack, path_id=ir_stmt.subject.path_id, ctx=ctx)
 
-        process_update_conflicts(ir_stmt=ir_stmt, dml_parts=parts, ctx=ctx)
+        process_extra_conflicts(ir_stmt=ir_stmt, dml_parts=parts, ctx=ctx)
     elif isinstance(ir_stmt, irast.DeleteStmt):
         base_typeref = ir_stmt.subject.typeref.real_material_type
 
@@ -896,15 +896,8 @@ def process_insert_body(
         ctx.toplevel_stmt.append_cte(real_insert_cte)
         ctx.toplevel_stmt.append_cte(insert_cte)
 
-    for extra_conflict in (ir_stmt.conflict_checks or ()):
-        compile_insert_else_body(
-            insert_stmt,
-            ir_stmt,
-            extra_conflict,
-            inner_iterator,
-            None,
-            ctx=ctx,
-        )
+    # XXX: do we need to pass in inner_iterator here?
+    process_extra_conflicts(ir_stmt=ir_stmt, dml_parts=dml_parts, ctx=ctx)
 
 
 def process_insert_rewrites(
@@ -1459,7 +1452,7 @@ def compile_insert_else_body(
         ictx.expr_exposed = False
         ictx.path_scope[subject_id] = ictx.rel
 
-        compile_insert_else_body_failure_check(on_conflict, ctx=ictx)
+        compile_insert_else_body_failure_check(ir_stmt, on_conflict, ctx=ictx)
 
         merge_iterator(enclosing_cte_iterator, ictx.rel, ctx=ictx)
         clauses.setup_iterator_volatility(enclosing_cte_iterator, ctx=ictx)
@@ -1557,6 +1550,7 @@ def compile_insert_else_body(
 
 
 def compile_insert_else_body_failure_check(
+        ir_stmt: irast.MutatingStmt,
         on_conflict: irast.OnConflictClause,
         *,
         ctx: context.CompilerContextLevel) -> None:
@@ -1566,7 +1560,9 @@ def compile_insert_else_body_failure_check(
 
     # Copy the type rels from the possibly conflicting earlier DML
     # into the None overlays so it gets picked up.
-    merge_overlays_globally((else_fail,), ctx=ctx)
+    # Also copy our own overlays, which we care about just for
+    # the pointer overlays.
+    merge_overlays_globally((ir_stmt, else_fail,), ctx=ctx)
 
     # Do some work so that we aren't looking at the existing on-disk
     # data, just newly data created data.
@@ -2130,9 +2126,9 @@ def process_update_shape(
     return (values, external_updates, ptr_map)
 
 
-def process_update_conflicts(
+def process_extra_conflicts(
     *,
-    ir_stmt: irast.UpdateStmt,
+    ir_stmt: irast.MutatingStmt,
     dml_parts: DMLParts,
     ctx: context.CompilerContextLevel,
 ) -> None:
@@ -2140,16 +2136,16 @@ def process_update_conflicts(
         return
 
     for extra_conflict in ir_stmt.conflict_checks:
-        q_set = extra_conflict.update_query_set
-        assert q_set
-        typeref = q_set.path_id.target.real_material_type
+        q_path = extra_conflict.check_anchor
+        assert q_path
+        typeref = q_path.target.real_material_type
         cte, _ = dml_parts.dml_ctes[typeref]
 
         pathctx.put_path_id_map(
-            cte.query, q_set.path_id, ir_stmt.subject.path_id)
+            cte.query, q_path, ir_stmt.subject.path_id)
 
         conflict_iterator = pgast.IteratorCTE(
-            path_id=q_set.path_id, cte=cte,
+            path_id=q_path, cte=cte,
             parent=ctx.enclosing_cte_iterator)
 
         compile_insert_else_body(

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -27,7 +27,7 @@ from edb.testbase import server as tb
 from edb.tools import test
 
 
-class TestInsert(tb.QueryTestCase):
+class TestInsert(tb.DDLTestCase):
     '''The scope of the tests is testing various modes of Object creation.'''
     NO_FACTOR = False
     WARN_FACTOR = True
@@ -5152,9 +5152,18 @@ class TestInsert(tb.QueryTestCase):
             SELECT (B, F);
         '''
 
+        await self.con.execute(query)
+
+        query = r'''
+            WITH name := 'Madeline Hatch',
+                 B := (INSERT Person {name := name}),
+                 F := (INSERT DerivedPerson {name := <str>(0*random())}),
+            SELECT (B, F);
+        '''
+
         with self.assertRaisesRegex(
-                edgedb.UnsupportedFeatureError,
-                "does not support volatile properties with exclusive"):
+                edgedb.ConstraintViolationError,
+                "name violates exclusivity constraint"):
             await self.con.execute(query)
 
     async def test_edgeql_insert_cross_type_conflict_15(self):

--- a/tests/test_edgeql_rewrites.py
+++ b/tests/test_edgeql_rewrites.py
@@ -66,6 +66,16 @@ class TestRewrites(tb.DDLTestCase):
           drop access policy filter_title;
           drop access policy dml;
         };
+
+        create type CT {
+            create property a -> str;
+            create property b -> str {
+                create rewrite update using (.a);
+                create constraint exclusive;
+            };
+        };
+        create type CS extending CT;
+
     """
     ]
 
@@ -1156,4 +1166,39 @@ class TestRewrites(tb.DDLTestCase):
                     (select Document filter .name = '1' limit 1)
                 ),
             };
+        ''')
+
+    async def test_edgeql_rewrites_conflicts_01(self):
+        await self.con.execute('''
+            insert CT; insert CS;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            r""
+        ):
+            await self.con.execute('''
+                update CT set { a := 'x' }
+            ''')
+
+        await self.con.execute('''
+            update CT set { a := <str>random() }
+        ''')
+
+    async def test_edgeql_rewrites_conflicts_02(self):
+        await self.con.execute('''
+            alter type CT alter property b create rewrite insert using (.a);
+        ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConstraintViolationError,
+            r""
+        ):
+            await self.con.execute('''
+                select {(insert CT { a := "y" }), (insert CS { a := "y" })}
+            ''')
+
+        await self.con.execute('''
+            select {(insert CT { a := <str>random() }),
+                    (insert CS { a := <str>random() })}
         ''')


### PR DESCRIPTION
We were not properly considering rewrites when analyzing DML
operations to see if we needed to insert explicit checks to avoid
conflicting on exclusive properties.

So first we update `_get_needed_ptrs` to chase down rewrites, also
explicitly consider rewritten pointers (using the new
`_get_rewritten_ptrs`) and then switch to *always* using the
fake_dml_set machinery when using conflict checks for inheritance
purposes, so that we always look at the actually inserted data instead
of what appears in the edgeql query. This required some hacking on the
backend also, but not too much.

This also allows volatile properties to be used in DML that requires conflict
checks, which is nice, because that was always a weird lurking problem.