### PR TITLE
Fix wrong values for multi links in triggers and some other places

### DIFF
--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -2364,10 +2364,16 @@ def _range_for_component_ptrref(
 def _prep_filter(larg: pgast.SelectStmt, rarg: pgast.SelectStmt) -> None:
     # Set up the proper join on the source field and clear the target list
     # of the rhs of a filter overlay.
-    assert isinstance(larg.target_list[0].val, pgast.ColumnRef)
-    assert isinstance(rarg.target_list[0].val, pgast.ColumnRef)
-    rarg.where_clause = astutils.join_condition(
-        larg.target_list[0].val, rarg.target_list[0].val)
+    lval = larg.target_list[0].val
+    assert isinstance(lval, pgast.ColumnRef)
+    if len(lval.name) == 1:
+        lval = astutils.get_column(larg.from_clause[0], lval)
+    rval = rarg.target_list[0].val
+    assert isinstance(rval, pgast.ColumnRef)
+    if len(rval.name) == 1:
+        rval = astutils.get_column(rarg.from_clause[0], rval)
+
+    rarg.where_clause = astutils.join_condition(lval, rval)
     rarg.target_list.clear()
 
 


### PR DESCRIPTION
When constructing the overlays, the FILTER join we constructed was
looking for `source = source`, because we weren't qualifying the
names.

Fixes #8604.