### PR TITLE
ON CONFLICT excluded and WHERE over SQL adapter

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -599,6 +599,9 @@ class UpdateQuery(Query):
 
     where: typing.Optional[Expr] = None
 
+    # Temporary metadata needed for SQL ON CONFLICT
+    sql_on_conflict: typing.Optional[tuple[typing.Any, typing.Any]] = None
+
 
 class DeleteQuery(Query):
     subject: Expr

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -621,7 +621,10 @@ def compile_UpdateQuery(
     ctx.env.dml_exprs.append(expr)
 
     with ctx.subquery() as ictx:
-        stmt = irast.UpdateStmt(span=expr.span)
+        stmt = irast.UpdateStmt(
+            span=expr.span,
+            sql_on_conflict=expr.sql_on_conflict,
+        )
         init_stmt(stmt, expr, ctx=ictx, parent_ctx=ctx)
 
         with ictx.new() as ectx:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1310,6 +1310,9 @@ class Rewrites:
 class UpdateStmt(MutatingStmt, FilteredStmt):
     _material_type: TypeRef | None = None
 
+    # Temporary metadata needed for SQL ON CONFLICT
+    sql_on_conflict: typing.Optional[tuple[PathId, PathId]] = None
+
     @property
     def material_type(self) -> TypeRef:
         assert self._material_type

--- a/edb/pgsql/resolver/context.py
+++ b/edb/pgsql/resolver/context.py
@@ -200,11 +200,13 @@ class CompiledDML:
 
     # for INSERTs, relation that provides values for UPDATE that happens ON
     # CONFLICT. not yet resolved
-    conflict_update_input: Optional[pgast.BaseRelation]
+    conflict_update_input: Optional[pgast.BaseRelation] = None
 
     # for INSERTs, name of CTE that provides values for UPDATE that happens ON
     # CONFLICT
-    conflict_update_name: Optional[str]
+    conflict_update_name: Optional[str] = None
+
+    conflict_update_iterator: Optional[str] = None
 
     # CTEs that perform the operation
     output_ctes: list[pgast.CommonTableExpr]


### PR DESCRIPTION
Adds support for references to `excluded` rvar
in UPDATE SET and WHERE clauses. It contains
values used in the INSERT query.

This PR also fixes the "iterator" problem of the
UPDATE, which must be executed *for each*
conflicting row, unless the UPDATE WHERE clause
returns FALSE.

It implementes this by wrapping EdgeQL `update`
into a `for` loop.

Additionally, it adds a join of iterators of
"update_value" and "insert_value" relations.
Ultimately, I'm planning to use actual ids instead
of iterators when "update value" gets the id from
"insert contents" CTE. That will require more
additional work, so I'm resorting to this hack for
now.
