### PR TITLE
Try to optimize away a per-object check in access policies

### DIFF
--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -41,6 +41,8 @@ if TYPE_CHECKING:
 
     class Name:
 
+        __match_args__ = ('name',)
+
         name: str
 
         @classmethod
@@ -75,6 +77,8 @@ if TYPE_CHECKING:
             ...
 
     class QualName(Name):
+
+        __match_args__ = ('module', 'name')
 
         module: str
         name: str

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -25,7 +25,7 @@ from edb.testbase import server as tb
 from edb.tools import test
 
 
-class TestEdgeQLPolicies(tb.QueryTestCase):
+class TestEdgeQLPolicies(tb.DDLTestCase):
     '''Tests for policies.'''
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
@@ -342,6 +342,265 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
             await self.con.query('''
                 select Ptr { tgt }
             ''')
+
+    async def test_edgeql_policies_05c(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (not global filter_owned and .b);
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05d(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (all({not global filter_owned, .b}));
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05e(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (
+                      exists (select .b filter not global filter_owned)
+                    );
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05f(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                # demorgan's law
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (not (global filter_owned or not .b));
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05g(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+                CREATE PROPERTY fo := (not global filter_owned);
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (.fo);
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05h(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (not global filter_owned ?? .b);
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05i(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (
+                      if true then not global filter_owned else .b);
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05j(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (assert_single(
+                      not global filter_owned and .b));
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            await self.con.query('''
+                select Ptr { tgt }
+            ''')
+
+    async def test_edgeql_policies_05k(self):
+        await self.con.execute('''
+            CREATE TYPE Tgt {
+                CREATE REQUIRED PROPERTY b -> bool;
+
+                CREATE ACCESS POLICY redact
+                    ALLOW SELECT USING (<bool><str>(
+                      not global filter_owned and .b));
+                CREATE ACCESS POLICY dml_always
+                    ALLOW UPDATE, INSERT, DELETE;
+            };
+            CREATE TYPE Ptr {
+                CREATE REQUIRED LINK tgt -> Tgt;
+            };
+        ''')
+        await self.con.query('''
+            insert Ptr { tgt := (insert Tgt { b := True }) };
+        ''')
+        await self.con.execute('''
+            set global filter_owned := True;
+        ''')
+
+        async with self.assertRaisesRegexTx(
+                edgedb.CardinalityViolationError,
+                r"is hidden by access policy"):
+            print(await self.con.query('''
+                select Ptr { tgt }
+            '''))
 
     async def test_edgeql_policies_06(self):
         await self.con.execute('''

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -151,6 +151,16 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             select pol::PolOwned
         ''')
 
+    def test_codegen_access_policy_uuid(self):
+        sql = self._compile('''
+            select pol::PolOwned
+        ''')
+        count = sql.count('IS NOT DISTINCT FROM')
+        self.assertEqual(
+            count, 1,
+            ".id ?= <uuid>{} not elided"
+        )
+
     def test_codegen_order_by_not_subquery_01(self):
         sql = self._compile_to_tree('''
             select User order by .name


### PR DESCRIPTION
We want postgres to not be able to decide that a type rewrite CTE is
empty, because that causes it to do optimizations that break our use
of `assert_exists` for required links.

In order to prevent postgres from determining that the CTE for a type
rewrite was empty in some cases (when it has something like `global
foo` in the filter and it is false), we were injecting an extra
`.id ?= <uuid>{}` condition to each access policy filter.
This is always false but postgres doesn't know that, so it defeats
that optimization.

It also defeats the use of indexes, which is bad. Add an analysis of
the access policy query to determine whether it is safe to omit that
check (by making sure that the object itself is always referenced).

This is somewhat dodgy, though.