### PR TITLE
Fix some object-returning functions when using `future warn_old_scoping`

### DIFF
--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -5259,6 +5259,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             drop type Z;
         """)
 
+    async def test_edgeql_ddl_function_43(self):
+        await self.con.execute("""
+            create future warn_old_scoping;
+            create type T;
+            create function all_objects() -> SET OF T USING (T);
+        """)
+
     async def test_edgeql_ddl_function_inh_01(self):
         await self.con.execute("""
             create abstract type T;

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -33,7 +33,9 @@ class TestEdgeQLPolicies(tb.QueryTestCase):
 
     SETUP = [
         '''
-            drop function all_objects();  # BUG!
+            # Dropping all_objects() is no longer required for correctness,
+            # but it does still speed things up a lot.
+            drop function all_objects();
             create future warn_old_scoping;
         ''',
         os.path.join(os.path.dirname(__file__), 'schemas',


### PR DESCRIPTION
The issue was that (due to some obscure interactions in the frontend
maybe worth looking at also), we were feeding the backend compiler IR
that just had a TypeRoot as the toplevel expression, not a SelectStmt.

This ought to work (or ought to be disallowed forcefully), but was
breaking.

The issue is that the rvar for a TypeRoot is a relation, not an rvar
for the ctx.rel already created. In that case, we need to include the
rvar into the toplevel query, or the query will be empty.

Fixes #8645.