### PR TITLE
Add Ollama support.

### DIFF
--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -507,7 +507,7 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             ext::ai::text_gen_model_context_window := "200000";
     };
 
-   # Anthropic fastest model
+    # Anthropic fastest model
     create abstract type ext::ai::AnthropicClaude_3_5_HaikuModel
         extending ext::ai::TextGenerationModel
     {
@@ -553,6 +553,28 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
     };
 
     # Ollama embedding models
+    create abstract type ext::ai::OllamaLlama_3_2_Model
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "llama3.2";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "131072";
+    };
+
+    create abstract type ext::ai::OllamaLlama_3_3_Model
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "llama3.3";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "131072";
+    };
+
     create abstract type ext::ai::OllamaNomicEmbedTextModel
         extending ext::ai::EmbeddingModel
     {
@@ -703,7 +725,7 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
                      1. Never directly reference the given context in your \
                         answer.\n\
                      2. Never include phrases like 'Based on the context, ...' \
-                        or any similar phrases in your responses. \
+                        or any similar phrases in your responses.\n\
                      3. When the context does not provide information about \
                         the question, answer with \
                         'No information available.'.\n\

--- a/edb/lib/ext/ai.edgeql
+++ b/edb/lib/ext/ai.edgeql
@@ -24,7 +24,7 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
     create module ext::ai;
 
     create scalar type ext::ai::ProviderAPIStyle
-        extending enum<OpenAI, Anthropic>;
+        extending enum<OpenAI, Anthropic, Ollama>;
 
     create abstract type ext::ai::ProviderConfig extending cfg::ConfigObject {
         create required property name: std::str {
@@ -134,6 +134,31 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
         alter property api_style {
             set protected := true;
             set default := ext::ai::ProviderAPIStyle.Anthropic;
+        };
+    };
+
+    create type ext::ai::OllamaProviderConfig extending ext::ai::ProviderConfig {
+        alter property name {
+            set protected := true;
+            set default := 'builtin::ollama';
+        };
+
+        alter property display_name {
+            set protected := true;
+            set default := 'Ollama';
+        };
+
+        alter property api_url {
+            set default := 'http://localhost:11434/api'
+        };
+
+        alter property secret {
+            set default := ''
+        };
+
+        alter property api_style {
+            set protected := true;
+            set default := ext::ai::ProviderAPIStyle.Ollama;
         };
     };
 
@@ -525,6 +550,37 @@ CREATE EXTENSION PACKAGE ai VERSION '1.0' {
             ext::ai::model_provider := "builtin::anthropic";
         alter annotation
             ext::ai::text_gen_model_context_window := "200000";
+    };
+
+    # Ollama embedding models
+    create abstract type ext::ai::OllamaNomicEmbedTextModel
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "nomic-embed-text";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "768";
+    };
+
+    create abstract type ext::ai::OllamaBgeM3Model
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "bge-m3";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "1024";
     };
 
     create scalar type ext::ai::DistanceFunction


### PR DESCRIPTION
related #8516

Adds support for Ollama indexes, rags queries, and embeddings queries.

Supports the following models:
- `llama3.2`
- `llama3.3`
- `nomic-embed-text`
- `bge-m3`

Note: Adding more flexible models will require some re-thinking of how we deal with models in the schema.