### PR TITLE
Refactor rust parser

### DIFF
--- a/edb/edgeql-parser/src/parser/cst.rs
+++ b/edb/edgeql-parser/src/parser/cst.rs
@@ -1,0 +1,77 @@
+use crate::helpers::quote_name;
+use crate::keywords::Keyword;
+use crate::position::Span;
+use crate::tokenizer::{Kind, Token, Value};
+
+/// A node of the CST tree.
+///
+/// Warning: allocated in the bumpalo arena, which does not Drop.
+/// Any types that do allocation with global allocator (such as String or Vec),
+/// must manually drop. This is why Terminal has a special vec arena that does
+/// Drop.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum CSTNode<'a> {
+    #[default]
+    Empty,
+    Terminal(&'a Terminal),
+    Production(Production<'a>),
+}
+#[derive(Clone, Debug)]
+pub struct Terminal {
+    pub kind: Kind,
+    pub text: String,
+    pub value: Option<Value>,
+    pub span: Span,
+    pub(super) is_placeholder: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Production<'a> {
+    pub id: usize,
+    pub args: &'a [CSTNode<'a>],
+
+    /// When a production is inlined, its id is saved into the new production
+    /// This is needed when matching CST nodes by production id.
+    pub inlined_ids: Option<&'a [usize]>,
+}
+
+impl std::fmt::Display for Terminal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if (self.is_placeholder && self.kind == Kind::Ident) || self.text.is_empty() {
+            if let Some(user_friendly) = self.kind.user_friendly_text() {
+                return write!(f, "{}", user_friendly);
+            }
+        }
+
+        match self.kind {
+            Kind::Ident => write!(f, "'{}'", &quote_name(&self.text)),
+            Kind::Keyword(Keyword(kw)) => write!(f, "keyword '{}'", kw.to_ascii_uppercase()),
+            _ => write!(f, "'{}'", self.text),
+        }
+    }
+}
+
+impl Terminal {
+    pub fn from_token(token: Token) -> Self {
+        Terminal {
+            kind: token.kind,
+            text: token.text.into(),
+            value: token.value,
+            span: token.span,
+            is_placeholder: false,
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn from_start_name(start_name: &str) -> Self {
+        use super::spec;
+
+        Terminal {
+            kind: spec::get_token_kind(start_name),
+            text: "".to_string(),
+            value: None,
+            span: Default::default(),
+            is_placeholder: false,
+        }
+    }
+}

--- a/edb/edgeql-parser/src/parser/mod.rs
+++ b/edb/edgeql-parser/src/parser/mod.rs
@@ -1,12 +1,15 @@
+mod cst;
 mod custom_errors;
+mod spec;
+
+pub use cst::{CSTNode, Production, Terminal};
+pub use spec::{Action, Reduce, Spec, SpecSerializable};
 
 use append_only_vec::AppendOnlyVec;
-use indexmap::IndexMap;
 
-use crate::helpers::quote_name;
 use crate::keywords::{self, Keyword};
 use crate::position::Span;
-use crate::tokenizer::{Error, Kind, Token, Value};
+use crate::tokenizer::{Error, Kind, Value};
 
 pub struct Context<'s> {
     spec: &'s Spec,
@@ -243,65 +246,6 @@ fn new_token_for_injection<'a>(kind: Kind, ctx: &'a Context) -> &'a Terminal {
         span: Span::default(),
         is_placeholder: true,
     })
-}
-
-pub struct Spec {
-    pub actions: Vec<IndexMap<Kind, Action>>,
-    pub goto: Vec<IndexMap<String, usize>>,
-    pub start: String,
-    pub inlines: IndexMap<usize, u8>,
-    pub production_names: Vec<(String, String)>,
-}
-
-#[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum Action {
-    Shift(usize),
-    Reduce(Reduce),
-}
-
-#[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Reduce {
-    /// Index of the production in the associated production array
-    pub production_id: usize,
-
-    pub non_term: String,
-
-    /// Number of arguments
-    pub cnt: usize,
-}
-
-/// A node of the CST tree.
-///
-/// Warning: allocated in the bumpalo arena, which does not Drop.
-/// Any types that do allocation with global allocator (such as String or Vec),
-/// must manually drop. This is why Terminal has a special vec arena that does
-/// Drop.
-#[derive(Debug, Clone, Copy, Default)]
-pub enum CSTNode<'a> {
-    #[default]
-    Empty,
-    Terminal(&'a Terminal),
-    Production(Production<'a>),
-}
-#[derive(Clone, Debug)]
-pub struct Terminal {
-    pub kind: Kind,
-    pub text: String,
-    pub value: Option<Value>,
-    pub span: Span,
-    is_placeholder: bool,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Production<'a> {
-    pub id: usize,
-    pub args: &'a [CSTNode<'a>],
-
-    /// When a production is inlined, its id is saved into the new production
-    /// This is needed when matching CST nodes by production id.
-    pub inlined_ids: Option<&'a [usize]>,
 }
 
 struct StackNode<'p> {
@@ -610,160 +554,5 @@ fn injection_cost(kind: &Kind) -> u16 {
         Assign | Arrow => 5,
 
         _ => 100, // forbidden
-    }
-}
-
-impl std::fmt::Display for Terminal {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if (self.is_placeholder && self.kind == Kind::Ident) || self.text.is_empty() {
-            if let Some(user_friendly) = self.kind.user_friendly_text() {
-                return write!(f, "{}", user_friendly);
-            }
-        }
-
-        match self.kind {
-            Kind::Ident => write!(f, "'{}'", &quote_name(&self.text)),
-            Kind::Keyword(Keyword(kw)) => write!(f, "keyword '{}'", kw.to_ascii_uppercase()),
-            _ => write!(f, "'{}'", self.text),
-        }
-    }
-}
-
-impl Terminal {
-    pub fn from_token(token: Token) -> Self {
-        Terminal {
-            kind: token.kind,
-            text: token.text.into(),
-            value: token.value,
-            span: token.span,
-            is_placeholder: false,
-        }
-    }
-
-    #[cfg(feature = "serde")]
-    pub fn from_start_name(start_name: &str) -> Self {
-        Terminal {
-            kind: get_token_kind(start_name),
-            text: "".to_string(),
-            value: None,
-            span: Default::default(),
-            is_placeholder: false,
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct SpecSerializable {
-    pub actions: Vec<Vec<(String, Action)>>,
-    pub goto: Vec<Vec<(String, usize)>>,
-    pub start: String,
-    pub inlines: Vec<(usize, u8)>,
-    pub production_names: Vec<(String, String)>,
-}
-
-#[cfg(feature = "serde")]
-impl From<SpecSerializable> for Spec {
-    fn from(v: SpecSerializable) -> Spec {
-        let actions = v
-            .actions
-            .into_iter()
-            .map(|x| x.into_iter().map(|(k, a)| (get_token_kind(&k), a)))
-            .map(IndexMap::from_iter)
-            .collect();
-        let goto = v.goto.into_iter().map(IndexMap::from_iter).collect();
-        let inlines = IndexMap::from_iter(v.inlines);
-
-        Spec {
-            actions,
-            goto,
-            start: v.start,
-            inlines,
-            production_names: v.production_names,
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-fn get_token_kind(token_name: &str) -> Kind {
-    use Kind::*;
-
-    match token_name {
-        "+" => Add,
-        "&" => Ampersand,
-        "@" => At,
-        ".<" => BackwardLink,
-        "}" => CloseBrace,
-        "]" => CloseBracket,
-        ")" => CloseParen,
-        "??" => Coalesce,
-        ":" => Colon,
-        "," => Comma,
-        "++" => Concat,
-        "/" => Div,
-        "." => Dot,
-        "**" => DoubleSplat,
-        "=" => Eq,
-        "//" => FloorDiv,
-        "%" => Modulo,
-        "*" => Mul,
-        "::" => Namespace,
-        "{" => OpenBrace,
-        "[" => OpenBracket,
-        "(" => OpenParen,
-        "|" => Pipe,
-        "^" => Pow,
-        ";" => Semicolon,
-        "-" => Sub,
-
-        "?!=" => DistinctFrom,
-        ">=" => GreaterEq,
-        "<=" => LessEq,
-        "?=" => NotDistinctFrom,
-        "!=" => NotEq,
-        "<" => Less,
-        ">" => Greater,
-
-        "IDENT" => Ident,
-        "EOI" | "<$>" => EOI,
-        "<e>" => Epsilon,
-
-        "BCONST" => BinStr,
-        "FCONST" => FloatConst,
-        "ICONST" => IntConst,
-        "NFCONST" => DecimalConst,
-        "NICONST" => BigIntConst,
-        "SCONST" => Str,
-
-        "STARTBLOCK" => StartBlock,
-        "STARTEXTENSION" => StartExtension,
-        "STARTFRAGMENT" => StartFragment,
-        "STARTMIGRATION" => StartMigration,
-        "STARTSDLDOCUMENT" => StartSDLDocument,
-
-        "+=" => AddAssign,
-        "->" => Arrow,
-        ":=" => Assign,
-        "-=" => SubAssign,
-
-        "PARAMETER" => Parameter,
-        "PARAMETERANDTYPE" => ParameterAndType,
-        "SUBSTITUTION" => Substitution,
-
-        "STRINTERPSTART" => StrInterpStart,
-        "STRINTERPCONT" => StrInterpCont,
-        "STRINTERPEND" => StrInterpEnd,
-
-        _ => {
-            let mut token_name = token_name.to_lowercase();
-
-            if let Some(rem) = token_name.strip_prefix("dunder") {
-                token_name = format!("__{rem}__");
-            }
-
-            let kw = crate::keywords::lookup_all(&token_name)
-                .unwrap_or_else(|| panic!("unknown keyword {token_name}"));
-            Keyword(kw)
-        }
     }
 }

--- a/edb/edgeql-parser/src/parser/spec.rs
+++ b/edb/edgeql-parser/src/parser/spec.rs
@@ -1,0 +1,146 @@
+use indexmap::IndexMap;
+
+use crate::tokenizer::Kind;
+
+pub struct Spec {
+    pub actions: Vec<IndexMap<Kind, Action>>,
+    pub goto: Vec<IndexMap<String, usize>>,
+    pub start: String,
+    pub inlines: IndexMap<usize, u8>,
+    pub production_names: Vec<(String, String)>,
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Action {
+    Shift(usize),
+    Reduce(Reduce),
+}
+
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Reduce {
+    /// Index of the production in the associated production array
+    pub production_id: usize,
+
+    pub non_term: String,
+
+    /// Number of arguments
+    pub cnt: usize,
+}
+
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct SpecSerializable {
+    pub actions: Vec<Vec<(String, Action)>>,
+    pub goto: Vec<Vec<(String, usize)>>,
+    pub start: String,
+    pub inlines: Vec<(usize, u8)>,
+    pub production_names: Vec<(String, String)>,
+}
+
+#[cfg(feature = "serde")]
+impl From<SpecSerializable> for Spec {
+    fn from(v: SpecSerializable) -> Spec {
+        let actions = v
+            .actions
+            .into_iter()
+            .map(|x| x.into_iter().map(|(k, a)| (get_token_kind(&k), a)))
+            .map(IndexMap::from_iter)
+            .collect();
+        let goto = v.goto.into_iter().map(IndexMap::from_iter).collect();
+        let inlines = IndexMap::from_iter(v.inlines);
+
+        Spec {
+            actions,
+            goto,
+            start: v.start,
+            inlines,
+            production_names: v.production_names,
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+pub(super) fn get_token_kind(token_name: &str) -> Kind {
+    use Kind::*;
+
+    match token_name {
+        "+" => Add,
+        "&" => Ampersand,
+        "@" => At,
+        ".<" => BackwardLink,
+        "}" => CloseBrace,
+        "]" => CloseBracket,
+        ")" => CloseParen,
+        "??" => Coalesce,
+        ":" => Colon,
+        "," => Comma,
+        "++" => Concat,
+        "/" => Div,
+        "." => Dot,
+        "**" => DoubleSplat,
+        "=" => Eq,
+        "//" => FloorDiv,
+        "%" => Modulo,
+        "*" => Mul,
+        "::" => Namespace,
+        "{" => OpenBrace,
+        "[" => OpenBracket,
+        "(" => OpenParen,
+        "|" => Pipe,
+        "^" => Pow,
+        ";" => Semicolon,
+        "-" => Sub,
+
+        "?!=" => DistinctFrom,
+        ">=" => GreaterEq,
+        "<=" => LessEq,
+        "?=" => NotDistinctFrom,
+        "!=" => NotEq,
+        "<" => Less,
+        ">" => Greater,
+
+        "IDENT" => Ident,
+        "EOI" | "<$>" => EOI,
+        "<e>" => Epsilon,
+
+        "BCONST" => BinStr,
+        "FCONST" => FloatConst,
+        "ICONST" => IntConst,
+        "NFCONST" => DecimalConst,
+        "NICONST" => BigIntConst,
+        "SCONST" => Str,
+
+        "STARTBLOCK" => StartBlock,
+        "STARTEXTENSION" => StartExtension,
+        "STARTFRAGMENT" => StartFragment,
+        "STARTMIGRATION" => StartMigration,
+        "STARTSDLDOCUMENT" => StartSDLDocument,
+
+        "+=" => AddAssign,
+        "->" => Arrow,
+        ":=" => Assign,
+        "-=" => SubAssign,
+
+        "PARAMETER" => Parameter,
+        "PARAMETERANDTYPE" => ParameterAndType,
+        "SUBSTITUTION" => Substitution,
+
+        "STRINTERPSTART" => StrInterpStart,
+        "STRINTERPCONT" => StrInterpCont,
+        "STRINTERPEND" => StrInterpEnd,
+
+        _ => {
+            let mut token_name = token_name.to_lowercase();
+
+            if let Some(rem) = token_name.strip_prefix("dunder") {
+                token_name = format!("__{rem}__");
+            }
+
+            let kw = crate::keywords::lookup_all(&token_name)
+                .unwrap_or_else(|| panic!("unknown keyword {token_name}"));
+            Keyword(kw)
+        }
+    }
+}

--- a/rust/pgrust/src/python/mod.rs
+++ b/rust/pgrust/src/python/mod.rs
@@ -192,6 +192,7 @@ impl PyConnectionParams {
         }
     }
 
+    #[pyo3(signature = (username, home_dir))]
     pub fn resolve(
         &self,
         py: Python,
@@ -278,6 +279,7 @@ struct PyConnectionState {
 #[pymethods]
 impl PyConnectionState {
     #[new]
+    #[pyo3(signature = (dsn, username, home_dir))]
     fn new(
         py: Python,
         dsn: &PyConnectionParams,


### PR DESCRIPTION
Minor refactor that splits rust parser code into multiple files.

In preparation for syntactial suggestions for LSP.
