### PR TITLE
Fix our optimization for skipping optional checks based on card inference

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -648,7 +648,8 @@ def _infer_set_inner(
     # but it can't actually be zero, clear the optionality to avoid
     # subpar codegen.
     if (
-        (node := scope_tree.find_child(ir.path_id)) is not None
+        new_scope.parent
+        and (node := new_scope.parent.find_child(ir.path_id)) is not None
         and node.optional
         and not card.can_be_zero()
     ):

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -931,14 +931,73 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             ''',
             [],
         )
+
+        # This first query used to give an access policy violation,
+        # and now gives a MissingRequiredError.  This is because owner
+        # is treated as ONE and thus we do some optimization that are
+        # unsound and cause the policy to not fail.
+        #
+        # (This could also happen before also, though, if it was used
+        # in a way that wasn't getting optional wrapped also)
+        #
+        # But this *can only happen* when it is going to fail
+        # anyway, and not by constraint collision.
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            "",
+        ):
+            await self.con.execute('''
+                insert Issue {
+                    name := '',
+                    body := '',
+                    number := '4',
+                    status := {},
+                    owner := {},
+                };
+            ''')
         async with self.assertRaisesRegexTx(
             edgedb.InvalidValueError,
             "access policy violation on insert",
         ):
             await self.con.execute('''
                 insert Issue {
-                    name := '', body := '', status := {}, number := '',
-                    owner := {}};
+                    name := '',
+                    body := '',
+                    number := '4',
+                    status := (select Status limit 1),
+                    owner := (select User limit 1),
+                };
+            ''')
+
+    async def test_edgeql_policies_multi_missing_01(self):
+        await self.con.execute('''
+            create type T {
+                create required property name -> str {
+                    create constraint exclusive;
+                };
+                create required multi property x -> int64;
+                create access policy ok allow all;
+                create access policy foo_1 deny all using (
+                    (select .x limit 1) ?!= 0
+                )
+             };
+        ''')
+
+        await self.con.execute('''
+            insert T {
+                name := "x",
+                x := {0},
+            };
+        ''')
+        async with self.assertRaisesRegexTx(
+            edgedb.MissingRequiredError,
+            "",
+        ):
+            await self.con.execute('''
+                insert T {
+                    name := "x",
+                    x := {},
+                };
             ''')
 
     async def test_edgeql_policies_volatile_01(self):

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -103,6 +103,13 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             "optional wrapper generated when it shouldn't be needed"
         )
 
+    SCHEMA_pol = '''
+        global name -> str;
+        type PolOwned extending default::Owned {
+            access policy x allow all using (.owner.name ?= global name);
+        }
+    '''
+
     def test_codegen_elide_optional_wrapper_01(self):
         self.no_optional_test('''
             select Issue { te := .time_estimate ?? -1 }
@@ -126,6 +133,22 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
     def test_codegen_elide_optional_wrapper_05(self):
         self.no_optional_test('''
             select Owned { z := .owner.name ?= <optional str>$0 }
+        ''')
+
+    def test_codegen_elide_optional_wrapper_06(self):
+        self.no_optional_test('''
+            select Owned filter {.owner.name ?= <optional str>$0}
+        ''')
+
+    def test_codegen_elide_optional_wrapper_07(self):
+        self.no_optional_test('''
+            select Owned { z := .owner.name ?= <optional str>$0 }
+            filter {.z}
+        ''')
+
+    def test_codegen_elide_optional_wrapper_08(self):
+        self.no_optional_test('''
+            select pol::PolOwned
         ''')
 
     def test_codegen_order_by_not_subquery_01(self):


### PR DESCRIPTION
It was depending on the enclosing scope_tree in a way that wasn't
right. Instead, look somewhere based on the scope tree of the set
itself.