### PR TITLE
Fix MacOS sentencepiece build for gel-ls

### DIFF
--- a/.github/workflows.src/ls-build.inc.yml
+++ b/.github/workflows.src/ls-build.inc.yml
@@ -178,6 +178,7 @@
         <%- if tgt.family == "generic" %>
         BUILD_GENERIC: true
         <%- endif %>
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 

--- a/.github/workflows/ls-nightly.yml
+++ b/.github/workflows/ls-nightly.yml
@@ -269,6 +269,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 
@@ -330,6 +331,7 @@ jobs:
         EXTRA_OPTIMIZATIONS: "true"
         METAPKG_GIT_CACHE: disabled
         BUILD_GENERIC: true
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       run: |
         edgedb-pkg/integration/macos/build.sh
 


### PR DESCRIPTION
Apply the same fix as in #8583, but for build of gel-ls.
