### PR TITLE
Batch embeddings requests in queries with multiple ai text search calls.

### DIFF
--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -970,9 +970,10 @@ def _batch_embeddings_inputs(
     ]
 
     # Get indexes of inputs, sorted from shortest to longest by token count
+    # Use the text itself as a tie breaker for consistency
     unbatched_input_indexes = list(range(len(inputs)))
     unbatched_input_indexes.sort(
-        key=lambda index: input_token_counts[index],
+        key=lambda index: (input_token_counts[index], inputs[index]),
         reverse=False,
     )
 

--- a/edb/server/protocol/ai_ext.py
+++ b/edb/server/protocol/ai_ext.py
@@ -2658,12 +2658,210 @@ async def generate_embeddings_for_text(
     return result.data.embeddings
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
+class TextEmbeddingsResult:
+    success: Optional[list[list[float]]] = None
+
+    too_long: Optional[list[int]] = None
+
+
+async def generate_embeddings_for_texts(
+    db: dbview.Database,
+    http_client: http.HttpClient,
+    inputs: list[tuple[str | uuid.UUID, str]],
+) -> TextEmbeddingsResult:
+    """Generate embeddings for strings to search for ai indexed objects.
+
+    Each input string may have a different object. The object is specified
+    by the object type id as either a string or uuid.
+
+    Produces embeddings for the input strings by:
+    - grouping string by their index model and shortening
+    - batching those groups
+    - then doing embeddings requests in batches
+
+    Input strings are truncated if allowed by their index.
+
+    If any string is too long and truncating is not allowed, a "too_long"
+    result is returned.
+
+    If all embeddings requests are successful, the embeddings are returned
+    as a "success" result in the same order as the inputs.
+    """
+    # Gather information about the indexes and embeddings
+    # For each type, we will need:
+    # - model name
+    # - max input tokens
+    # - max batch tokens
+    # - provider config
+    # - allowed to truncate
+    # - shortening, if any
+    type_ai_indexes: dict[str, AIIndex] = {}
+    for type_id, _ in inputs:
+        type_id = str(type_id)
+        if type_id not in type_ai_indexes:
+            type_ai_indexes[type_id] = await get_ai_index_for_type(db, type_id)
+
+    model_providers = {
+        ai_index.model: ai_index.provider
+        for ai_index in type_ai_indexes.values()
+    }
+    model_max_input_tokens: dict[str, int] = {
+        model_name: await _get_model_annotation_as_int(
+            db,
+            base_model_type="ext::ai::EmbeddingModel",
+            model_name=model_name,
+            annotation_name="ext::ai::embedding_model_max_input_tokens",
+        )
+        for model_name in model_providers.keys()
+    }
+    model_max_batch_tokens: dict[str, int] = {
+        model_name: await _get_model_annotation_as_int(
+            db,
+            base_model_type="ext::ai::EmbeddingModel",
+            model_name=model_name,
+            annotation_name="ext::ai::embedding_model_max_batch_tokens",
+        )
+        for model_name in model_providers.keys()
+    }
+
+    provider_configs = {
+        provider: _get_provider_config(db=db, provider_name=provider)
+        for provider in set(model_providers.values())
+    }
+
+    # Group the inputs by model and shortening
+    group_input_indexes: dict[tuple[str, Optional[int]], list[int]] = {}
+
+    for input_index, (type_id, _) in enumerate(inputs):
+        ai_index = type_ai_indexes[str(type_id)]
+
+        model_name = ai_index.model
+        shortening = (
+            ai_index.index_embedding_dimensions
+            if (
+                ai_index.index_embedding_dimensions
+                < ai_index.model_embedding_dimensions
+            ) else
+            None
+        )
+
+        group_key = (model_name, shortening)
+
+        if group_key not in group_input_indexes:
+            group_input_indexes[group_key] = []
+
+        group_input_indexes[group_key].append(input_index)
+
+    # Batch each group separately
+    group_batch_texts_and_indexes: dict[
+        tuple[str, Optional[int]],
+        list[tuple[
+            # texts, truncated if needed
+            list[str],
+            # the associated input index
+            list[int],
+        ]]
+    ] = {}
+    too_long: list[int] = []
+
+    for group_key, input_indexes in group_input_indexes.items():
+        model_name, shortening = group_key
+        provider = model_providers[model_name]
+
+        tokenizer = get_model_tokenizer(provider, model_name)
+        max_input_tokens = model_max_input_tokens[model_name]
+        max_batch_tokens = model_max_batch_tokens[model_name]
+
+        texts = [
+            (
+                inputs[input_index][1],
+                type_ai_indexes[str(inputs[input_index][0])].truncate_to_max,
+            )
+            for input_index in input_indexes
+        ]
+
+        text_batches, excluded_indexes = batch_texts(
+            texts,
+            tokenizer,
+            max_input_tokens,
+            max_batch_tokens,
+        )
+
+        if excluded_indexes or too_long:
+            # If any input is too long, collect all inputs that are too long
+            # and return them as a failure
+            too_long.extend(
+                input_indexes[excluded_index]
+                for excluded_index in excluded_indexes
+            )
+            continue
+
+        group_batch_texts_and_indexes[group_key] = []
+
+        for text_batch in text_batches:
+            batched_texts: list[str] = []
+            batched_input_indexes: list[int] = []
+
+            for entry in text_batch.entries:
+                batched_texts.append(entry.input_text)
+                batched_input_indexes.append(
+                    input_indexes[entry.input_index]
+                )
+
+            group_batch_texts_and_indexes[group_key].append(
+                (batched_texts, batched_input_indexes)
+            )
+
+    if too_long:
+        return TextEmbeddingsResult(too_long=too_long)
+
+    # Do the embeddings
+
+    # We have been tracking the input indexes of the batch texts this whole
+    # time. Use these indexes to fill in a result embeddings list
+    embeddings: list[Optional[list[float]]] = [None] * len(inputs)
+
+    for group_key, batched_texts_and_indexes in (
+        group_batch_texts_and_indexes.items()
+    ):
+        model_name, shortening = group_key
+        provider = model_providers[model_name]
+
+        provider_config = provider_configs[provider]
+
+        for batched_texts, batched_input_indexes in batched_texts_and_indexes:
+            embeddings_result = await _generate_embeddings(
+                provider_config,
+                model_name,
+                batched_texts,
+                shortening,
+                None,
+                http_client,
+            )
+            if isinstance(embeddings_result.data, rs.Error):
+                raise AIProviderError(embeddings_result.data.message)
+            decoded_result = json.loads(
+                embeddings_result.data.embeddings.decode("utf-8")
+            )
+            for entry_index, entry_result in enumerate(decoded_result["data"]):
+                input_index = batched_input_indexes[entry_index]
+                embeddings[input_index] = entry_result["embedding"]
+
+    assert all(e is not None for e in embeddings)
+
+    return TextEmbeddingsResult(
+        success=cast(list[list[float]], embeddings),
+    )
+
+
+@dataclass(frozen=True, kw_only=True)
 class AIIndex:
     model: str
     provider: str
     model_embedding_dimensions: int
     index_embedding_dimensions: int
+    truncate_to_max: bool
 
 
 async def get_ai_index_for_type(
@@ -2716,6 +2914,12 @@ async def get_ai_index_for_type(
                         LIMIT
                             1
                     ).0,
+                    truncate_to_max := any((
+                        for kwarg in array_unpack(.kwargs) select (
+                            kwarg.name = 'truncate_to_max'
+                            and str_lower(kwarg.expr) = 'true'
+                        )
+                    ))
                 }
             FILTER
                 .ancestors.name = 'ext::ai::index'
@@ -2742,4 +2946,5 @@ async def get_ai_index_for_type(
         provider=index["provider"],
         model_embedding_dimensions=index["model_embedding_dimensions"],
         index_embedding_dimensions=index["index_embedding_dimensions"],
+        truncate_to_max=index["truncate_to_max"],
     )

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -22,8 +22,8 @@ type TestEmbeddingModel
 {
     annotation ext::ai::model_name := "text-embedding-test";
     annotation ext::ai::model_provider := "custom::test";
-    annotation ext::ai::embedding_model_max_input_tokens := "8191";
-    annotation ext::ai::embedding_model_max_batch_tokens := "16384";
+    annotation ext::ai::embedding_model_max_input_tokens := "100";
+    annotation ext::ai::embedding_model_max_batch_tokens := "500";
     annotation ext::ai::embedding_model_max_output_dimensions := "10";
     annotation ext::ai::embedding_model_supports_shortening := "true";
 };
@@ -38,6 +38,15 @@ type Stuff extending Astronomy {
     content2: str;
     deferred index ext::ai::index(embedding_model := 'text-embedding-test')
         on ({.content} ++ {.content2});
+};
+
+type Truncated {
+    content: str;
+    deferred index ext::ai::index(
+        embedding_model := 'text-embedding-test',
+        truncate_to_max := true,
+    )
+        on (.content);
 };
 
 type Star extending Astronomy;

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -484,74 +484,6 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                 delete Astronomy;
             ''')
 
-    async def test_ext_ai_indexing_06(self):
-        try:
-            await self.con.execute(
-                """
-                insert Astronomy {
-                    content := 'Skies on Venus are orange'
-                };
-                insert Astronomy {
-                    content := 'Skies on Mars are red'
-                };
-                insert Astronomy {
-                    content := 'Skies on Pluto are black and starry'
-                };
-                insert Astronomy {
-                    content := 'Skies on Earth are blue'
-                };
-                """,
-            )
-
-            async for tr in self.try_until_succeeds(
-                ignore=(AssertionError,),
-                timeout=30.0,
-            ):
-                async with tr:
-                    await self.assert_query_result(
-                        r'''
-                        with
-                            result := ext::ai::search(
-                                Astronomy, <str>$qv)
-                        select
-                            result.object {
-                                content,
-                                distance := result.distance,
-                            }
-                        order by
-                            result.distance asc empty last
-                            then result.object.content
-                        ''',
-                        [
-                            {
-                                'content': 'Skies on Earth are blue',
-                                'distance': 0.09861218113400261,
-                            },
-                            {
-                                'content': 'Skies on Venus are orange',
-                                'distance': 0.11303140601637596,
-                            },
-                            {
-                                'content': 'Skies on Mars are red',
-                                'distance': 0.14066215115268055,
-                            },
-                            {
-                                'content': (
-                                    'Skies on Pluto are black and starry'
-                                ),
-                                'distance': 0.32063377951324246,
-                            },
-                        ],
-                        variables={
-                            "qv": "Nice weather",
-                        }
-                    )
-
-        finally:
-            await self.con.execute('''
-                delete Astronomy;
-            ''')
-
     async def test_ext_ai_batch_embeddings_01(self):
         # Content that can be batched without being truncated
         #
@@ -829,6 +761,471 @@ class TestExtAI(tb.BaseHttpExtensionTest):
                 }],
             }],
         )
+
+    async def test_ext_ai_text_search_01(self):
+        try:
+            await self.con.execute(
+                """
+                insert Astronomy {
+                    content := 'Skies on Venus are orange'
+                };
+                insert Astronomy {
+                    content := 'Skies on Mars are red'
+                };
+                insert Astronomy {
+                    content := 'Skies on Pluto are black and starry'
+                };
+                insert Astronomy {
+                    content := 'Skies on Earth are blue'
+                };
+                """,
+            )
+
+            async for tr in self.try_until_succeeds(
+                ignore=(AssertionError,),
+                timeout=30.0,
+            ):
+                async with tr:
+                    await self.assert_query_result(
+                        r'''
+                        with
+                            result := ext::ai::search(
+                                Astronomy, <str>$qv)
+                        select
+                            result.object {
+                                content,
+                                distance := result.distance,
+                            }
+                        order by
+                            result.distance asc empty last
+                            then result.object.content
+                        ''',
+                        [
+                            {
+                                'content': 'Skies on Earth are blue',
+                                'distance': 0.09861218113400261,
+                            },
+                            {
+                                'content': 'Skies on Venus are orange',
+                                'distance': 0.11303140601637596,
+                            },
+                            {
+                                'content': 'Skies on Mars are red',
+                                'distance': 0.14066215115268055,
+                            },
+                            {
+                                'content': (
+                                    'Skies on Pluto are black and starry'
+                                ),
+                                'distance': 0.32063377951324246,
+                            },
+                        ],
+                        variables={
+                            "qv": "Nice weather",
+                        }
+                    )
+
+        finally:
+            await self.con.execute('''
+                delete Astronomy;
+            ''')
+
+    async def test_ext_ai_text_search_02(self):
+        # Ai text search calls batch their embeddings requests
+        # with short inputs
+        #
+        # Some parameters are repeated.
+        query_prefix = 'text_search_02_'
+
+        try:
+            await self.con.execute(
+                """
+                insert Astronomy {
+                    content := 'Skies on Earth are blue'
+                };
+                """,
+            )
+
+            async for tr in self.try_until_succeeds(
+                ignore=(AssertionError,),
+                timeout=30.0,
+            ):
+                async with tr:
+                    await self.assert_query_result(
+                        f'''
+                        select (
+                            assert_single(ext::ai::search(
+                                Astronomy, <str>$qa
+                            ).distance),
+                            assert_single(ext::ai::search(
+                                Astronomy, <str>$qa
+                            ).distance),
+                            assert_single(ext::ai::search(
+                                Astronomy, <str>$qb
+                            ).distance),
+                            assert_single(ext::ai::search(
+                                Astronomy, <str>$qb
+                            ).distance),
+                            assert_single(ext::ai::search(
+                                Astronomy, <str>$qb
+                            ).distance),
+                            assert_single(ext::ai::search(
+                                Astronomy, <str>$qc
+                            ).distance),
+                            assert_single(ext::ai::search(
+                                Astronomy, '{query_prefix + "Always night"}'
+                            ).distance),
+                            assert_single(ext::ai::search(
+                                Astronomy, '{query_prefix + "Always night"}'
+                            ).distance),
+                        )
+                        ''',
+                        [(
+                            0.10778218378080595,
+                            0.10778218378080595,
+                            0.350480947161671,
+                            0.350480947161671,
+                            0.350480947161671,
+                            0.1513315752084945,
+                            0.16085360832172635,
+                            0.16085360832172635,
+                        )],
+                        variables={
+                            "qa": query_prefix + "Nice weather",
+                            "qb": query_prefix + "Lots of clouds",
+                            "qc": query_prefix + "Dust everywhere",
+                        }
+                    )
+
+        finally:
+            await self.con.execute('''
+                delete Astronomy;
+            ''')
+
+        # Check search embeddings were batched correctly
+        current_requests = [
+            embeddings_request
+            for embeddings_request in TestExtAI._embeddings_log
+            if any(
+                entry.startswith(query_prefix)
+                for entry in embeddings_request
+            )
+        ]
+
+        prefix_length = len(query_prefix)
+        actual_batches = [
+            [
+                entry[prefix_length:]
+                for entry in embeddings_request
+            ]
+            for embeddings_request in current_requests
+        ]
+
+        # These will be embedded repeatedly in try_until_succeeds
+        expected_batches = [[
+            "Dust everywhere",
+            "Always night",
+            "Always night",
+            "Nice weather",
+            "Lots of clouds",
+        ]]
+        expected_batches = (
+            expected_batches * (len(actual_batches) // len(expected_batches))
+        )
+
+        assert_data_shape.assert_data_shape(
+            actual_batches,
+            expected_batches,
+            self.fail,
+            message='Embeddings not batched correctly.'
+        )
+
+    async def test_ext_ai_text_search_03(self):
+        # Ai text search calls batch their embeddings requests
+        # with long inputs, no truncation needed
+        #
+        # Note:
+        #   ai_ext.py: TestTokenizer counts each char as a separate token
+        #   ext_ai.esdl: TestEmbeddingModel has a max input token length 100
+        #   ext_ai.esdl: TestEmbeddingModel has a max batch token length 500
+        query_prefix = 'text_search_03_'
+        entry_count = 20
+
+        queries = [
+            f"{query_prefix}{str(n).zfill(3)}{'a' * (50 + n)}"
+            for n in range(entry_count)
+        ]
+
+        try:
+            await self.con.execute(
+                """
+                insert Astronomy {
+                    content := 'Skies on Earth are blue'
+                };
+                """,
+            )
+
+            async for tr in self.try_until_succeeds(
+                ignore=(AssertionError,),
+                timeout=30.0,
+            ):
+                async with tr:
+                    await self.assert_query_result(
+                        f'''
+                        select ({
+                            ", ".join(
+                                f"assert_single(ext::ai::search("
+                                f"    Astronomy, <str>${n}"
+                                f").distance)"
+                                for n in range(len(queries))
+                            )
+                        })
+                        ''',
+                        [(
+                            0.4663014891358067,
+                            0.4669372419132616,
+                            0.4675494836157368,
+                            0.46813949300135127,
+                            0.46870845787047366,
+                            0.469257483000719,
+                            0.4697875972666343,
+                            0.47029976004002993,
+                            0.4707948669542362,
+                            0.4712737551047398,
+                            0.471737207749386,
+                            0.472185958563376,
+                            0.47262069549743413,
+                            0.4730420642816191,
+                            0.47345067161213195,
+                            0.47384708805405473,
+                            0.4742318506890981,
+                            0.4746054655340881,
+                            0.4749684097530038,
+                            0.4753211336828156,
+                        )],
+                        variables=tuple(queries)
+                    )
+
+        finally:
+            await self.con.execute('''
+                delete Astronomy;
+            ''')
+
+        # Check search embeddings were batched correctly
+        current_requests = [
+            embeddings_request
+            for embeddings_request in TestExtAI._embeddings_log
+            if any(
+                entry.startswith(query_prefix)
+                for entry in embeddings_request
+            )
+        ]
+
+        prefix_length = len(query_prefix)
+        actual_batches = [
+            [
+                int(entry[prefix_length:prefix_length + 3])
+                for entry in embeddings_request
+            ]
+            for embeddings_request in current_requests
+        ]
+
+        # These will be embedded repeatedly in try_until_succeeds
+        expected_batches = [
+            [19, 0, 1, 2, 3, 4],
+            [18, 5, 6, 7, 8, 9],
+            [17, 10, 11, 12, 13, 14],
+            [16, 15],
+        ]
+        expected_batches = (
+            expected_batches * (len(actual_batches) // len(expected_batches))
+        )
+
+        assert_data_shape.assert_data_shape(
+            actual_batches,
+            expected_batches,
+            self.fail,
+            message='Embeddings not batched correctly.'
+        )
+
+    async def test_ext_ai_text_search_04(self):
+        # Ai text search calls batch their embeddings requests
+        # with long inputs, and truncation needed
+        #
+        # Note:
+        #   ai_ext.py: TestTokenizer counts each char as a separate token
+        #   ext_ai.esdl: TestEmbeddingModel has a max input token length 100
+        #   ext_ai.esdl: TestEmbeddingModel has a max batch token length 500
+        query_prefix = 'text_search_04_'
+        short_entry_count = 10
+        long_entry_count = 10
+
+        # 10 entries to get embeddings and 10 entries which are too long
+        contents = (
+            [
+                f"{query_prefix}{str(n).zfill(3)}{'a' * (50 + n)}"
+                for n in range(short_entry_count)
+            ]
+            + [
+                f"{query_prefix}{str(n).zfill(3)}{'a' * (200 + n)}"
+                for n in range(
+                    short_entry_count,
+                    short_entry_count + long_entry_count
+                )
+            ]
+        )
+
+        try:
+            await self.con.execute(
+                """
+                insert Truncated {
+                    content := 'Skies on Earth are blue'
+                };
+                """,
+            )
+
+            async for tr in self.try_until_succeeds(
+                ignore=(AssertionError,),
+                timeout=30.0,
+            ):
+                async with tr:
+                    await self.assert_query_result(
+                        f'''
+                        select ({
+                            ", ".join(
+                                f"assert_single(ext::ai::search("
+                                f"    Truncated, <str>${n}"
+                                f").distance)"
+                                for n in range(len(contents))
+                            )
+                        })
+                        ''',
+                        [(
+                            0.4663014891358067,
+                            0.4669372419132616,
+                            0.4675494836157368,
+                            0.46813949300135127,
+                            0.46870845787047366,
+                            0.469257483000719,
+                            0.4697875972666343,
+                            0.47029976004002993,
+                            0.4707948669542362,
+                            0.4712737551047398,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                            0.47914243469471374,
+                        )],
+                        variables=tuple(contents)
+                    )
+
+        finally:
+            await self.con.execute('''
+                delete Truncated;
+            ''')
+
+        # Check search embeddings were batched correctly
+        current_requests = [
+            embeddings_request
+            for embeddings_request in TestExtAI._embeddings_log
+            if any(
+                entry.startswith(query_prefix)
+                for entry in embeddings_request
+            )
+        ]
+
+        prefix_length = len(query_prefix)
+        actual_batches = [
+            [
+                int(entry[prefix_length:prefix_length + 3])
+                for entry in embeddings_request
+            ]
+            for embeddings_request in current_requests
+        ]
+
+        # These will be embedded repeatedly in try_until_succeeds
+        expected_batches = [
+            [19, 0, 1, 2, 3, 4],
+            [18, 5, 6, 7, 8, 9],
+            [17, 10, 11, 12, 13],
+            [16, 14, 15],
+        ]
+        expected_batches = (
+            expected_batches * (len(actual_batches) // len(expected_batches))
+        )
+
+        assert_data_shape.assert_data_shape(
+            actual_batches,
+            expected_batches,
+            self.fail,
+            message='Embeddings not batched correctly.'
+        )
+
+    async def test_ext_ai_text_search_05(self):
+        # Ai text search calls batch their embeddings requests
+        # with long inputs, and truncation not allowed
+        #
+        # Note:
+        #   ai_ext.py: TestTokenizer counts each char as a separate token
+        #   ext_ai.esdl: TestEmbeddingModel has a max input token length 100
+        #   ext_ai.esdl: TestEmbeddingModel has a max batch token length 500
+        query_prefix = 'text_search_05_'
+        short_entry_count = 10
+        long_entry_count = 10
+
+        # 10 entries to get embeddings and 10 entries which are too long
+        contents = (
+            [
+                f"{query_prefix}{str(n).zfill(3)}{'a' * (50 + n)}"
+                for n in range(short_entry_count)
+            ]
+            + [
+                f"{query_prefix}{str(n).zfill(3)}{'a' * (200 + n)}"
+                for n in range(
+                    short_entry_count,
+                    short_entry_count + long_entry_count
+                )
+            ]
+        )
+
+        try:
+            await self.con.execute(
+                """
+                insert Astronomy {
+                    content := 'Skies on Earth are blue'
+                };
+                """,
+            )
+
+            async with self.assertRaisesRegexTx(
+                edgedb.QueryError,
+                r"Search text exceeds maximum input token length: "
+                r"text_search_05_"
+            ):
+                await self.con.execute(
+                    f'''
+                    select ({
+                        ", ".join(
+                            f"assert_single(ext::ai::search("
+                            f"    Astronomy, <str>${n}"
+                            f").distance)"
+                            for n in range(len(contents))
+                        )
+                    })
+                    ''',
+                    *contents
+                )
+
+        finally:
+            await self.con.execute('''
+                delete Truncated;
+            ''')
 
 
 class CharacterTokenizer(ai_ext.Tokenizer):


### PR DESCRIPTION
Close #8200 

- Refactor the ai extension code to simplify text truncation and batching requests
- Add `ai_ext.generate_embeddings_for_texts` which gets embeddings for an arbitrary number of inputs which may have different indexes, models, providers, etc.
- Batch the param conversions for ai text search