### PR TITLE
Add guidance for optional needle in `in` operator

### DIFF
--- a/docs/reference/stdlib/set.rst
+++ b/docs/reference/stdlib/set.rst
@@ -144,6 +144,16 @@ Sets
         ... select A filter A in B;
         {2, 4}
 
+    If your "needle" is optional, the result will be an empty set, which you will need to handle in your conditional logic, typically with the :eql:op:`coalesce` operator:
+
+    .. code-block:: edgeql-repl
+
+      db> select (<bool>{} in {true, true, false});
+      {}
+
+      db> select (<bool>{} in {true, true, false}) ?? false;
+      {false}
+
 
 ----------
 


### PR DESCRIPTION
If the needle (or left operand) in the `in` operator is optional, the result will be an empty set. Similar to other non-coalescing operators, the empty set needs to be handled explicitly by the caller.