### PR TITLE
Fix to handle pg_home_directory the same way as libpq

### DIFF
--- a/edb/server/pgcon/rust_transport.py
+++ b/edb/server/pgcon/rust_transport.py
@@ -454,7 +454,7 @@ async def create_postgres_connection(
     connect_timeout = dsn.connect_timeout
     try:
         state = pgrust.PyConnectionState(
-            dsn._params, "postgres", str(get_pg_home_directory())
+            dsn._params, "postgres", get_pg_home_directory()
         )
     except Exception as e:
         raise ValueError(e)

--- a/rust/pgrust/examples/connect.rs
+++ b/rust/pgrust/examples/connect.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[allow(deprecated)]
         let home = std::env::home_dir().unwrap();
         conn.password
-            .resolve(&home, &conn.hosts, &conn.database, &conn.database)?;
+            .resolve(Some(&home), &conn.hosts, &conn.database, &conn.database)?;
         args.database = conn.database;
         args.username = conn.user;
         args.password = conn.password.password().unwrap_or_default().to_string();

--- a/rust/pgrust/examples/dsn.rs
+++ b/rust/pgrust/examples/dsn.rs
@@ -9,12 +9,12 @@ fn main() {
     eprintln!("DSN: {dsn}\n----\n{:#?}\n", params);
     params
         .password
-        .resolve(&home, &params.hosts, &params.database, &params.user)
+        .resolve(Some(&home), &params.hosts, &params.database, &params.user)
         .unwrap();
     eprintln!(
         "Resolved password:\n------------------\n{:#?}\n",
         params.password
     );
-    params.ssl.resolve(&home).unwrap();
+    params.ssl.resolve(Some(&home)).unwrap();
     eprintln!("Resolved SSL:\n-------------\n{:#?}\n", ());
 }

--- a/rust/pgrust/src/connection/dsn/params.rs
+++ b/rust/pgrust/src/connection/dsn/params.rs
@@ -288,14 +288,16 @@ impl Ssl {
         let key = params
             .key
             .clone()
-            .or_else(|| home_dir.map(|p| p.join(USER_KEY_FILE)));
+            .or_else(|| home_dir.map(|p| p.join(USER_KEY_FILE)))
+            .filter(|p| p.exists());
         if key.is_some() {
             params.key = key;
         }
         let cert = params
             .cert
             .clone()
-            .or_else(|| home_dir.map(|p| p.join(USER_CERT_FILE)));
+            .or_else(|| home_dir.map(|p| p.join(USER_CERT_FILE)))
+            .filter(|p| p.exists());
         if cert.is_some() {
             params.cert = cert;
         }

--- a/rust/pgrust/src/connection/dsn/params.rs
+++ b/rust/pgrust/src/connection/dsn/params.rs
@@ -8,6 +8,25 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+#[cfg(windows)]
+mod cert_paths {
+    // On Windows, the "home" directory is already PostgreSQL-specific
+    pub const USER_CERT_FILE: &str = "postgresql.crt";
+    pub const USER_KEY_FILE: &str = "postgresql.key";
+    pub const ROOT_CERT_FILE: &str = "root.crt";
+    pub const ROOT_CRL_FILE: &str = "root.crl";
+}
+#[cfg(not(windows))]
+mod cert_paths {
+    pub const USER_CERT_FILE: &str = ".postgresql/postgresql.crt";
+    pub const USER_KEY_FILE: &str = ".postgresql/postgresql.key";
+    pub const ROOT_CERT_FILE: &str = ".postgresql/root.crt";
+    pub const ROOT_CRL_FILE: &str = ".postgresql/root.crl";
+}
+
+use cert_paths::*;
+
+
 impl<'a, I: Into<RawConnectionParameters<'a>>, E: EnvVar> TryInto<ConnectionParameters> for (I, E) {
     type Error = ParseError;
     fn try_into(self) -> Result<ConnectionParameters, ParseError> {
@@ -240,8 +259,7 @@ pub struct SslParameters {
 
 impl Ssl {
     /// Resolve the SSL paths relative to the home directory.
-    pub fn resolve(&mut self, home_dir: &Path) -> Result<(), std::io::Error> {
-        let postgres_dir = home_dir;
+    pub fn resolve(&mut self, home_dir: Option<&Path>) -> Result<(), std::io::Error> {
         let Ssl::Enable(mode, params) = self else {
             return Ok(());
         };
@@ -249,35 +267,37 @@ impl Ssl {
             let root_cert = params
                 .rootcert
                 .clone()
-                .unwrap_or_else(|| postgres_dir.join("root.crt"));
-            if root_cert.exists() {
+                .or_else(|| home_dir.map(|p| p.join(ROOT_CERT_FILE)));
+            if let Some(root_cert) = root_cert.clone().filter(|p| p.exists()) {
                 params.rootcert = Some(root_cert);
             } else if *mode > SslMode::Require {
+                let reason = root_cert.map(|p| format!(": {p:?}")).unwrap_or_default();
                 return Err(std::io::Error::new(ErrorKind::NotFound,
-                    format!("Root certificate not found: {root_cert:?}. Either provide the file or change sslmode to disable SSL certificate verification.")));
+                    format!("Root certificate not found{reason}. Either provide the file or change sslmode to disable SSL certificate verification.")));
             }
 
             let crl = params
                 .crl
                 .clone()
-                .unwrap_or_else(|| postgres_dir.join("root.crl"));
-            if crl.exists() {
-                params.crl = Some(crl);
+                .or_else(|| home_dir.map(|p| p.join(ROOT_CRL_FILE)))
+                .filter(|p| p.exists());
+            if crl.is_some() {
+                params.crl = crl;
             }
         }
         let key = params
             .key
             .clone()
-            .unwrap_or_else(|| postgres_dir.join("postgresql.key"));
-        if key.exists() {
-            params.key = Some(key);
+            .or_else(|| home_dir.map(|p| p.join(USER_KEY_FILE)));
+        if key.is_some() {
+            params.key = key;
         }
         let cert = params
             .cert
             .clone()
-            .unwrap_or_else(|| postgres_dir.join("postgresql.crt"));
-        if cert.exists() {
-            params.cert = Some(cert);
+            .or_else(|| home_dir.map(|p| p.join(USER_CERT_FILE)));
+        if cert.is_some() {
+            params.cert = cert;
         }
         Ok(())
     }

--- a/rust/pgrust/src/connection/dsn/params.rs
+++ b/rust/pgrust/src/connection/dsn/params.rs
@@ -26,7 +26,6 @@ mod cert_paths {
 
 use cert_paths::*;
 
-
 impl<'a, I: Into<RawConnectionParameters<'a>>, E: EnvVar> TryInto<ConnectionParameters> for (I, E) {
     type Error = ParseError;
     fn try_into(self) -> Result<ConnectionParameters, ParseError> {

--- a/rust/pgrust/src/connection/dsn/passfile.rs
+++ b/rust/pgrust/src/connection/dsn/passfile.rs
@@ -124,13 +124,17 @@ impl Password {
     /// Attempt to resolve a password against the given homedir.
     pub fn resolve(
         &mut self,
-        home: &Path,
+        home: Option<&Path>,
         hosts: &[Host],
         database: &str,
         user: &str,
     ) -> Result<Option<PasswordWarning>, std::io::Error> {
         let passfile = match self {
             Password::Unspecified => {
+                let Some(home) = home else {
+                    *self = Password::Unspecified;
+                    return Ok(None);
+                };
                 let passfile = home.join(PGPASSFILE);
                 // Don't warn about implicit missing or inaccessible files
                 if !matches!(passfile.try_exists(), Ok(true)) {

--- a/rust/pgrust/src/python/mod.rs
+++ b/rust/pgrust/src/python/mod.rs
@@ -192,7 +192,7 @@ impl PyConnectionParams {
         }
     }
 
-    pub fn resolve(&self, py: Python, username: String, home_dir: String) -> PyResult<Self> {
+    pub fn resolve(&self, py: Python, username: String, home_dir: Option<String>) -> PyResult<Self> {
         let os = py.import("os")?;
         let environ = os.getattr("environ")?;
 
@@ -203,7 +203,7 @@ impl PyConnectionParams {
         let mut params = ConnectionParameters::try_from(params)
             .map_err(|err| PyException::new_err(err.to_string()))?;
         if let Some(warning) = params.password.resolve(
-            Path::new(&home_dir),
+            home_dir.as_deref().map(Path::new),
             &params.hosts,
             &params.database,
             &params.user,
@@ -214,7 +214,7 @@ impl PyConnectionParams {
 
         params
             .ssl
-            .resolve(Path::new(&home_dir))
+            .resolve(home_dir.as_deref().map(Path::new))
             .map_err(|err| PyException::new_err(err.to_string()))?;
         Ok(Self {
             inner: params.into(),
@@ -277,7 +277,7 @@ impl PyConnectionState {
         py: Python,
         dsn: &PyConnectionParams,
         username: String,
-        home_dir: String,
+        home_dir: Option<String>,
     ) -> PyResult<Self> {
         let os = py.import("os")?;
         let environ = os.getattr("environ")?;
@@ -289,7 +289,7 @@ impl PyConnectionState {
         let mut params = ConnectionParameters::try_from(params)
             .map_err(|err| PyException::new_err(err.to_string()))?;
         if let Some(warning) = params.password.resolve(
-            Path::new(&home_dir),
+            home_dir.as_deref().map(Path::new),
             &params.hosts,
             &params.database,
             &params.user,
@@ -300,7 +300,7 @@ impl PyConnectionState {
 
         params
             .ssl
-            .resolve(Path::new(&home_dir))
+            .resolve(home_dir.as_deref().map(Path::new))
             .map_err(|err| PyException::new_err(err.to_string()))?;
         let credentials = Credentials {
             username: params.user.clone(),

--- a/rust/pgrust/src/python/mod.rs
+++ b/rust/pgrust/src/python/mod.rs
@@ -192,7 +192,12 @@ impl PyConnectionParams {
         }
     }
 
-    pub fn resolve(&self, py: Python, username: String, home_dir: Option<String>) -> PyResult<Self> {
+    pub fn resolve(
+        &self,
+        py: Python,
+        username: String,
+        home_dir: Option<String>,
+    ) -> PyResult<Self> {
         let os = py.import("os")?;
         let environ = os.getattr("environ")?;
 


### PR DESCRIPTION
* Allow non-existing home directory
* Fix to look for `~/.pgpass` instead of `~/.postgresql/.pgpass`

Fixes #6763
Refs #7659, https://www.postgresql.org/docs/current/libpq-pgpass.html
Closes #8514