### PR TITLE
Avoid hanging onto Schema objects with lru_caches

### DIFF
--- a/edb/common/lru.py
+++ b/edb/common/lru.py
@@ -98,7 +98,7 @@ class _NoPickle:
         self.obj = None
 
 
-def lru_method_cache(size: int | None=128) -> Callable[[Tf], Tf]:
+def lru_method_cache(maxsize: int | None=128) -> Callable[[Tf], Tf]:
     """A version of lru_cache for methods that shouldn't leak memory.
 
     Basically the idea is that we generate a per-object lru-cached
@@ -115,7 +115,7 @@ def lru_method_cache(size: int | None=128) -> Callable[[Tf], Tf]:
             _m = getattr(self, key, None)
             if not _m:
                 _m = _NoPickle(
-                    functools.lru_cache(size)(functools.partial(f, self))
+                    functools.lru_cache(maxsize)(functools.partial(f, self))
                 )
                 setattr(self, key, _m)
             return _m.obj(*args, **kwargs)
@@ -127,3 +127,25 @@ def lru_method_cache(size: int | None=128) -> Callable[[Tf], Tf]:
 
 def method_cache(f: Tf) -> Tf:
     return lru_method_cache(None)(f)
+
+
+_LRU_CACHES: list[functools._lru_cache_wrapper] = []
+
+
+def per_job_lru_cache(maxsize: int | None=128) -> Callable[[Tf], Tf]:
+    """A version of lru_cache that can be cleared en masse.
+
+    All the caches will be tracked and calling clear_lru_caches()
+    will clear them all.
+    """
+    def transformer(f: Tf) -> Tf:
+        wrapped = functools.lru_cache(maxsize)(f)
+        _LRU_CACHES.append(wrapped)
+        return wrapped  # type: ignore
+
+    return transformer
+
+
+def clear_lru_caches():
+    for cache in _LRU_CACHES:
+        cache.cache_clear()

--- a/edb/graphql/compiler.py
+++ b/edb/graphql/compiler.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 from typing import Any, Optional, Mapping
 
-import functools
 
 from edb import graphql
 
@@ -29,7 +28,6 @@ from edb.schema import schema as s_schema
 from graphql.language import lexer as gql_lexer
 
 
-@functools.lru_cache()
 def _get_gqlcore(
     std_schema: s_schema.FlatSchema,
     user_schema: s_schema.FlatSchema,

--- a/edb/pgsql/schemamech.py
+++ b/edb/pgsql/schemamech.py
@@ -819,7 +819,7 @@ def get_ref_storage_info(
 
     for ref, (ptr, src) in ref_ptrs.items():
         ptr_info = types.get_pointer_storage_info(
-            ptr, source=src, resolve_type=False, schema=schema)
+            ptr, source=src, resolve_type=False, schema=schema)  # type: ignore
 
         # See if any of the refs are hosted in pointer tables and others
         # are not...
@@ -835,8 +835,11 @@ def get_ref_storage_info(
         for ref in objtype_biased.copy():
             ptr, src = ref_ptrs[ref]
             ptr_info = types.get_pointer_storage_info(
-                ptr, source=src, resolve_type=False, link_bias=True,
-                schema=schema)
+                ptr, source=src,  # type: ignore
+                resolve_type=False,
+                link_bias=True,
+                schema=schema,
+            )
 
             if ptr_info is not None and ptr_info.table_type == 'link':
                 link_biased[ref] = ptr_info

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -19,12 +19,12 @@
 
 from __future__ import annotations
 
-import functools
 import dataclasses
 import uuid
 from typing import Literal, Optional, cast, overload
 
 from edb.common.typeutils import not_none
+from edb.common import lru
 
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
@@ -534,7 +534,7 @@ def _pointer_storable_in_pointer(
     )
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def get_pointer_storage_info(
     pointer: s_pointers.Pointer,
     *,
@@ -665,7 +665,7 @@ def get_ptrref_storage_info(
     )
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def _get_ptrref_storage_info(
     ptrref: irast.BasePointerRef,
     *,

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -20,9 +20,8 @@
 from __future__ import annotations
 from typing import Any, Optional, Mapping, cast
 
-import functools
-
 from edb import errors
+from edb.common import lru
 
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
@@ -68,7 +67,7 @@ def _is_reachable(
         )
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def get_implicit_cast_distance(
     schema: s_schema.Schema,
     source: s_types.Type,
@@ -89,7 +88,7 @@ def is_implicitly_castable(
     return get_implicit_cast_distance(schema, source, target) >= 0
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def find_common_castable_type(
     schema: s_schema.Schema,
     source: s_types.Type,
@@ -123,7 +122,7 @@ def find_common_castable_type(
                 return target
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def is_assignment_castable(
     schema: s_schema.Schema,
     source: s_types.Type,
@@ -145,7 +144,7 @@ def is_assignment_castable(
     return False
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def is_castable(
     schema: s_schema.Schema,
     source: s_types.Type,

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -41,7 +41,6 @@ import collections
 import collections.abc
 import copy
 import enum
-import functools
 import re
 import uuid
 
@@ -50,6 +49,7 @@ from edb.edgeql import qltypes
 from edb.common.typeutils import not_none
 
 from edb.common import checked
+from edb.common import lru
 from edb.common import markup
 from edb.common import ordered
 from edb.common import parametric
@@ -1065,7 +1065,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
         return type(self).__name__, self.id
 
     @staticmethod
-    @functools.lru_cache(maxsize=10240)
+    @lru.per_job_lru_cache(maxsize=10240)
     def raw_schema_restore(
         sclass_name: str,
         obj_id: uuid.UUID,
@@ -2357,7 +2357,7 @@ class ObjectCollection(
         return (clsname, typeargs, ids, tuple(attrs.items()))
 
     @staticmethod
-    @functools.lru_cache(maxsize=10240)
+    @lru.per_job_lru_cache(maxsize=10240)
     def schema_restore(
         data: tuple[
             str,

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -171,6 +171,8 @@ class ScalarType(
             return False
         left = self.get_base_for_cast(schema)
         right = other.get_base_for_cast(schema)
+        assert isinstance(left, s_types.Type)
+        assert isinstance(right, s_types.Type)
         return s_casts.is_assignment_castable(schema, left, right)
 
     def implicitly_castable_to(

--- a/edb/schema/schema.py
+++ b/edb/schema/schema.py
@@ -36,7 +36,6 @@ from typing import (
 
 import abc
 import collections
-import functools
 import itertools
 
 import immutables as immu
@@ -2167,7 +2166,7 @@ class ChainedSchema(Schema):
         return migration
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def _get_functions(
     schema: FlatSchema,
     name: sn.Name,
@@ -2181,7 +2180,7 @@ def _get_functions(
     )
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def _get_operators(
     schema: FlatSchema,
     name: sn.Name,
@@ -2195,7 +2194,7 @@ def _get_operators(
         )
 
 
-@functools.lru_cache()
+@lru.per_job_lru_cache()
 def _get_last_migration(
     schema: FlatSchema,
 ) -> Optional[s_migrations.Migration]:

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1358,6 +1358,7 @@ class Array(
             if other.is_polymorphic(schema):
                 return False
             right = other.get_base_for_cast(schema)
+            assert isinstance(right, Type)
             return s_casts.is_assignment_castable(schema, self, right)
 
         return self.get_element_type(schema).assignment_castable_to(
@@ -1376,6 +1377,7 @@ class Array(
             if other.is_polymorphic(schema):
                 return False
             right = other.get_base_for_cast(schema)
+            assert isinstance(right, Type)
             return s_casts.is_assignment_castable(schema, self, right)
 
         return self.get_element_type(schema).castable_to(

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -115,7 +115,7 @@ _ENV = os.environ.copy()
 _ENV['PYTHONPATH'] = ':'.join(sys.path)
 
 
-@functools.lru_cache()
+@functools.lru_cache(maxsize=4)
 def _pickle_memoized(obj: Any) -> bytes:
     return pickle.dumps(obj, -1)
 

--- a/edb/server/compiler_pool/worker_proc.py
+++ b/edb/server/compiler_pool/worker_proc.py
@@ -29,6 +29,7 @@ import traceback
 from edb.common import debug
 from edb.common import devmode
 from edb.common import markup
+from edb.common import lru
 from edb.edgeql import parser as ql_parser
 
 from . import amsg
@@ -69,6 +70,10 @@ def worker(sockname, version_serial, get_handler):
                 pickled = pickle.dumps((2, ex_str), -1)
 
             con.reply(req_id, pickled)
+
+            # Now that we have responded, clear the compiler LRU
+            # caches to avoid hanging onto heavy objects like schemas.
+            lru.clear_lru_caches()
     finally:
         con.abort()
 


### PR DESCRIPTION
The main fix here is to replace heavy lru_cache uses with a new
wrapper, `per_job_lru_cache`, all of which can be cleared together.

Then, we clear the caches after every call executed by the worker process.

I've tested locally, based on #8621, running uncached queries on 100
different databases, and memory usage plateus quickly and at a much
lower level than before.