### PR TITLE
Bump pg version that we expose over SQL adapter

### DIFF
--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -95,8 +95,8 @@ MAX_SUGGESTED_CLIENT_POOL_SIZE = 100
 _TLS_CERT_RELOAD_MAX_RETRIES = 5
 _TLS_CERT_RELOAD_EXP_INTERVAL = 0.1
 
-PGEXT_POSTGRES_VERSION = 13.9
-PGEXT_POSTGRES_VERSION_NUM = 130009
+PGEXT_POSTGRES_VERSION = 14.17
+PGEXT_POSTGRES_VERSION_NUM = 140017
 
 # The time in seconds the Gel server will wait for a tenant to be gracefully
 # shutdown when removed from a multi-tenant host.


### PR DESCRIPTION
I've bumped just the `server_version` and `server_version_num`, all
behavior remains the same (including pg_catalog, which mostly follows
the pg_catalog of the backend postgres).
