### PR TITLE
Start invalidating evicted cache entries on other frontends

### DIFF
--- a/edb/api/errors.txt
+++ b/edb/api/errors.txt
@@ -129,6 +129,7 @@
 0x_05_03_01_00   TransactionConflictError  #SHOULD_RETRY
 0x_05_03_01_01   TransactionSerializationError
 0x_05_03_01_02   TransactionDeadlockError
+0x_05_03_01_03   QueryCacheInvalidationError
 
 0x_05_04_00_00   WatchError
 

--- a/edb/errors/__init__.py
+++ b/edb/errors/__init__.py
@@ -85,6 +85,7 @@ __all__ = base.__all__ + (  # type: ignore
     'TransactionConflictError',
     'TransactionSerializationError',
     'TransactionDeadlockError',
+    'QueryCacheInvalidationError',
     'WatchError',
     'ConfigurationError',
     'AccessError',
@@ -405,6 +406,10 @@ class TransactionSerializationError(TransactionConflictError):
 
 class TransactionDeadlockError(TransactionConflictError):
     _code = 0x_05_03_01_02
+
+
+class QueryCacheInvalidationError(TransactionConflictError):
+    _code = 0x_05_03_01_03
 
 
 class WatchError(ExecutionError):

--- a/edb/server/compiler/rpc.pxd
+++ b/edb/server/compiler/rpc.pxd
@@ -60,3 +60,9 @@ cdef class CompilationRequest:
         object cache_key
 
     cdef _serialize(self)
+
+
+@cython.final
+cdef class CompilationRequestIdHandle:
+    cdef:
+        object cache_key

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -314,9 +314,10 @@ cdef class CompilationRequestIdHandle:
         return hash(self.cache_key)
 
     def __eq__(self, rhs) -> bool:
-        if isinstance(rhs, CompilationRequestIdHandle):
+        ty = type(rhs)
+        if ty is CompilationRequestIdHandle:
             return self.cache_key == rhs.cache_key
-        elif isinstance(rhs, CompilationRequest):
+        elif ty is CompilationRequest:
             return self.cache_key == rhs.get_cache_key()
         else:
             return NotImplemented

--- a/edb/server/compiler/rpc.pyx
+++ b/edb/server/compiler/rpc.pyx
@@ -277,7 +277,14 @@ cdef class CompilationRequest:
     def __hash__(self):
         return hash(self.get_cache_key())
 
-    def __eq__(self, other: CompilationRequest) -> bool:
+    def __eq__(self, rhs) -> bool:
+        cdef:
+            CompilationRequest other
+
+        if not isinstance(rhs, CompilationRequest):
+            return NotImplemented
+        other = rhs
+
         return (
             self.source.cache_key() == other.source.cache_key() and
             self.protocol_version == other.protocol_version and
@@ -292,6 +299,27 @@ cdef class CompilationRequest:
             self.role_name == other.role_name and
             self.branch_name == other.branch_name
         )
+
+
+# A handle class to allow deleting cache entries just by their cache_key.
+@cython.final
+cdef class CompilationRequestIdHandle:
+    def __cinit__(
+        self,
+        cache_key: uuid.UUID
+    ):
+        self.cache_key = cache_key
+
+    def __hash__(self):
+        return hash(self.cache_key)
+
+    def __eq__(self, rhs) -> bool:
+        if isinstance(rhs, CompilationRequestIdHandle):
+            return self.cache_key == rhs.cache_key
+        elif isinstance(rhs, CompilationRequest):
+            return self.cache_key == rhs.get_cache_key()
+        else:
+            return NotImplemented
 
 
 cdef CompilationRequest _deserialize_comp_req(

--- a/edb/server/dbview/dbview.pyi
+++ b/edb/server/dbview/dbview.pyi
@@ -105,6 +105,9 @@ class Database:
     def hydrate_cache(self, query_cache: list[tuple[bytes, ...]]) -> None:
         ...
 
+    def invalidate_cache_entries(self, to_invalidate: list[uuid.UUID]) -> None:
+        ...
+
     def clear_query_cache(self) -> None:
         ...
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -553,6 +553,16 @@ cdef class Database:
                 "skipped %d incompatible cache items", -warning_count
             )
 
+    def invalidate_cache_entries(self, to_invalidate):
+        # TODO: this, better, in constant time
+        to_del = []
+        for obj in self._eql_to_compiled:
+            if obj.get_cache_key() in to_invalidate:
+                to_del.append(obj)
+
+        for obj in to_del:
+            del self._eql_to_compiled[obj]
+
     def clear_query_cache(self):
         self._eql_to_compiled.clear()
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -554,14 +554,9 @@ cdef class Database:
             )
 
     def invalidate_cache_entries(self, to_invalidate):
-        # TODO: this, better, in constant time
-        to_del = []
-        for obj in self._eql_to_compiled:
-            if obj.get_cache_key() in to_invalidate:
-                to_del.append(obj)
-
-        for obj in to_del:
-            del self._eql_to_compiled[obj]
+        for key in to_invalidate:
+            handle = rpc.CompilationRequestIdHandle(key)
+            self._eql_to_compiled.pop(handle, None)
 
     def clear_query_cache(self):
         self._eql_to_compiled.clear()

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -203,6 +203,8 @@ cdef class Database:
         self._cache_queue = asyncio.Queue()
         self._cache_worker_task = asyncio.create_task(
             self.monitor(self.cache_worker, 'cache_worker'))
+        # Queue of (key: str, is_add: bool) pairs. is_add signals
+        # whether it is an addition or deletion.
         self._cache_notify_queue = asyncio.Queue()
         self._cache_notify_task = asyncio.create_task(
             self.monitor(self.cache_notifier, 'cache_notifier'))
@@ -253,6 +255,10 @@ cdef class Database:
                 unit_group.cache_state = CacheState.Evicted
             if keys:
                 await self.tenant.evict_query_cache(self.name, keys)
+                for key in keys:
+                    self._cache_notify_queue.put_nowait(
+                        (str(key), False)
+                    )
 
             # Now, populate the cache
             # Empty the queue, for batching reasons.
@@ -288,7 +294,9 @@ cdef class Database:
                     self._func_cache_gt_tx_seq[query_req] = units
                 else:
                     units[0].maybe_use_func_cache()
-                self._cache_notify_queue.put_nowait(str(units[0].cache_key))
+                self._cache_notify_queue.put_nowait(
+                    (str(units[0].cache_key), True)
+                )
 
     cdef inline uint64_t tx_seq_begin_tx(self):
         self._tx_seq += 1
@@ -331,7 +339,8 @@ cdef class Database:
             lambda keys: self.tenant.signal_sysevent(
                 'query-cache-changes',
                 dbname=self.name,
-                keys=keys,
+                to_add=[k for k, b in keys if b],
+                to_invalidate=[k for k, b in keys if not b],
             ),
             max_wait=1.0,
             delay_amt=0.2,

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -553,6 +553,9 @@ cdef class Database:
                 "skipped %d incompatible cache items", -warning_count
             )
 
+    def invalidate_cache_entry_object(self, obj):
+        self._eql_to_compiled.pop(obj, None)
+
     def invalidate_cache_entries(self, to_invalidate):
         for key in to_invalidate:
             handle = rpc.CompilationRequestIdHandle(key)

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -2125,10 +2125,10 @@ cdef class PGConnection:
                     self.tenant.on_remote_database_quarantine(dbname)
                 elif event == 'query-cache-changes':
                     dbname = event_payload['dbname']
-                    keys = event_payload.get('keys')
+                    to_add = event_payload.get('to_add')
                     to_invalidate = event_payload.get('to_invalidate')
                     self.tenant.on_remote_query_cache_change(
-                        dbname, keys=keys, to_invalidate=to_invalidate
+                        dbname, to_add=to_add, to_invalidate=to_invalidate
                     )
                 else:
                     raise AssertionError(f'unexpected system event: {event!r}')

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -2126,7 +2126,10 @@ cdef class PGConnection:
                 elif event == 'query-cache-changes':
                     dbname = event_payload['dbname']
                     keys = event_payload.get('keys')
-                    self.tenant.on_remote_query_cache_change(dbname, keys=keys)
+                    to_invalidate = event_payload.get('to_invalidate')
+                    self.tenant.on_remote_query_cache_change(
+                        dbname, keys=keys, to_invalidate=to_invalidate
+                    )
                 else:
                     raise AssertionError(f'unexpected system event: {event!r}')
 

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -2103,7 +2103,6 @@ class Tenant(ha_base.ClusterProtocol):
 
         if to_invalidate:
             if db := self.maybe_get_db(dbname=dbname):
-                # print("invalidating", to_invalidate)
                 db.invalidate_cache_entries(
                     [uuid.UUID(s) for s in to_invalidate]
                 )


### PR DESCRIPTION
We just weren't ever doing that. There was a commented out
signal_sysevent, but that forced a full reread, which was too
expensive to work.

That substantially *reduces* the frequency of errors
(by about two orders of magnitude in the test in #8636),
but there is still a race condition where the other frontends
may not have processed the eviction in time. So we also need
to handle the errors and cause retries, as well as evicting
the entry.

Fixes #8636.