### PR TITLE
server: add cached branch limit to the compiler pool

### DIFF
--- a/edb/common/lru.py
+++ b/edb/common/lru.py
@@ -131,7 +131,7 @@ def method_cache(f: Tf) -> Tf:
     return lru_method_cache(None)(f)
 
 
-def clear_cache(method: Tf) -> None:
+def clear_method_cache(method: Tf) -> None:
     assert isinstance(method, MethodType)
     key = f'__{method.__func__.__name__}_cached'
     _m: Optional[_NoPickle] = getattr(method.__self__, key, None)

--- a/edb/common/lru.py
+++ b/edb/common/lru.py
@@ -23,7 +23,8 @@ import collections.abc
 import functools
 
 
-from typing import TypeVar, Callable
+from typing import TypeVar, Callable, Optional
+from types import MethodType
 
 
 class LRUMapping(collections.abc.MutableMapping):
@@ -111,6 +112,7 @@ def lru_method_cache(size: int | None=128) -> Callable[[Tf], Tf]:
     def transformer(f: Tf) -> Tf:
         key = f'__{f.__name__}_cached'
 
+        @functools.wraps(f)
         def func(self, *args, **kwargs):
             _m = getattr(self, key, None)
             if not _m:
@@ -127,3 +129,11 @@ def lru_method_cache(size: int | None=128) -> Callable[[Tf], Tf]:
 
 def method_cache(f: Tf) -> Tf:
     return lru_method_cache(None)(f)
+
+
+def clear_cache(method: Tf) -> None:
+    assert isinstance(method, MethodType)
+    key = f'__{method.__func__.__name__}_cached'
+    _m: Optional[_NoPickle] = getattr(method.__self__, key, None)
+    if _m is not None:
+        _m.obj.cache_clear()

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -830,8 +830,8 @@ server_options = typeutils.chain_decorators([
         envvar="GEL_SERVER_COMPILER_WORKER_BRANCH_LIMIT",
         cls=EnvvarResolver,
         help='The maximum NUM of branches each compiler worker could cache up '
-             'to, default is 5.  If the worker serves multiple tenants as in '
-             '--compiler-pool-mode=fixed_multi_tenant or remote, each tenant '
+             'to, default is 5.  If the worker serves multiple tenants (as in '
+             '--compiler-pool-mode=fixed_multi_tenant or remote), this tenant '
              'on that worker will be able to cache up to NUM branches.'
     ),
     click.option(

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -861,7 +861,7 @@ server_options = typeutils.chain_decorators([
         "--compiler-pool-tenant-cache-size",
         hidden=True,
         type=int,
-        default=100,
+        default=20,
         envvar="GEL_SERVER_COMPILER_POOL_TENANT_CACHE_SIZE",
         cls=EnvvarResolver,
         help="Maximum number of tenants for which each compiler worker can "
@@ -1169,10 +1169,11 @@ compiler_options = typeutils.chain_decorators([
     click.option(
         "--client-schema-cache-size",
         type=int,
-        default=100,
-        help="Number of client schemas each worker could cache at most. The "
-             "compiler server is not affected by this setting, it keeps a "
-             "pickled copy of the client schema of all active clients."
+        default=20,
+        help="Maximum number of clients for which each worker can cache their "
+             "schemas, The compiler server is not affected by this setting, "
+             "it keeps pickled copies of schemas from all active clients "
+             "(each capped by --compiler-worker-branch-limit of the client)."
     ),
     click.option(
         '-I', '--listen-addresses', type=str, multiple=True,

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -254,6 +254,7 @@ class ServerConfig(NamedTuple):
     extensions_dir: tuple[pathlib.Path, ...]
     max_backend_connections: Optional[int]
     compiler_pool_size: int
+    compiler_worker_branch_limit: int
     compiler_pool_mode: CompilerPoolMode
     compiler_pool_addr: tuple[str, int]
     compiler_pool_tenant_cache_size: int
@@ -811,10 +812,28 @@ server_options = typeutils.chain_decorators([
              f'minus the NUM of --reserved-pg-connections.',
         callback=_validate_max_backend_connections),
     click.option(
-        '--compiler-pool-size', type=int,
+        '--compiler-pool-size', type=int, metavar='NUM',
         envvar="GEL_SERVER_COMPILER_POOL_SIZE",
         cls=EnvvarResolver,
-        callback=_validate_compiler_pool_size),
+        callback=_validate_compiler_pool_size,
+        help='Size of the compiler pool.  When --compiler-pool-mode=fixed or '
+             'fixed_multi_tenant, it is the NUM of compiler worker processes, '
+             f"defaults to {compute_default_compiler_pool_size()} (you'll see "
+             '1 extra template process); for on_demand, it is the maximum NUM '
+             'of workers the pool could scale up to, with the same default; '
+             'for remote, it is the maximum NUM of concurrent requests to the '
+             'remote compiler server, defaults to 2.'
+    ),
+    click.option(
+        '--compiler-worker-branch-limit', type=int, metavar='NUM',
+        default=5,
+        envvar="GEL_SERVER_COMPILER_WORKER_BRANCH_LIMIT",
+        cls=EnvvarResolver,
+        help='The maximum NUM of branches each compiler worker could cache up '
+             'to, default is 5.  If the worker serves multiple tenants as in '
+             '--compiler-pool-mode=fixed_multi_tenant or remote, each tenant '
+             'on that worker will be able to cache up to NUM branches.'
+    ),
     click.option(
         '--compiler-pool-mode',
         type=CompilerPoolModeChoice(),

--- a/edb/server/compiler_pool/multitenant_worker.py
+++ b/edb/server/compiler_pool/multitenant_worker.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Optional, NamedTuple, Sequence
+from typing import Any, Callable, Optional, NamedTuple, Sequence
 
 import pickle
 
@@ -396,7 +396,8 @@ def call_for_client(
     return meth(client_id, dbname, *compile_args)
 
 
-def get_handler(methname: str):
+def get_handler(methname: str) -> Callable[..., Any]:
+    meth: Callable[..., Any]
     methname = methname.removeprefix("v2_")
     if methname == "__init_worker__":
         meth = __init_worker__

--- a/edb/server/compiler_pool/multitenant_worker.py
+++ b/edb/server/compiler_pool/multitenant_worker.py
@@ -347,7 +347,7 @@ def call_for_client(client_id, pickled_schema, invalidation, msg, *args):
         assert args == ()
         methname, args = pickle.loads(msg)
         dbname = args[0]
-        args = args[6:]
+        args = args[7:]
 
     if methname == "compile":
         meth = compile

--- a/edb/server/compiler_pool/multitenant_worker.py
+++ b/edb/server/compiler_pool/multitenant_worker.py
@@ -18,7 +18,7 @@
 
 
 from __future__ import annotations
-from typing import Any, Optional, NamedTuple
+from typing import Any, Optional, NamedTuple, Sequence
 
 import pickle
 
@@ -337,17 +337,34 @@ def compile_sql(
     )
 
 
-def call_for_client(client_id, pickled_schema, invalidation, msg, *args):
+def call_for_client(
+    client_id: int,
+    pickled_schema: Optional[bytes],
+    invalidation: Sequence[int],
+    msg: Optional[bytes],
+    *args: Any,
+) -> Any:
     __sync__(client_id, pickled_schema, invalidation)
     if msg is None:
-        methname = args[0]
-        dbname = args[1]
-        args = args[2:]
+        methname, dbname, *compile_args = args
     else:
         assert args == ()
         methname, args = pickle.loads(msg)
-        dbname = args[0]
-        args = args[7:]
+        (
+            dbname,
+
+            # These are pass-thru arguments from Gel server, they are already
+            # utilized in the compiler server and forwarded to us through
+            # "pickled_schema" argument, so we don't need them here.
+            evicted_dbs,
+            user_schema,
+            reflection_cache,
+            global_schema,
+            database_config,
+            system_config,
+
+            *compile_args,
+        ) = args
 
     if methname == "compile":
         meth = compile
@@ -358,8 +375,10 @@ def call_for_client(client_id, pickled_schema, invalidation, msg, *args):
     elif methname == "compile_sql":
         meth = compile_sql
     else:
-        meth = getattr(COMPILER, methname)
-    return meth(client_id, dbname, *args)
+        raise NotImplementedError(
+            f"call_for_client() is not implemented for {methname!r} method. "
+        )
+    return meth(client_id, dbname, *compile_args)
 
 
 def get_handler(methname):

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -72,7 +72,8 @@ if TYPE_CHECKING:
     from edb.server.compiler import dbstate
     from edb.server.compiler import sertypes
 
-SyncStateCallback = SyncFinalizer = Callable[[], None]
+SyncStateCallback = Callable[[], None]
+SyncFinalizer = Callable[[], None]
 Config = immutables.Map[str, config.SettingValue]
 InitArgs = tuple[
     pgparams.BackendRuntimeParams,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -104,6 +104,7 @@ KILL_TIMEOUT: float = 10.0
 ADAPTIVE_SCALE_UP_WAIT_TIME: float = 3.0
 ADAPTIVE_SCALE_DOWN_WAIT_TIME: float = 60.0
 WORKER_PKG: str = __name__.rpartition('.')[0] + '.'
+CALL_FOR_CLIENT_VERSION = 2
 
 
 logger = logging.getLogger("edb.server")
@@ -1461,7 +1462,7 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
                 "is not set"
             )
         self._secret = secret.encode()
-        self._server_version = 2
+        self._server_version = CALL_FOR_CLIENT_VERSION
 
     async def start(self, *, retry: bool = False) -> None:
         if self._worker is None:
@@ -2048,6 +2049,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
             client_id,
             pickled_schema,
             worker.get_invalidation(),
+            CALL_FOR_CLIENT_VERSION,
             None,  # forwarded msg is only used in remote compiler server
             method_name,
             dbname,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -253,6 +253,7 @@ class Worker(BaseWorker):
 class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
 
     _loop: asyncio.AbstractEventLoop
+    _worker_branch_limit: int
     _backend_runtime_params: pgparams.BackendRuntimeParams
     _std_schema: s_schema.FlatSchema
     _refl_schema: s_schema.FlatSchema
@@ -263,9 +264,11 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
         self,
         *,
         loop: asyncio.AbstractEventLoop,
+        worker_branch_limit: int,
         **kwargs: Any,
     ) -> None:
         self._loop = loop
+        self._worker_branch_limit = worker_branch_limit
         self._init(kwargs)
 
     def _init(self, kwargs: dict[str, Any]) -> None:
@@ -1972,6 +1975,7 @@ async def create_compiler_pool(
     *,
     runstate_dir: str,
     pool_size: int,
+    worker_branch_limit: int,
     backend_runtime_params: pgparams.BackendRuntimeParams,
     std_schema: s_schema.FlatSchema,
     refl_schema: s_schema.FlatSchema,
@@ -1984,6 +1988,7 @@ async def create_compiler_pool(
     pool = pool_class(
         loop=loop,
         pool_size=pool_size,
+        worker_branch_limit=worker_branch_limit,
         runstate_dir=runstate_dir,
         backend_runtime_params=backend_runtime_params,
         std_schema=std_schema,

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -1383,7 +1383,7 @@ class RemoteWorker(BaseWorker):
         method_name: str,
         args: tuple[Any, ...],
     ) -> memoryview:
-        msg = pickle.dumps((method_name, args))
+        msg = pickle.dumps(("v2_" + method_name, args))
         digest = hmac.digest(self._secret, msg, "sha256")
         return await self._con.request(digest + msg)
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -1370,16 +1370,19 @@ class SimpleAdaptivePool(BaseLocalPool[Worker, InitArgs]):
 class RemoteWorker(BaseWorker):
     _con: amsg.HubConnection
     _secret: bytes
+    _server_version: int
 
     def __init__(
         self,
         con: amsg.HubConnection,
         secret: bytes,
         *args: Any,
+        server_version: int,
     ) -> None:
         super().__init__(*args)
         self._con = con
         self._secret = secret
+        self._server_version = server_version
 
     def close(self) -> None:
         if self._closed:
@@ -1392,9 +1395,24 @@ class RemoteWorker(BaseWorker):
         method_name: str,
         args: tuple[Any, ...],
     ) -> memoryview:
-        msg = pickle.dumps(("v2_" + method_name, args))
+        msg = pickle.dumps((method_name, args))
         digest = hmac.digest(self._secret, msg, "sha256")
         return await self._con.request(digest + msg)
+
+    def prepare_evict_db(self, keep: int) -> list[str]:
+        match self._server_version:
+            case 1:
+                return []
+            case _:
+                return super().prepare_evict_db(keep)
+
+    def evict_db(self, name: str) -> None:
+        match self._server_version:
+            case 1:
+                # shouldn't happen, but just in case
+                raise RuntimeError("evict_db is not supported by this server")
+            case _:
+                super().evict_db(name)
 
 
 @srvargs.CompilerPoolMode.Remote.assign_implementation
@@ -1406,6 +1424,7 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
     _semaphore: asyncio.BoundedSemaphore
     _pool_size: int
     _secret: bytes
+    _server_version: int
 
     def __init__(
         self,
@@ -1427,6 +1446,7 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
                 "is not set"
             )
         self._secret = secret.encode()
+        self._server_version = 2
 
     async def start(self, *, retry: bool = False) -> None:
         if self._worker is None:
@@ -1473,7 +1493,14 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
         std_args = (
             self._std_schema, self._refl_schema, self._schema_class_layout
         )
-        client_args = (self._backend_runtime_params,)
+        client_args: tuple[Any, ...]
+        match self._server_version:
+            case 1:
+                # compatible with pre-#8621 servers
+                client_args = (immutables.Map(), self._backend_runtime_params)
+            case _:
+                client_args = (self._backend_runtime_params,)
+
         return init_args, (
             pickle.dumps(std_args, -1),
             pickle.dumps(client_args, -1),
@@ -1491,18 +1518,47 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
     ) -> None:
         if self._worker is None:
             return
+        # Note: `version` is worker not `self._server_version`; `version` is
+        # `_template_proc_version` in FixedPool and is not used here.
+        con = amsg.HubConnection(transport, protocol, self._loop, version)
         try:
-            init_args, init_args_pickled = self._get_init_args()
-            worker = RemoteWorker(
-                amsg.HubConnection(transport, protocol, self._loop, version),
-                self._secret,
-                *init_args,
-            )
-            await worker.call(
-                '__init_server__',
-                defines.EDGEDB_CATALOG_VERSION,
-                init_args_pickled,
-            )
+            while True:
+                init_args, init_args_pickled = self._get_init_args()
+                worker = RemoteWorker(
+                    con,
+                    self._secret,
+                    *init_args,
+                    server_version=self._server_version,
+                )
+
+                try:
+                    await worker.call(
+                        '__init_server__',
+                        defines.EDGEDB_CATALOG_VERSION,
+                        init_args_pickled,
+                    )
+                except ValueError:
+                    # Here we depend on a ValueError in v1 server trying to
+                    # unpack `client_args` into `(dbs, backend_runtime_params)`
+                    # while we attempt to send only `(backend_runtime_params,)`
+                    # (both supported in v2 server) first, in order to detect
+                    # the server version. We cannot use the method_name prefix
+                    # hack for detection because v1 server will hang until it's
+                    # called with exactly `__init_server__` with no prefix.
+                    if self._server_version > 1:
+                        self._server_version -= 1
+                        lru.clear_cache(self._make_cached_init_args)
+                        logger.info(
+                            f"falling back to compiler server protocol "
+                            f"version {self._server_version}"
+                        )
+                    else:
+                        raise state.IncompatibleClient(
+                            "the compiler server's version is incompatible"
+                        )
+                else:
+                    break
+
         except state.IncompatibleClient as ex:
             transport.abort()
             if self._worker is not None:
@@ -1615,6 +1671,13 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
             else:
                 # Case 2: no state sync needed, release the lock immediately.
                 self._sync_lock.release()
+
+        if self._server_version == 1:
+            # Old server doesn't support the `evicted_dbs` param
+            method_name, dbname, evicted_dbs, *rem = preargs
+            assert evicted_dbs == []
+            preargs = (method_name, dbname, *rem)
+
         return preargs, callback, fini
 
     def get_debug_info(self) -> dict[str, Any]:
@@ -1622,6 +1685,7 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
             address="{}:{}".format(*self._pool_addr),
             size=self._semaphore._bound_value,  # type: ignore
             free=self._semaphore._value,  # type: ignore
+            server_version=self._server_version,
         )
 
     def get_size_hint(self) -> int:

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -2040,7 +2040,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
                     tenant_schema.get_db(dbname)
                 else:
                     # The worker has a different root user schema
-                    user_schema_pickle_arg = worker_db.user_schema_pickle
+                    user_schema_pickle_arg = user_schema_pickle
 
         try:
             units, new_pickled_state = await worker.call(

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -387,11 +387,14 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
                                 or worker_db.user_schema_pickle
                             ),
                             reflection_cache=(
-                                reflection_cache
-                                or worker_db.reflection_cache
+                                worker_db.reflection_cache
+                                if reflection_cache is None
+                                else reflection_cache
                             ),
                             database_config=(
-                                database_config or worker_db.database_config
+                                worker_db.database_config
+                                if database_config is None
+                                else database_config
                             ),
                         ),
                     )

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -1547,7 +1547,7 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
                     # called with exactly `__init_server__` with no prefix.
                     if self._server_version > 1:
                         self._server_version -= 1
-                        lru.clear_cache(self._make_cached_init_args)
+                        lru.clear_method_cache(self._make_cached_init_args)
                         logger.info(
                             f"falling back to compiler server protocol "
                             f"version {self._server_version}"

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -250,6 +250,8 @@ class MultiSchemaPool(
         client_id: int,
         catalog_version: int,
         init_args_pickled: pool_mod.RemoteInitArgsPickle,
+        *,
+        is_v2: bool,
     ) -> None:
         (
             std_args_pickled,
@@ -257,7 +259,22 @@ class MultiSchemaPool(
             global_schema_pickle,
             system_config_pickled,
         ) = init_args_pickled
-        backend_runtime_params, = pickle.loads(client_args_pickled)
+        if is_v2:
+            backend_runtime_params, = pickle.loads(client_args_pickled)
+            dbs_arg = immutables.Map()
+        else:
+            dbs, backend_runtime_params = pickle.loads(client_args_pickled)
+            dbs_arg = immutables.Map(
+                (
+                    dbname,
+                    PickledState(
+                        state.user_schema_pickle,
+                        pickle.dumps(state.reflection_cache, -1),
+                        pickle.dumps(state.database_config, -1),
+                    ),
+                )
+                for dbname, state in dbs.items()
+            )
         if self._inited.is_set():
             logger.debug("New client %d connected.", client_id)
             assert self._catalog_version is not None
@@ -280,7 +297,7 @@ class MultiSchemaPool(
                 client_id,
             )
         self._clients[client_id] = ClientSchema(
-            dbs=immutables.Map(),
+            dbs=dbs_arg,
             global_schema=global_schema_pickle,
             instance_config=system_config_pickled,
             dropped_dbs=(),
@@ -514,10 +531,13 @@ class MultiSchemaPool(
                 raise AssertionError("message signature verification failed")
 
             method_name, args = pickle.loads(msg)
+            is_v2 = (
+                method_name != (method_name := method_name.removeprefix("v2_"))
+            )
             if method_name != "__init_server__":
                 await self._ready_evt.wait()
             if method_name == "__init_server__":
-                await self._init_server(client_id, *args)
+                await self._init_server(client_id, *args, is_v2=is_v2)
                 pickled = pickle.dumps((0, None), -1)
             elif method_name in {
                 "compile",
@@ -525,16 +545,29 @@ class MultiSchemaPool(
                 "compile_graphql",
                 "compile_sql",
             }:
-                (
-                    dbname,
-                    evicted_dbs,
-                    user_schema,
-                    reflection_cache,
-                    global_schema,
-                    database_config,
-                    system_config,
-                    *args,
-                ) = args
+                if is_v2:
+                    (
+                        dbname,
+                        evicted_dbs,
+                        user_schema,
+                        reflection_cache,
+                        global_schema,
+                        database_config,
+                        system_config,
+                        *args,
+                    ) = args
+                else:
+                    # compatible with pre-#8621 clients
+                    evicted_dbs = []
+                    (
+                        dbname,
+                        user_schema,
+                        reflection_cache,
+                        global_schema,
+                        database_config,
+                        system_config,
+                        *args,
+                    ) = args
                 pickled = await self._call_for_client(
                     client_id=client_id,
                     method_name=method_name,

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -588,7 +588,9 @@ class MultiSchemaPool(
                 pickled = await self._request(method_name, bytes(msg))
         except Exception as ex:
             worker_proc.prepare_exception(ex)
-            if debug.flags.server:
+            if debug.flags.server and not isinstance(
+                ex, state_mod.StateNotFound
+            ):
                 markup.dump(ex)
             data = (1, ex, traceback.format_exc())
             try:

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -473,9 +473,9 @@ class MultiSchemaPool(
     async def compile_in_tx_(
         self,
         state_id: int,
-        client_id: int,
-        dbname: str,
-        user_schema_pickle: bytes,
+        client_id: Optional[int],
+        dbname: Optional[str],
+        user_schema_pickle: Optional[bytes],
         pickled_state: bytes,
         txid: int,
         *compile_args: Any,

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -672,6 +672,7 @@ async def server_main(
             loop=loop,
             runstate_dir=runstate_dir,
             pool_size=pool_size,
+            worker_branch_limit=0,  # compiler server doesn't use this limit
             cache_size=client_schema_cache_size,
             secret=secret.encode(),
         )

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -416,7 +416,7 @@ class MultiSchemaPool(
                 if updated:
                     # re-pickle the request if user schema changed
                     msg_arg = None
-                    extra_args = (method_name, dbname, args)
+                    extra_args = (method_name, dbname, *args)
                 else:
                     msg_arg = bytes(msg)
             invalidation = worker.flush_invalidation()

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -259,6 +259,7 @@ class MultiSchemaPool(
             global_schema_pickle,
             system_config_pickled,
         ) = init_args_pickled
+        dbs_arg: immutables.Map[str, PickledState]
         if is_v2:
             backend_runtime_params, = pickle.loads(client_args_pickled)
             dbs_arg = immutables.Map()

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -135,7 +135,6 @@ class Worker(pool_mod.Worker):
             manager,
             server,
             pid,
-            None,
             backend_runtime_params,
             std_schema,
             refl_schema,

--- a/edb/server/dbview/dbview.pyi
+++ b/edb/server/dbview/dbview.pyi
@@ -39,7 +39,6 @@ from edb.server import server
 from edb.server import tenant
 from edb.server.compiler import dbstate
 from edb.server.compiler import sertypes
-from edb.server.compiler_pool import state
 
 Config: TypeAlias = Mapping[str, config.SettingValue]
 
@@ -225,7 +224,6 @@ class DatabaseIndex:
     def get_cached_compiler_args(
         self,
     ) -> tuple[
-        immutables.Map[str, state.PickledDatabaseState],
         bytes,
         immutables.Map[str, config.SettingValue],
     ]:

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -45,7 +45,6 @@ from edb.server import compiler, defines, config, metrics, pgcon
 from edb.server.compiler import dbstate, enums, sertypes
 from edb.server.protocol import execute
 from edb.pgsql import dbops
-from edb.server.compiler_pool import state as compiler_state_mod
 from edb.server.pgcon import errors as pgerror
 
 from edb.server.protocol import ai_ext
@@ -2036,18 +2035,8 @@ cdef class DatabaseIndex:
 
     def get_cached_compiler_args(self):
         if self._cached_compiler_args is None:
-            dbs = immutables.Map()
-            for db in self._dbs.values():
-                dbs = dbs.set(
-                    db.name,
-                    compiler_state_mod.PickledDatabaseState(
-                        user_schema_pickle=db.user_schema_pickle,
-                        reflection_cache=db.reflection_cache,
-                        database_config=db.db_config,
-                    )
-                )
             self._cached_compiler_args = (
-                dbs, self._global_schema_pickle, self._comp_sys_config
+                self._global_schema_pickle, self._comp_sys_config
             )
         return self._cached_compiler_args
 

--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -228,6 +228,7 @@ async def _run_server(
             runstate_dir=runstate_dir,
             internal_runstate_dir=internal_runstate_dir,
             compiler_pool_size=args.compiler_pool_size,
+            compiler_worker_branch_limit=args.compiler_worker_branch_limit,
             compiler_pool_mode=args.compiler_pool_mode,
             compiler_pool_addr=args.compiler_pool_addr,
             nethosts=args.bind_addresses,

--- a/edb/server/multitenant.py
+++ b/edb/server/multitenant.py
@@ -475,6 +475,7 @@ async def run_server(
             cors_always_allowed_origins=args.cors_always_allowed_origins,
             disable_dynamic_system_config=args.disable_dynamic_system_config,
             compiler_pool_size=args.compiler_pool_size,
+            compiler_worker_branch_limit=args.compiler_worker_branch_limit,
             compiler_pool_mode=srvargs.CompilerPoolMode.MultiTenant,
             compiler_pool_addr=args.compiler_pool_addr,
             compiler_pool_tenant_cache_size=(

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -143,6 +143,7 @@ class BaseServer:
         runstate_dir,
         internal_runstate_dir,
         compiler_pool_size,
+        compiler_worker_branch_limit,
         compiler_pool_mode: srvargs.CompilerPoolMode,
         compiler_pool_addr,
         nethosts,
@@ -190,6 +191,7 @@ class BaseServer:
         self._internal_runstate_dir = internal_runstate_dir
         self._compiler_pool = None
         self._compiler_pool_size = compiler_pool_size
+        self._compiler_worker_branch_limit = compiler_worker_branch_limit
         self._compiler_pool_mode = compiler_pool_mode
         self._compiler_pool_addr = compiler_pool_addr
         self._system_compile_cache = lru.LRUMapping(
@@ -600,6 +602,7 @@ class BaseServer:
 
         args = dict(
             pool_size=self._compiler_pool_size,
+            worker_branch_limit=self._compiler_worker_branch_limit,
             pool_class=self._compiler_pool_mode.pool_class,
             runstate_dir=self._internal_runstate_dir,
             backend_runtime_params=runtime_params,

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -545,6 +545,7 @@ class TestCompilerPool(tbs.TestCase):
             pool_ = await pool.create_compiler_pool(
                 runstate_dir=td,
                 pool_size=2,
+                worker_branch_limit=5,
                 backend_runtime_params=pg_params.get_default_runtime_params(),
                 std_schema=self._std_schema,
                 refl_schema=self._refl_schema,


### PR DESCRIPTION
This PR adds a new option to the Gel server:

```
  --compiler-worker-branch-limit NUM
                                  The maximum NUM of branches each compiler
                                  worker could cache up to, default is 5.  If
                                  the worker serves multiple tenants as in
                                  --compiler-pool-mode=fixed_multi_tenant,
                                  each tenant on that worker will be able to
                                  cache up to NUM branches.
```

(or equivalent env var GEL_SERVER_COMPILER_WORKER_BRANCH_LIMIT)

In shared compiler mode, the remote compiler server has already been syncing with its workers for dropped branches; it was only that the "clients" (Gel servers using a remote compiler server) never requested their compiler to evict branches. With this PR, "clients" will ask their compiler to evict the cache of least-recently-used branches beyond NUM, and the compiler server will answer to that, hence evicting the corresponding cache on the worker processes. Note, this is done in a lazy way instead of immediate eviction on branch drop; the schema of dropped/evicted branches may still linger in the worker's memory until it is called for that client.

Each "client" sharing the same compiler server MAY set a different NUM, the compiler server and its workers will just follow orders to add/evict branch schemas. This means, the memory usage of the compiler server and its workers is decided by 2 factors:

1. The `--client-schema-cache-size` argument on the compiler server: this decides how many "clients" the compiler server will cache up to;
2. The `--compiler-worker-branch-limit` of each "client" (Gel server) using that compiler server.

In multi-tenant mode, the Gel server manages the cached branch schemas in each worker directly. Therefore, this new option will just work for all tenants consistently. The memory usage would be something like:

$$
\text{AverageBranchSize} \times \texttt{--compiler-worker-branch-limit} \times \texttt{--compiler-pool-tenant-cache-size} \times \texttt{--pool-size} + \text{Fixture}
$$

This PR lowered both `--client-schema-cache-size` and `--compiler-pool-tenant-cache-size` from 100 down to 20.

[CI run for remote compiler / multitenant](https://github.com/geldata/gel/actions/runs/14650653412)
[another run with bi-directional compat](https://github.com/geldata/gel/actions/runs/14716659865)


- [x] Add typing (#8622)
- [x] Add branch limit
- [ ] Add metrics