### PR TITLE
Fix access policies warnings when `future warn_old_scoping` exists

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -855,9 +855,10 @@ class ContextLevel(compiler.ContextLevel):
         self.no_factoring = s_futures.future_enabled(
             self.env.schema, 'simple_scoping'
         )
-        self.warn_factoring = s_futures.future_enabled(
-            self.env.schema, 'warn_old_scoping'
-        )
+        # When compiling schema things, we don't want to cause warnings
+        # The warnings will be emitted when updating the schema,
+        # and interact poorly with compilation.
+        self.warn_factoring = False
 
 
 class CompilerContext(compiler.CompilerContext[ContextLevel]):

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -2327,6 +2327,9 @@ def _get_shape_configuration_inner(
         stype is not None
         and has_implicit_tid(stype, is_mutation=is_mutation, ctx=ctx)
     ):
+        # HACK: Make sure set is here first, to avoid potential
+        # warn_old_scoping warnings.
+        pathctx.register_set_in_scope(ir_set, ctx=ctx)
         assert isinstance(stype, s_objtypes.ObjectType)
         _inline_type_computable(
             ir_set, stype, '__tid__', 'id', ctx=ctx, shape_ptrs=shape_ptrs)
@@ -2335,6 +2338,9 @@ def _get_shape_configuration_inner(
         stype is not None
         and has_implicit_tname(stype, is_mutation=is_mutation, ctx=ctx)
     ):
+        # HACK: Make sure set is here first, to avoid potential
+        # warn_old_scoping warnings.
+        pathctx.register_set_in_scope(ir_set, ctx=ctx)
         assert isinstance(stype, s_objtypes.ObjectType)
         _inline_type_computable(
             ir_set, stype, '__tname__', 'name', ctx=ctx, shape_ptrs=shape_ptrs)

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -179,10 +179,10 @@ class EdgeQLDataMigrationTestCase(tb.DDLTestCase):
         migration,
         *,
         populate: bool = False,
-        module: str = 'test',
+        module: str | None = 'test',
         explicit_modules: bool = False,
     ):
-        if explicit_modules:
+        if explicit_modules or module is None:
             migration_text = migration
         else:
             migration_text = f'''
@@ -205,7 +205,7 @@ class EdgeQLDataMigrationTestCase(tb.DDLTestCase):
         migration,
         *,
         populate: bool = False,
-        module: str = 'test',
+        module: str | None = 'test',
         explicit_modules: bool = False,
         user_input: Optional[Iterable[str]] = None,
     ):
@@ -12966,8 +12966,14 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
 class EdgeQLMigrationRewriteTestCase(EdgeQLDataMigrationTestCase):
     DEFAULT_MODULE = 'default'
 
-    async def migrate(self, *args, module: str = 'default', **kwargs):
-        await super().migrate(*args, module=module, **kwargs)
+    async def migrate(
+        self,
+        migration: str,
+        *,
+        module: str | None = 'default',
+        **kwargs,
+    ):
+        await super().migrate(migration, module=module, **kwargs)
 
     async def get_migrations(self):
         res = await self.con.query(


### PR DESCRIPTION
We produce bogus warnings about path factoring when 'future
warn_old_scoping` exists. This is because policies were being put in
the scope tree under WARN branches, but then the set was being
factored out when referenced as an anchor.

I found two migrations bug while dealing with this, and had to work
around them in tests. I'll file them seperately..