### PR TITLE
Fix ISE when with binding in dml function contains a set function/operator

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -419,7 +419,7 @@ def merge_iterator(
     select: pgast.SelectStmt,
     *,
     ctx: context.CompilerContextLevel
-) -> None:
+) -> Optional[pgast.PathRangeVar]:
     merge_iterator_scope(iterator, select, ctx=ctx)
 
     if iterator:
@@ -447,6 +447,11 @@ def merge_iterator(
             pathctx.put_path_rvar(
                 select, other_path, iterator_rvar, aspect=aspect
             )
+
+        return iterator_rvar
+
+    else:
+        return None
 
 
 def fini_dml_stmt(

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -3564,7 +3564,9 @@ def _compile_inlined_call_args(
 
         # Merge the new iterator
         ctx.path_scope = ctx.path_scope.new_child()
-        dml.merge_iterator(arg_iterator, ctx.rel, ctx=ctx)
+        arg_rvar = not_none(
+            dml.merge_iterator(arg_iterator, ctx.rel, ctx=ctx)
+        )
         clauses.setup_iterator_volatility(arg_iterator, ctx=ctx)
 
         ctx.enclosing_cte_iterator = arg_iterator
@@ -3585,17 +3587,20 @@ def _compile_inlined_call_args(
                 arg_path_id,
                 ctx=ctx,
             )
-            if arg_scope_stmt := relctx.maybe_get_scope_stmt(
-                arg_path_id, ctx=ctx
-            ):
-                # The rvar is joined to ctx.rel, but other sets may
-                # look for it in the scope statement. Make sure it's
-                # available.
-                pathctx.put_path_value_rvar(
-                    arg_scope_stmt,
-                    arg_path_id,
-                    arg_rvar,
-                )
+
+    for ir_arg in expr.args.values():
+        arg_path_id = ir_arg.expr.path_id
+        if arg_scope_stmt := relctx.maybe_get_scope_stmt(
+            arg_path_id, ctx=ctx
+        ):
+            # The args are joined to ctx.rel, but other sets may
+            # look for it in the scope statement. Make sure it's
+            # available.
+            pathctx.put_path_value_rvar(
+                arg_scope_stmt,
+                arg_path_id,
+                arg_rvar,
+            )
 
 
 def process_set_as_func_enumerate(


### PR DESCRIPTION
Set funcs/ops such as ?? compile their arguments in a new scope.

If such funcs/ops are used in a volatile binding in a dml function, a non-volatile bindings which is compiled from the volatile binding will not have direct access to the args iterator rvar.

Instead, they need access via the args' scope stmt.
