### PR TITLE
Fix more server_param_conversion breakage of patches+IPU testing

### DIFF
--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -358,7 +358,9 @@ def _get_delta_context_args(ctx: compiler.CompileContext) -> dict[str, Any]:
 
 
 def _process_delta(
-    ctx: compiler.CompileContext, delta: s_delta.DeltaRoot
+    ctx: compiler.CompileContext,
+    delta: s_delta.DeltaRoot,
+    context_args: Any = None,
 ) -> tuple[pg_dbops.SQLBlock, frozenset[str], Any]:
     """Adapt and process the delta command."""
 
@@ -367,7 +369,7 @@ def _process_delta(
 
     pgdelta = pg_delta.CommandMeta.adapt(delta)
     assert isinstance(pgdelta, pg_delta.DeltaRoot)
-    context = _new_delta_context(ctx)
+    context = _new_delta_context(ctx, context_args)
     schema = pgdelta.apply(schema, context)
     current_tx.update_schema(schema)
 
@@ -1374,7 +1376,7 @@ def repair_schema(
 
     # Apply and adapt delta, build native delta plan, which
     # will also update the schema.
-    block, new_types, config_ops = _process_delta(ctx, delta)
+    block, new_types, config_ops = _process_delta(ctx, delta, context_args)
     is_transactional = block.is_transactional()
     assert not new_types
     assert is_transactional

--- a/edb/server/pgcon/connect.py
+++ b/edb/server/pgcon/connect.py
@@ -22,6 +22,7 @@ import logging
 import textwrap
 
 from edb.pgsql.common import quote_ident as pg_qi
+from edb.pgsql.common import versioned_schema
 from edb.pgsql import params as pg_params
 from edb.server import pgcon
 
@@ -102,6 +103,7 @@ def _build_init_con_script(*, check_pg_is_in_recovery: bool) -> bytes:
     else:
         pg_is_in_recovery = ''
 
+    edgedb_schema = versioned_schema('edgedb')
     return textwrap.dedent(f'''
         {pg_is_in_recovery}
 
@@ -112,7 +114,8 @@ def _build_init_con_script(*, check_pg_is_in_recovery: bool) -> bytes:
         CREATE CONSTRAINT TRIGGER _edgecon_state_local_reset
         AFTER INSERT ON _edgecon_state
         DEFERRABLE INITIALLY DEFERRED
-        FOR EACH ROW EXECUTE FUNCTION edgedb._clear_fe_local_sql_settings();
+        FOR EACH ROW
+        EXECUTE FUNCTION {edgedb_schema}._clear_fe_local_sql_settings();
 
         PREPARE _clear_state AS
             WITH x1 AS (


### PR DESCRIPTION
The DESCRIBE of functions that use server_param_conversions wouldn't output
the server_param_conversions field, since it was not marked as
allow_ddl_set. Mark it as allow_ddl_set but manually prohibit users from
setting it.

This is very much on the borderline of being worth supporting.

Also make schema_repair() use testmode (which it was trying but failing to
do), so that schemas that use testmode features still work. Patches
actually was working in CI, but not locally, since it didn't use this.