### PR TITLE
Add a test case for mutation rewrites

### DIFF
--- a/tests/test_edgeql_rewrites.py
+++ b/tests/test_edgeql_rewrites.py
@@ -1139,6 +1139,28 @@ class TestRewrites(tb.DDLTestCase):
             update H.x set { text := 'full' };
         ''')
 
+    async def test_edgeql_rewrites_31(self):
+        await self.con.execute('''
+            create type A;
+            create type B {
+                create multi link a: A;
+                create property has_updated: bool {
+                        create rewrite update using (true);
+                };
+            };
+
+            insert A;
+            insert B;
+            update B set { a += (select A) };
+        ''')
+
+        await self.assert_query_result(
+            '''
+            select B.has_updated;
+            ''',
+            [True]
+        )
+
     async def test_edgeql_rewrites_triggers_01(self):
         await self.con.execute('''
             create type Pidgeon {


### PR DESCRIPTION
Closes #8564

Last week I though this was not working correctly.
I though it was not applying rewrites. But we do
have code paths exactly for this. And now I'm not
able to reproduce it.

We can test it from now on anyway.
