### PR TITLE
Fix SET GLOBAL when right hand side needs to use access policies

### DIFF
--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -1350,6 +1350,7 @@ class ConfigCommand(Command, Expr):
     requires_restart: bool
     backend_setting: typing.Optional[str]
     is_system_config: bool
+    type_rewrites: typing.Optional[dict[tuple[uuid.UUID, bool], Set]] = None
     globals: typing.Optional[list[Global]] = None
     scope_tree: typing.Optional[ScopeTreeNode] = None
 

--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -118,6 +118,8 @@ def compile_ir_to_sql_tree(
             query_params = list(ir_expr.params)
             if ir_expr.globals:
                 query_globals = list(ir_expr.globals)
+            if ir_expr.type_rewrites:
+                type_rewrites = ir_expr.type_rewrites
         else:
             scope_tree = irast.new_scope_tree()
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1592,9 +1592,11 @@ def _get_compile_options(
     ctx: CompileContext,
     *,
     is_explain: bool = False,
+    no_implicit_fields: bool = False,
 ) -> qlcompiler.CompilerOptions:
-    can_have_implicit_fields = (
-        ctx.output_format is enums.OutputFormat.BINARY)
+    can_have_implicit_fields = not no_implicit_fields and (
+        ctx.output_format is enums.OutputFormat.BINARY
+    )
 
     return qlcompiler.CompilerOptions(
         modaliases=ctx.state.current_tx().get_modaliases(),
@@ -1610,6 +1612,7 @@ def _get_compile_options(
         json_parameters=ctx.json_parameters,
         implicit_limit=ctx.implicit_limit,
         bootstrap_mode=ctx.bootstrap_mode,
+        dump_restore_mode=ctx.dump_restore_mode,
         apply_query_rewrites=(
             not ctx.bootstrap_mode
             and not ctx.schema_reflection_mode
@@ -2436,7 +2439,6 @@ def _compile_ql_config_op(
     current_tx = ctx.state.current_tx()
     schema = current_tx.get_schema(ctx.compiler_state.std_schema)
 
-    modaliases = current_tx.get_modaliases()
     session_config = current_tx.get_session_config()
     database_config = current_tx.get_database_config()
 
@@ -2450,14 +2452,13 @@ def _compile_ql_config_op(
         raise errors.QueryError(
             'CONFIGURE INSTANCE cannot be executed in a transaction block')
 
+    options = _get_compile_options(ctx, no_implicit_fields=True)
+    options.in_server_config_op = True
+
     ir = qlcompiler.compile_ast_to_ir(
         ql,
         schema=schema,
-        options=qlcompiler.CompilerOptions(
-            modaliases=modaliases,
-            in_server_config_op=True,
-            dump_restore_mode=ctx.dump_restore_mode,
-        ),
+        options=options,
     )
 
     globals = None


### PR DESCRIPTION
Previously, we were always *compiling* access policies but then
ignoring them. This meant that they were not applied but that if they
referenced a global, we would try to inject it, which would cause an
ISE.

Fix by respecting access policies correctly.

Fixes #8618