### PR TITLE
Fix proto hang running script after setting default_transaction_*

### DIFF
--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -571,6 +571,7 @@ cdef class PGConnection:
 
         if state is not None and start == 0:
             self._build_apply_state_req(state, out)
+            # N.B: Condition here needs to match that in wait_for_state_resp
             if needs_commit_state or self.state_reset_needs_commit:
                 self.write_sync(out)
 
@@ -685,7 +686,8 @@ cdef class PGConnection:
     async def wait_for_state_resp(
         self, bytes state, bint state_sync, bint needs_commit_state
     ):
-        if state_sync:
+        # N.B: Condition here needs to match that in send_query_unit_group
+        if state_sync or self.state_reset_needs_commit:
             try:
                 await self._parse_apply_state_resp(2 if state is None else 3)
             finally:
@@ -2007,6 +2009,12 @@ cdef class PGConnection:
 
         cdef:
             char mtype = self.buffer.get_message_type()
+
+        # Process a sync, or else the state machine might hang
+        # forever... but still fail!
+        if mtype == b'Z':
+            self.parse_sync_message()
+
         raise RuntimeError(
             f'unexpected message type {chr(mtype)!r}')
 
@@ -2185,7 +2193,7 @@ cdef class PGConnection:
             self.xact_status = PQTRANS_UNKNOWN
 
         if self.debug:
-            self.debug_print('SYNC MSG', self.xact_status)
+            self.debug_print('SYNC MSG', self.xact_status, chr(status))
 
         self.buffer.finish_message()
         return status


### PR DESCRIPTION
If `state_reset_needs_commit` is set in `send_query_unit_group`, then
it will ask for a sync, even if needs_commit_state was not set. But
`wait_for_state_resp` didn't know about this, so it did not wait for
the sync, which then arrived later, during `wait_for_command`, which
choked on it during `fallthrough`.

Then, during the cleanup for `parse_execute_script_context`, the
processing hung forever looking for a sync that already arrived.

So, we:
 * Make sure wait_for_state_resp uses the same wait condition
 * Process a sync in fallthrough before raising the exception,
   so that a sync appearing at the wrong time due to a state machine
   bug doesn't get caught later waiting for the sync.

There is a test that triggers this in a pending gel-python patch I'm
working on.

I wasn't able to produce a test that worked in this test suite,
because our testbase connection's `with_options` is broken for reasons
that are still mysterious to me. The state *is* getting threaded in,
so I'm guessing that something is wrong with the codec and it isn't
getting encoded right.