### PR TITLE
Support doing non-DDL DML as part of patches

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -687,6 +687,11 @@ class DDLCommand(DDLOperation, Command):
     __abstract_node__ = True
 
 
+class DDLQuery(DDLCommand):
+    '''A query wrapped in DDL. Appears in migrations.'''
+    query: Query
+
+
 class NonTransactionalDDLCommand(DDLCommand):
     __abstract_node__ = True
 

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -843,6 +843,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
 
     # DDL nodes
 
+    def visit_DDLQuery(self, node: qlast.DDLQuery) -> None:
+        self.visit(node.query)
+
     def visit_Position(self, node: qlast.Position) -> None:
         self.write(node.position)
         if node.ref:

--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -380,9 +380,8 @@ def commands_block(parent, *commands, opt=True, production_tpl=ProductionTpl):
 
 class NestedQLBlockStmt(Nonterm):
 
-    @parsing.inline(0)
     def reduce_Stmt(self, *kids):
-        pass
+        self.val = qlast.DDLQuery(query=kids[0].val)
 
     @parsing.inline(0)
     def reduce_OptWithDDLStmt(self, *kids):

--- a/edb/schema/ddl.py
+++ b/edb/schema/ddl.py
@@ -439,7 +439,7 @@ def cmd_from_ddl(
     testmode: bool=False
 ) -> sd.Command:
     ddl = s_expr.imprint_expr_context(stmt, modaliases)
-    assert isinstance(ddl, qlast.DDLCommand)
+    assert isinstance(ddl, qlast.DDLOperation)
 
     if context is None:
         context = sd.CommandContext(

--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1646,7 +1646,7 @@ class Query(Command):
     These are found in migrations.
     """
 
-    astnode = qlast.Query
+    astnode = qlast.DDLQuery
 
     expr = struct.Field(s_expr.Expression)
 
@@ -1657,10 +1657,11 @@ class Query(Command):
         astnode: qlast.DDLOperation,
         context: CommandContext,
     ) -> Command:
+        assert isinstance(astnode, qlast.DDLQuery)
         return cls(
             span=astnode.span,
             expr=s_expr.Expression.from_ast(
-                astnode,  # type: ignore
+                astnode.query,
                 schema=schema,
                 modaliases=context.modaliases,
                 localnames=context.localnames,

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -879,7 +879,9 @@ def prepare_patch(
         assert '+user_ext' not in kind
 
         for ddl_cmd in edgeql.parse_block(patch):
-            assert isinstance(ddl_cmd, qlast.DDLCommand)
+            if not isinstance(ddl_cmd, qlast.DDLCommand):
+                assert isinstance(ddl_cmd, qlast.Query)
+                ddl_cmd = qlast.DDLQuery(query=ddl_cmd)
             # First apply it to the regular schema, just so we can update
             # stdschema
             delta_command = s_ddl.delta_from_ddl(
@@ -930,7 +932,9 @@ def prepare_patch(
         )
 
         for ddl_cmd in edgeql.parse_block(patch):
-            assert isinstance(ddl_cmd, qlast.DDLCommand)
+            if not isinstance(ddl_cmd, qlast.DDLCommand):
+                assert isinstance(ddl_cmd, qlast.Query)
+                ddl_cmd = qlast.DDLQuery(query=ddl_cmd)
 
             delta_command = s_ddl.delta_from_ddl(
                 ddl_cmd, modaliases={}, schema=cschema,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1874,10 +1874,13 @@ def _compile_ql_query(
         (mstate := current_tx.get_migration_state())
         and not migration_block_query
     ):
-        mstate = mstate._replace(
-            accepted_cmds=mstate.accepted_cmds + (ql,),
-        )
-        current_tx.update_migration_state(mstate)
+        if isinstance(ql, qlast.Query):
+            mstate = mstate._replace(
+                accepted_cmds=(
+                    mstate.accepted_cmds + (qlast.DDLQuery(query=ql),)
+                )
+            )
+            current_tx.update_migration_state(mstate)
 
         return dbstate.NullQuery()
 

--- a/edb/server/compiler/status.py
+++ b/edb/server/compiler/status.py
@@ -268,3 +268,8 @@ def _explain(ql: qlast.Base) -> bytes:
 @get_status.register(qlast.AdministerStmt)
 def _administer(ql: qlast.Base) -> bytes:
     return b'ADMINISTER'
+
+
+@get_status.register(qlast.DDLQuery)
+def _query(ql: qlast.DDLQuery) -> bytes:
+    return get_status(ql.query)


### PR DESCRIPTION
The only thing preventing this from working was two asserts, since the
delta machinery worked with non-DDL already (it had something
registered with `astnode = qlast.Query`).

Instead of doubling down on lying about the types of things, though, I
am attempting to wrap it properly in another type, which is most of
the bulk of this PR.

See #8585, where it is tested.