### PR TITLE
server: add more compiler pool metrics

### DIFF
--- a/edb/common/prometheus.py
+++ b/edb/common/prometheus.py
@@ -452,6 +452,12 @@ class BaseLabeledCounter(BaseMetric):
                     f'{self._name}_created{{{fmt_label}}} {float(value)}'
                 )
 
+    def clear(self, label_filter: typing.Callable[..., bool]) -> None:
+        for label in list(self._metric_values):
+            if label_filter(*label):
+                self._metric_values.pop(label)
+                self._metric_created.pop(label, None)
+
 
 class _TotalMixin(BaseMetric):
 

--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -257,6 +257,7 @@ async def compile(
             operation_name,
             variables,
             client_id=tenant.client_id,
+            client_name=tenant.get_instance_name(),
         )
     finally:
         metrics.query_compilation_duration.observe(

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1159,7 +1159,7 @@ server_options = typeutils.chain_decorators([
     click.option(
         '--compiler-worker-max-rss',
         type=int,
-        help='Maximum allowed RSS (in KiB) per compiler worker process. Any '
+        help='Maximum allowed RSS (in bytes) per compiler worker process. Any '
              'worker exceeding this limit will be terminated and recreated. '
              'Each worker is free from this limit in its first 20-30 hours '
              'after spawn to avoid infinite restarts or a thundering herd.',
@@ -1208,7 +1208,7 @@ compiler_options = typeutils.chain_decorators([
     click.option(
         '--worker-max-rss',
         type=int,
-        help='Maximum allowed RSS (in KiB) per worker process. Any worker '
+        help='Maximum allowed RSS (in bytes) per worker process. Any worker '
              'exceeding this limit will be terminated and recreated. '
              'Each worker is free from this limit in its first 20-30 hours '
              'after spawn to avoid infinite restarts or a thundering herd.',

--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -1160,7 +1160,9 @@ server_options = typeutils.chain_decorators([
         '--compiler-worker-max-rss',
         type=int,
         help='Maximum allowed RSS (in KiB) per compiler worker process. Any '
-             'worker exceeding this limit will be terminated and recreated.',
+             'worker exceeding this limit will be terminated and recreated. '
+             'Each worker is free from this limit in its first 20-30 hours '
+             'after spawn to avoid infinite restarts or a thundering herd.',
     ),
 ])
 
@@ -1207,7 +1209,9 @@ compiler_options = typeutils.chain_decorators([
         '--worker-max-rss',
         type=int,
         help='Maximum allowed RSS (in KiB) per worker process. Any worker '
-             'exceeding this limit will be terminated and recreated.',
+             'exceeding this limit will be terminated and recreated. '
+             'Each worker is free from this limit in its first 20-30 hours '
+             'after spawn to avoid infinite restarts or a thundering herd.',
     ),
 ])
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -304,9 +304,11 @@ class Worker(BaseWorker):
         if time.monotonic() > self._allow_high_rss_until:
             rss = self.get_rss()
             if rss > max_rss:
-                if debug.flags.server:
-                    print(f"HIT MEMORY LIMIT ({rss} > {max_rss}), "
-                          f"KILLING {self._pid}")
+                logger.info(
+                    'worker process with PID %d exceeds high RSS limit '
+                    '(%d > %d), killing now',
+                    self._pid, rss, max_rss,
+                )
                 self.close()
                 return True
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -97,6 +97,8 @@ PreArgs = tuple[Any, ...]
 BaseWorker_T = TypeVar("BaseWorker_T", bound="BaseWorker")
 Worker_T = TypeVar("Worker_T", bound="Worker")
 AbstractPool_T = TypeVar("AbstractPool_T", bound="AbstractPool")
+BaseLocalPool_T = TypeVar("BaseLocalPool_T", bound="BaseLocalPool")
+TenantStore_T = TypeVar("TenantStore_T")
 
 
 PROCESS_INITIAL_RESPONSE_TIMEOUT: float = 60.0
@@ -105,6 +107,7 @@ ADAPTIVE_SCALE_UP_WAIT_TIME: float = 3.0
 ADAPTIVE_SCALE_DOWN_WAIT_TIME: float = 60.0
 WORKER_PKG: str = __name__.rpartition('.')[0] + '.'
 CALL_FOR_CLIENT_VERSION = 2
+DEFAULT_CLIENT: str = 'default'
 
 
 logger = logging.getLogger("edb.server")
@@ -172,8 +175,8 @@ class BaseWorker:
     def prepare_evict_db(self, keep: int) -> list[str]:
         return list(self._dbs.keys())[keep:]
 
-    def evict_db(self, name: str) -> None:
-        self._dbs.pop(name, None)
+    def evict_db(self, name: str) -> Optional[state.PickledDatabaseState]:
+        return self._dbs.pop(name, None)
 
     async def call(
         self,
@@ -252,6 +255,39 @@ class Worker(BaseWorker):
             '__init_worker__',
             init_args_pickled,
         )
+
+    def set_db(self, name: str, db: state.PickledDatabaseState) -> None:
+        pid = str(self._pid)
+        old_size: Optional[int] = None
+        if (old_db := self._dbs.get(name)) is not None:
+            old_size = old_db.get_estimated_size()
+        super().set_db(name, db)
+        metrics.compiler_process_schema_size.inc(
+            db.get_estimated_size() - (old_size or 0), pid, DEFAULT_CLIENT
+        )
+        if old_size is None:
+            action = 'cache-add'
+            metrics.compiler_process_branches.set(
+                len(self._dbs), pid, DEFAULT_CLIENT
+            )
+        else:
+            action = 'cache-update'
+        metrics.compiler_process_branch_actions.inc(
+            1, pid, DEFAULT_CLIENT, action
+        )
+
+    def evict_db(self, name: str) -> Optional[state.PickledDatabaseState]:
+        pid = str(self._pid)
+        db = self._dbs.get(name)
+        super().evict_db(name)
+        if db is not None:
+            metrics.compiler_process_schema_size.dec(
+                db.get_estimated_size(), pid, DEFAULT_CLIENT
+            )
+            metrics.compiler_process_branch_actions.inc(
+                1, pid, DEFAULT_CLIENT, 'cache-evict'
+            )
+        return db
 
     def get_pid(self) -> int:
         return self._pid
@@ -415,8 +451,10 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
         worker_db = worker.get_db(dbname)
         preargs: list[Any] = [method_name, dbname]
         to_update: dict[str, Any] = {}
+        branch_cache_hit = True
 
         if worker_db is None:
+            branch_cache_hit = False
             evicted_dbs = worker.prepare_evict_db(
                 self._worker_branch_limit - 1
             )
@@ -440,12 +478,14 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
             preargs.append([])  # evicted_dbs
 
             if worker_db.user_schema_pickle is not user_schema_pickle:
+                branch_cache_hit = False
                 preargs.append(user_schema_pickle)
                 to_update['user_schema_pickle'] = user_schema_pickle
             else:
                 preargs.append(None)
 
             if worker_db.reflection_cache is not reflection_cache:
+                branch_cache_hit = False
                 preargs.append(_pickle_memoized(reflection_cache))
                 to_update['reflection_cache'] = reflection_cache
             else:
@@ -458,6 +498,7 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
                 preargs.append(None)
 
             if worker_db.database_config is not database_config:
+                branch_cache_hit = False
                 preargs.append(_pickle_memoized(database_config))
                 to_update['database_config'] = database_config
             else:
@@ -468,6 +509,8 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
                 to_update['system_config'] = system_config
             else:
                 preargs.append(None)
+
+        self._report_branch_request(worker, branch_cache_hit)
 
         if to_update:
             callback = functools.partial(
@@ -480,6 +523,14 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
             callback = None
 
         return tuple(preargs), callback, lambda: None
+
+    def _report_branch_request(
+        self,
+        worker: BaseWorker_T,
+        cache_hit: bool,
+        client: str = DEFAULT_CLIENT,
+    ) -> None:
+        pass
 
     async def _acquire_worker(
         self,
@@ -865,6 +916,9 @@ class AbstractPool(Generic[BaseWorker_T, InitArgs_T, InitArgsPickle_T]):
     def get_size_hint(self) -> int:
         raise NotImplementedError
 
+    def refresh_metrics(self) -> None:
+        pass
+
 
 class BaseLocalPool(
     AbstractPool[Worker_T, InitArgs_T, bytes],
@@ -917,6 +971,18 @@ class BaseLocalPool(
         self._stats_spawned = 0
         self._stats_killed = 0
 
+    def _report_branch_request(
+        self, worker: Worker_T, cache_hit: bool, client: str = DEFAULT_CLIENT
+    ) -> None:
+        pid = str(worker.get_pid())
+        metrics.compiler_process_branch_actions.inc(
+            1, pid, client, 'request'
+        )
+        if cache_hit:
+            metrics.compiler_process_branch_actions.inc(
+                1, pid, client, 'cache-hit'
+            )
+
     def is_running(self) -> bool:
         return bool(self._running)
 
@@ -965,6 +1031,17 @@ class BaseLocalPool(
         logger.debug("Worker with PID %s disconnected.", pid)
         self._workers.pop(pid, None)
         metrics.current_compiler_processes.dec()
+
+        expect = str(pid)
+
+        def pid_filter(pid_str: str, *remaining_tags) -> bool:
+            return pid_str == expect
+
+        metrics.compiler_process_memory.clear(pid_filter)
+        metrics.compiler_process_schema_size.clear(pid_filter)
+        metrics.compiler_process_branches.clear(pid_filter)
+        metrics.compiler_process_branch_actions.clear(pid_filter)
+        metrics.compiler_process_client_actions.clear(pid_filter)
 
     async def start(self) -> None:
         if self._running is not None:
@@ -1067,6 +1144,7 @@ class BaseLocalPool(
         weighter: Optional[queue.Weighter[Worker_T]] = None,
         **compiler_args: Any,
     ) -> Worker_T:
+        start_time = time.monotonic()
         while (
             worker := await self._workers_queue.acquire(
                 condition=condition, weighter=weighter
@@ -1074,6 +1152,7 @@ class BaseLocalPool(
         ).get_pid() not in self._workers:
             # The worker was disconnected; skip to the next one.
             pass
+        metrics.compiler_pool_wait_time.observe(time.monotonic() - start_time)
         return worker
 
     def _release_worker(
@@ -1097,6 +1176,10 @@ class BaseLocalPool(
             worker_pids=list(self._workers.keys()),
             template_pid=self.get_template_pid(),
         )
+
+    def refresh_metrics(self) -> None:
+        for w in self._workers.values():
+            metrics.compiler_process_memory.set(w.get_rss(), str(w.get_pid()))
 
 
 class FixedPoolImpl(
@@ -1598,9 +1681,12 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
             self._loop.create_task(self.start(retry=True))
 
     async def _acquire_worker(self, **compiler_args: Any) -> RemoteWorker:
+        start_time = time.monotonic()
         await self._semaphore.acquire()
         assert self._worker is not None
-        return await self._worker
+        rv = await self._worker
+        metrics.compiler_pool_wait_time.observe(time.monotonic() - start_time)
+        return rv
 
     def _release_worker(
         self,
@@ -1731,6 +1817,9 @@ class TenantSchema:
     def evict_db(self, name: str) -> None:
         self.dbs.pop(name, None)
 
+    def get_estimated_size(self) -> int:
+        return sum(db.get_estimated_size() for db in self.dbs.values())
+
 
 class PickledState(NamedTuple):
     user_schema: Optional[bytes]
@@ -1745,23 +1834,24 @@ class PickledSchema(NamedTuple):
     dropped_dbs: tuple = ()
 
 
-class MultiTenantWorker(Worker):
-    _manager: MultiTenantPool
-    current_client_id: Optional[int]
-    _cache: collections.OrderedDict[int, TenantSchema]
+class BaseMultiTenantWorker(Worker, Generic[TenantStore_T, BaseLocalPool_T]):
+
+    _manager: BaseLocalPool_T
+    _cache: collections.OrderedDict[int, TenantStore_T]
     _invalidated_clients: list[int]
     _last_used_by_client: dict[int, float]
+    _client_names: dict[int, str]
 
     def __init__(
         self,
-        manager: MultiTenantPool,
+        manager: BaseLocalPool_T,
         server: amsg.Server,
         pid: int,
         backend_runtime_params: pgparams.BackendRuntimeParams,
         std_schema: s_schema.FlatSchema,
         refl_schema: s_schema.FlatSchema,
         schema_class_layout: s_refl.SchemaClassLayout,
-    ) -> None:
+    ):
         super().__init__(
             manager,
             server,
@@ -1773,16 +1863,25 @@ class MultiTenantWorker(Worker):
             None,
             None,
         )
-        self.current_client_id = None
         self._cache = collections.OrderedDict()
         self._invalidated_clients = []
         self._last_used_by_client = {}
+        self._client_names = {}
+        self._init()
 
-    def get_tenant_schema(self, client_id: int) -> Optional[TenantSchema]:
-        return self._cache.get(client_id)
+    def _init(self) -> None:
+        pass
+
+    def get_tenant_schema(
+        self, client_id: int, *, touch: bool = True
+    ) -> Optional[TenantStore_T]:
+        rv = self._cache.get(client_id)
+        if rv is not None and touch:
+            self._cache.move_to_end(client_id, last=False)
+        return rv
 
     def set_tenant_schema(
-        self, client_id: int, tenant_schema: TenantSchema
+        self, client_id: int, tenant_schema: TenantStore_T
     ) -> None:
         self._cache[client_id] = tenant_schema
         self._cache.move_to_end(client_id, last=False)
@@ -1791,8 +1890,54 @@ class MultiTenantWorker(Worker):
     def cache_size(self) -> int:
         return len(self._cache) - len(self._invalidated_clients)
 
-    def last_used(self, client_id) -> float:
+    def last_used(self, client_id: int) -> float:
         return self._last_used_by_client.get(client_id, 0)
+
+    def flush_invalidation(self) -> list[int]:
+        evicted = 0
+        pid_str = str(self.get_pid())
+        evicted_names = set()
+
+        client_ids, self._invalidated_clients = self._invalidated_clients, []
+        for client_id in client_ids:
+            if self._cache.pop(client_id, None) is not None:
+                evicted += 1
+            self._last_used_by_client.pop(client_id, None)
+
+            client_name = self._client_names.pop(client_id, None)
+            if client_name is not None:
+                evicted_names.add(client_name)
+
+        if evicted:
+            metrics.compiler_process_client_actions.inc(
+                evicted, pid_str, 'cache-evict'
+            )
+        if evicted_names:
+            def tag_filter(pid: str, client: str, *remaining_tags) -> bool:
+                return pid == pid_str and client in evicted_names
+
+            metrics.compiler_process_schema_size.clear(tag_filter)
+            metrics.compiler_process_branches.clear(tag_filter)
+            metrics.compiler_process_branch_actions.clear(tag_filter)
+
+        return client_ids
+
+    def set_client_name(self, client_id: int, name: Optional[str]) -> None:
+        if client_id not in self._client_names:
+            self._client_names[client_id] = name or f'unknown-{client_id}'
+
+    def get_client_name(self, client_id: int) -> str:
+        return self._client_names.get(client_id) or f'unknown-{client_id}'
+
+
+class MultiTenantWorker(
+    BaseMultiTenantWorker[TenantSchema, "MultiTenantPool"]
+):
+
+    current_client_id: Optional[int]
+
+    def _init(self) -> None:
+        self.current_client_id = None
 
     def invalidate(self, client_id: int) -> None:
         if client_id in self._cache:
@@ -1805,12 +1950,6 @@ class MultiTenantWorker(Worker):
 
     def get_invalidation(self) -> list[int]:
         return self._invalidated_clients[:]
-
-    def flush_invalidation(self) -> None:
-        client_ids, self._invalidated_clients = self._invalidated_clients, []
-        for client_id in client_ids:
-            self._cache.pop(client_id, None)
-            self._last_used_by_client.pop(client_id, None)
 
 
 @srvargs.CompilerPoolMode.MultiTenant.assign_implementation
@@ -1845,7 +1984,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
         client_id: int,
         worker: MultiTenantWorker,
     ) -> queue.Comparable:
-        tenant_schema = worker.get_tenant_schema(client_id)
+        tenant_schema = worker.get_tenant_schema(client_id, touch=False)
         return (
             bool(tenant_schema),
             worker.last_used(client_id)
@@ -1860,13 +1999,15 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
         weighter: Optional[queue.Weighter[MultiTenantWorker]] = None,
         **compiler_args: Any
     ) -> MultiTenantWorker:
-        client_id = compiler_args.get("client_id")
+        client_id: Optional[int] = compiler_args.get("client_id")
         if weighter is None and client_id is not None:
             weighter = functools.partial(self._weighter, client_id)
         rv = await super()._acquire_worker(
             condition=condition, weighter=weighter, **compiler_args
         )
         rv.current_client_id = client_id
+        if client_id is not None:
+            rv.set_client_name(client_id, compiler_args.get("client_name"))
         return rv
 
     def _release_worker(
@@ -1895,6 +2036,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
             *,
             worker: MultiTenantWorker,
             client_id: int,
+            client_name: str,
             dbname: str,
             evicted_dbs: list[str],
             user_schema_pickle: Optional[bytes] = None,
@@ -1903,6 +2045,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
             database_config: Optional[Config] = None,
             instance_config: Optional[Config] = None,
         ) -> None:
+            pid = str(worker.get_pid())
             tenant_schema = worker.get_tenant_schema(client_id)
             if tenant_schema is None:
                 assert user_schema_pickle is not None
@@ -1910,6 +2053,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
                 assert global_schema_pickle is not None
                 assert database_config is not None
                 assert instance_config is not None
+                assert len(evicted_dbs) == 0
 
                 tenant_schema = TenantSchema(
                     client_id,
@@ -1926,9 +2070,21 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
                     instance_config,
                 )
                 worker.set_tenant_schema(client_id, tenant_schema)
+
+                metrics.compiler_process_branch_actions.inc(
+                    1, pid, client_name, 'cache-add'
+                )
+                metrics.compiler_process_client_actions.inc(
+                    1, pid, 'cache-add'
+                )
+
             else:
                 for name in evicted_dbs:
                     tenant_schema.evict_db(name)
+                if evicted_dbs:
+                    metrics.compiler_process_branch_actions.inc(
+                        len(evicted_dbs), pid, client_name, 'cache-evict'
+                    )
 
                 worker_db = tenant_schema.get_db(dbname)
                 if worker_db is None:
@@ -1943,6 +2099,12 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
                             reflection_cache=reflection_cache,
                             database_config=database_config,
                         ),
+                    )
+                    metrics.compiler_process_branch_actions.inc(
+                        1, pid, client_name, 'cache-add'
+                    )
+                    metrics.compiler_process_client_actions.inc(
+                        1, pid, 'cache-update'
                     )
 
                 elif (
@@ -1965,19 +2127,36 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
                             ),
                         )
                     )
+                    metrics.compiler_process_branch_actions.inc(
+                        1, pid, client_name, 'cache-update'
+                    )
+                    metrics.compiler_process_client_actions.inc(
+                        1, pid, 'cache-update'
+                    )
 
                 if global_schema_pickle is not None:
                     tenant_schema.global_schema_pickle = global_schema_pickle
                 if instance_config is not None:
                     tenant_schema.system_config = instance_config
+
             worker.flush_invalidation()
+
+            metrics.compiler_process_schema_size.set(
+                tenant_schema.get_estimated_size(), pid, client_name
+            )
+            metrics.compiler_process_branches.set(
+                len(tenant_schema.dbs), pid, client_name
+            )
 
         client_id = worker.current_client_id
         assert client_id is not None
-        tenant_schema = worker.get_tenant_schema(client_id)
+        client_name = worker.get_client_name(client_id)
+        tenant_schema = worker.get_tenant_schema(client_id, touch=False)
         to_update: dict[str, Hashable]
         evicted_dbs = []
+        branch_cache_hit = True
         if tenant_schema is None:
+            branch_cache_hit = False
             # make room for the new client in this worker
             worker.maybe_invalidate_last()
             to_update = {
@@ -1990,6 +2169,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
         else:
             worker_db = tenant_schema.get_db(dbname)
             if worker_db is None:
+                branch_cache_hit = False
                 evicted_dbs = tenant_schema.prepare_evict_db(
                     self._worker_branch_limit - 1
                 )
@@ -2001,10 +2181,13 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
             else:
                 to_update = {}
                 if worker_db.user_schema_pickle is not user_schema_pickle:
+                    branch_cache_hit = False
                     to_update["user_schema_pickle"] = user_schema_pickle
                 if worker_db.reflection_cache is not reflection_cache:
+                    branch_cache_hit = False
                     to_update["reflection_cache"] = reflection_cache
                 if worker_db.database_config is not database_config:
+                    branch_cache_hit = False
                     to_update["database_config"] = database_config
             if (
                 tenant_schema.global_schema_pickle
@@ -2013,6 +2196,8 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
                 to_update["global_schema_pickle"] = global_schema_pickle
             if tenant_schema.system_config is not system_config:
                 to_update["instance_config"] = system_config
+
+        self._report_branch_request(worker, branch_cache_hit, client_name)
 
         if to_update:
             pickled = {
@@ -2036,6 +2221,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
                 sync_worker_state_cb,
                 worker=worker,
                 client_id=client_id,
+                client_name=client_name,
                 dbname=dbname,
                 evicted_dbs=evicted_dbs,
                 **to_update,  # type: ignore
@@ -2043,6 +2229,9 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
         else:
             pickled_schema = None
             callback = None
+            metrics.compiler_process_client_actions.inc(
+                1, str(worker.get_pid()), 'cache-hit'
+            )
 
         return (
             "call_for_client",
@@ -2072,7 +2261,7 @@ class MultiTenantPool(FixedPoolImpl[MultiTenantWorker, MultiTenantInitArgs]):
         # over only the pickled state. Then prefer the least-recently used one
         # if many workers passed any check in the weighter, or the most vacant.
         def weighter(w: MultiTenantWorker) -> queue.Comparable:
-            if ts := w.get_tenant_schema(client_id):
+            if ts := w.get_tenant_schema(client_id, touch=False):
                 # Don't use ts.get_db() here to avoid confusing the LRU queue
                 if db := ts.dbs.get(dbname):
                     return (

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -298,7 +298,7 @@ class Worker(BaseWorker):
         return self._pid
 
     def get_rss(self) -> int:
-        return self._proc.memory_info().rss // 1024
+        return self._proc.memory_info().rss
 
     def maybe_close_for_high_rss(self, max_rss: int) -> bool:
         if time.monotonic() > self._allow_high_rss_until:

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 from typing import Any, Callable, cast, NamedTuple, Optional, Sequence
 
 import asyncio
-import collections
 import hmac
 import functools
 import logging
@@ -29,7 +28,6 @@ import pathlib
 import pickle
 import secrets
 import tempfile
-import time
 import traceback
 
 import click
@@ -39,9 +37,6 @@ import immutables
 from edb.common import debug
 from edb.common import lru
 from edb.common import markup
-from edb.pgsql import params as pgparams
-from edb.schema import reflection as s_refl
-from edb.schema import schema as s_schema
 from edb.server import metrics
 from edb.server import args as srvargs
 from edb.server import defines
@@ -83,6 +78,16 @@ class PickledState(NamedTuple):
             database_config = self.database_config
         return PickledState(user_schema, reflection_cache, database_config)
 
+    def get_estimated_size(self) -> int:
+        rv = 0
+        if self.user_schema is not None:
+            rv += len(self.user_schema)
+        if self.reflection_cache is not None:
+            rv += len(self.reflection_cache)
+        if self.database_config is not None:
+            rv += len(self.database_config)
+        return rv // 1024
+
 
 class ClientSchema(NamedTuple):
     dbs: immutables.Map[str, PickledState]
@@ -90,7 +95,7 @@ class ClientSchema(NamedTuple):
     instance_config: Optional[bytes]
     dropped_dbs: tuple
 
-    def diff(self, other: ClientSchema) -> ClientSchema:
+    def diff(self, other: ClientSchema) -> tuple[ClientSchema, int, int]:
         # Compare this schema with the other schema, generate a new schema with
         # fields from this schema which are different in the other schema,
         # while the identical fields are left None, so that we can send the
@@ -99,69 +104,38 @@ class ClientSchema(NamedTuple):
         dropped_dbs = tuple(
             dbname for dbname in other.dbs if dbname not in self.dbs
         )
+        added = 0
+        updated = 0
         dbs: immutables.Map[str, PickledState] = immutables.Map()
         for dbname, state in self.dbs.items():
             other_state = other.dbs.get(dbname)
             if other_state is None:
                 dbs = dbs.set(dbname, state)
+                added += 1
             elif state is not other_state:
                 dbs = dbs.set(dbname, state.diff(other_state))
+                updated += 1
         global_schema = instance_config = None
         if self.global_schema is not other.global_schema:
             global_schema = self.global_schema
         if self.instance_config is not other.instance_config:
             instance_config = self.instance_config
-        return ClientSchema(dbs, global_schema, instance_config, dropped_dbs)
+        return (
+            ClientSchema(dbs, global_schema, instance_config, dropped_dbs),
+            added,
+            updated,
+        )
+
+    def get_estimated_size(self) -> int:
+        return sum(db.get_estimated_size() for db in self.dbs.values())
 
 
-class Worker(pool_mod.Worker):
+class Worker(pool_mod.BaseMultiTenantWorker[ClientSchema, "MultiSchemaPool"]):
 
     _last_pickled_state_id: int
-    _cache: collections.OrderedDict[int, ClientSchema]
-    _invalidated_clients: list[int]
-    _last_used_by_client: dict[int, float]
 
-    def __init__(
-        self,
-        manager: MultiSchemaPool,
-        server: amsg.Server,
-        pid: int,
-        backend_runtime_params: pgparams.BackendRuntimeParams,
-        std_schema: s_schema.FlatSchema,
-        refl_schema: s_schema.FlatSchema,
-        schema_class_layout: s_refl.SchemaClassLayout,
-    ) -> None:
-        super().__init__(
-            manager,
-            server,
-            pid,
-            backend_runtime_params,
-            std_schema,
-            refl_schema,
-            schema_class_layout,
-            None,
-            None,
-        )
+    def _init(self) -> None:
         self._last_pickled_state_id = 0
-        self._cache = collections.OrderedDict()
-        self._invalidated_clients = []
-        self._last_used_by_client = {}
-
-    def get_client_schema(self, client_id: int) -> ClientSchema | None:
-        return self._cache.get(client_id)
-
-    def set_client_schema(
-        self, client_id: int, client_schema: ClientSchema
-    ) -> None:
-        self._cache[client_id] = client_schema
-        self._cache.move_to_end(client_id, last=False)
-        self._last_used_by_client[client_id] = time.monotonic()
-
-    def cache_size(self) -> int:
-        return len(self._cache) - len(self._invalidated_clients)
-
-    def last_used(self, client_id: int) -> float:
-        return self._last_used_by_client.get(client_id, 0)
 
     def invalidate(self, client_id: int) -> None:
         if self._cache.pop(client_id, None):
@@ -173,12 +147,6 @@ class Worker(pool_mod.Worker):
             client_id, _ = self._cache.popitem(last=True)
             self._invalidated_clients.append(client_id)
             self._last_used_by_client.pop(client_id, None)
-
-    def flush_invalidation(self) -> list[int]:
-        rv, self._invalidated_clients = self._invalidated_clients, []
-        for client_id in rv:
-            self._cache.pop(client_id, None)
-        return rv
 
     async def call(
         self,
@@ -212,6 +180,7 @@ class MultiSchemaPool(
     _inited: asyncio.Event
     _clients: dict[int, ClientSchema]
     _client_versions: dict[int, int]
+    _client_names: dict[int, str]
     _secret: bytes
 
     def __init__(self, cache_size, *, secret, **kwargs):
@@ -221,6 +190,7 @@ class MultiSchemaPool(
         self._cache_size = cache_size
         self._clients = {}
         self._client_versions = {}
+        self._client_names = {}
         self._secret = secret
 
     def _init(self, kwargs: dict[str, Any]) -> None:
@@ -250,6 +220,7 @@ class MultiSchemaPool(
     async def _init_server(
         self,
         client_id: int,
+        client_name: str,
         catalog_version: int,
         init_args_pickled: pool_mod.RemoteInitArgsPickle,
     ) -> None:
@@ -309,6 +280,7 @@ class MultiSchemaPool(
             dropped_dbs=(),
         )
         self._client_versions[client_id] = client_version
+        self._client_names[client_id] = client_name
 
     def _sync(
         self,
@@ -379,7 +351,7 @@ class MultiSchemaPool(
             return False
 
     def _weighter(self, client_id: int, worker: Worker) -> queue.Comparable:
-        client_schema = worker.get_client_schema(client_id)
+        client_schema = worker.get_tenant_schema(client_id, touch=False)
         return (
             bool(client_schema),
             worker.last_used(client_id)
@@ -422,21 +394,71 @@ class MultiSchemaPool(
             weighter=functools.partial(self._weighter, client_id)
         )
         try:
+            pid = str(worker.get_pid())
             client_schema = self._clients[client_id]
+            client_name = self._client_names[client_id]
+            worker.set_client_name(client_id, client_name)
             diff: Optional[ClientSchema] = client_schema
-            cache = worker.get_client_schema(client_id)
+            cache = worker.get_tenant_schema(client_id)
             extra_args: tuple[Any, ...] = ()
+            metrics.compiler_process_branch_actions.inc(
+                1, pid, client_name, 'request'
+            )
             if cache is client_schema:
                 # client schema is already in sync, don't send again
                 diff = None
                 msg_arg = bytes(msg)
+                metrics.compiler_process_client_actions.inc(
+                    1, pid, 'cache-hit'
+                )
+                metrics.compiler_process_branch_actions.inc(
+                    1, pid, client_name, 'cache-hit'
+                )
+
             else:
+                metrics.compiler_process_schema_size.set(
+                    client_schema.get_estimated_size(), pid, client_name
+                )
+                metrics.compiler_process_branches.set(
+                    len(client_schema.dbs), pid, client_name
+                )
+
                 if cache is None:
                     # make room for the new client in this worker
                     worker.invalidate_last(self._cache_size)
+                    metrics.compiler_process_branch_actions.inc(
+                        len(client_schema.dbs), pid, client_name, 'cache-add'
+                    )
+                    metrics.compiler_process_client_actions.inc(
+                        1, pid, 'cache-add'
+                    )
+
                 else:
                     # only send the difference in user schema
-                    diff = client_schema.diff(cache)
+                    diff, dbs_added, dbs_updated = client_schema.diff(cache)
+                    if dbname not in diff.dbs:
+                        metrics.compiler_process_branch_actions.inc(
+                            1, pid, client_name, 'cache-hit'
+                        )
+                    if dbs_added:
+                        metrics.compiler_process_branch_actions.inc(
+                            dbs_added, pid, client_name, 'cache-add'
+                        )
+                    if dbs_updated:
+                        metrics.compiler_process_branch_actions.inc(
+                            dbs_updated, pid, client_name, 'cache-update'
+                        )
+                    if diff.dropped_dbs:
+                        metrics.compiler_process_branch_actions.inc(
+                            len(diff.dropped_dbs),
+                            pid,
+                            client_name,
+                            'cache-evict',
+                        )
+                    metrics.compiler_process_client_actions.inc(
+                        1, pid, 'cache-update'
+                    )
+
                 if updated:
                     # re-pickle the request if user schema changed
                     msg_arg = None
@@ -455,7 +477,7 @@ class MultiSchemaPool(
             )
             status, *data = pickle.loads(resp)
             if status == 0:
-                worker.set_client_schema(client_id, client_schema)
+                worker.set_tenant_schema(client_id, client_schema)
                 if method_name == "compile":
                     _units, new_pickled_state = data[0]
                     if new_pickled_state:
@@ -465,7 +487,7 @@ class MultiSchemaPool(
             elif status == 1:
                 exc, _tb = data
                 if not isinstance(exc, state_mod.FailedStateSync):
-                    worker.set_client_schema(client_id, client_schema)
+                    worker.set_tenant_schema(client_id, client_schema)
             else:
                 exc = RuntimeError(
                     "could not serialize result in worker subprocess"
@@ -542,7 +564,7 @@ class MultiSchemaPool(
             if method_name != "__init_server__":
                 await self._ready_evt.wait()
             if method_name == "__init_server__":
-                await self._init_server(client_id, *args)
+                await self._init_server(client_id, protocol.client_name, *args)
                 pickled = pickle.dumps((0, None), -1)
             elif method_name in {
                 "compile",
@@ -612,6 +634,7 @@ class MultiSchemaPool(
         logger.debug("Client %d disconnected, invalidating cache.", client_id)
         self._clients.pop(client_id, None)
         self._client_versions.pop(client_id, None)
+        self._client_names.pop(client_id, None)
         for worker in self._workers.values():
             worker.invalidate(client_id)
 
@@ -622,6 +645,7 @@ class CompilerServerProtocol(asyncio.Protocol):
     _stream: amsg.MessageStream
     _transport: Optional[asyncio.Transport]
     _client_id: int
+    _client_name: str
 
     def __init__(
         self,
@@ -634,12 +658,18 @@ class CompilerServerProtocol(asyncio.Protocol):
         self._stream = amsg.MessageStream()
         self._transport = None
         self._client_id = _client_id_seq = _client_id_seq + 1
+        self._client_name = 'unknown'
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self._transport = cast(asyncio.Transport, transport)
         self._transport.write(
             amsg._uint64_packer(os.getpid()) + amsg._uint64_packer(0)
         )
+        peername = transport.get_extra_info('peername')
+        try:
+            self._client_name = '%s:%d' % peername
+        except Exception:
+            self._client_name = str(peername)
 
     def connection_lost(self, exc: Optional[Exception]) -> None:
         self._transport = None
@@ -657,6 +687,10 @@ class CompilerServerProtocol(asyncio.Protocol):
     def client_id(self) -> int:
         return self._client_id
 
+    @property
+    def client_name(self) -> str:
+        return self._client_name
+
     def reply(self, req_id: int, resp: bytes) -> None:
         if self._transport is None:
             return
@@ -672,11 +706,13 @@ class CompilerServerProtocol(asyncio.Protocol):
 
 
 class MetricsProtocol(asyncio.Protocol):
+    _pool: MultiSchemaPool
     transport: Optional[asyncio.Transport]
     parser: httptools.HttpRequestParser
     url: Optional[bytes]
 
-    def __init__(self):
+    def __init__(self, pool: MultiSchemaPool) -> None:
+        self._pool = pool
         self.transport = None
         self.parser = httptools.HttpRequestParser(self)
         self.url = None
@@ -699,6 +735,7 @@ class MetricsProtocol(asyncio.Protocol):
                 self.respond("200 OK", "OK")
 
             case b"GET", b"/metrics":
+                self._pool.refresh_metrics()
                 self.respond(
                     "200 OK",
                     metrics.registry.generate(),
@@ -786,7 +823,7 @@ async def server_main(
                             loop,
                             listen_addresses,
                             metrics_port,
-                            MetricsProtocol,
+                            lambda: MetricsProtocol(pool),
                             "metrics",
                         )
                     )

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -86,7 +86,7 @@ class PickledState(NamedTuple):
             rv += len(self.reflection_cache)
         if self.database_config is not None:
             rv += len(self.database_config)
-        return rv // 1024
+        return rv
 
 
 class ClientSchema(NamedTuple):

--- a/edb/server/compiler_pool/state.py
+++ b/edb/server/compiler_pool/state.py
@@ -43,6 +43,13 @@ class PickledDatabaseState(typing.NamedTuple):
     reflection_cache: ReflectionCache
     database_config: immutables.Map[str, config.SettingValue]
 
+    def get_estimated_size(self) -> int:
+        return (
+            len(self.user_schema_pickle) +
+            len(self.reflection_cache) * 128 +
+            len(self.database_config) * 128
+        ) // 1024
+
 
 class FailedStateSync(Exception):
     pass

--- a/edb/server/compiler_pool/state.py
+++ b/edb/server/compiler_pool/state.py
@@ -48,7 +48,7 @@ class PickledDatabaseState(typing.NamedTuple):
             len(self.user_schema_pickle) +
             len(self.reflection_cache) * 128 +
             len(self.database_config) * 128
-        ) // 1024
+        )
 
 
 class FailedStateSync(Exception):

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -1272,6 +1272,7 @@ cdef class DatabaseConnectionView:
                             query_req.serialize(),
                             "<unknown>",
                             client_id=self.tenant.client_id,
+                            client_name=self.tenant.get_instance_name(),
                         )
                 except Exception:
                     # ignore cache entry that cannot be recompiled
@@ -1690,6 +1691,7 @@ cdef class DatabaseConnectionView:
                     query_req.source.text(),
                     self.in_tx_error(),
                     client_id=self.tenant.client_id,
+                    client_name=self.tenant.get_instance_name(),
                 )
             else:
                 result = await compiler_pool.compile(
@@ -1702,6 +1704,7 @@ cdef class DatabaseConnectionView:
                     query_req.serialize(),
                     query_req.source.text(),
                     client_id=self.tenant.client_id,
+                    client_name=self.tenant.get_instance_name(),
                 )
         finally:
             metrics.edgeql_query_compilation_duration.observe(

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -47,14 +47,14 @@ current_compiler_processes = registry.new_gauge(
 )
 
 compiler_process_memory = registry.new_labeled_gauge(
-    'compiler_process_memory',
-    'Current memory usage of compiler processes in KiB.',
+    'compiler_process_memory_bytes',
+    'Current memory usage of compiler processes in bytes.',
     labels=('pid',),
 )
 
 compiler_process_schema_size = registry.new_labeled_gauge(
-    'compiler_process_schema_size',
-    'Current size of compiler process schema cache in KiB.',
+    'compiler_process_schema_size_bytes',
+    'Current size of compiler process schema cache in bytes.',
     labels=('pid', 'client'),
 )
 

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -41,6 +41,44 @@ current_compiler_processes = registry.new_gauge(
     'Current number of active compiler processes.'
 )
 
+compiler_process_memory = registry.new_labeled_gauge(
+    'compiler_process_memory',
+    'Current memory usage of compiler processes in KiB.',
+    labels=('pid',),
+)
+
+compiler_process_schema_size = registry.new_labeled_gauge(
+    'compiler_process_schema_size',
+    'Current size of compiler process schema cache in KiB.',
+    labels=('pid', 'client'),
+)
+
+compiler_process_branches = registry.new_labeled_gauge(
+    'compiler_process_branches',
+    'Total number of branches cached in each compiler process.',
+    labels=('pid', 'client'),
+)
+
+compiler_process_branch_actions = registry.new_labeled_counter(
+    'compiler_process_branch_actions_total',
+    'Number of different branch actions happened in each '
+    'compiler process.',
+    labels=('pid', 'client', 'action'),
+)
+
+compiler_process_client_actions = registry.new_labeled_counter(
+    'compiler_process_client_actions_total',
+    'Number of different client actions happened in each '
+    'compiler process.',
+    labels=('pid', 'action'),
+)
+
+compiler_pool_wait_time = registry.new_histogram(
+    'compiler_pool_wait_time',
+    'Time it takes to acquire a compiler process.',
+    unit=prom.Unit.SECONDS,
+)
+
 current_branches = registry.new_labeled_gauge(
     'branches_current',
     'Current number of branches.',

--- a/edb/server/metrics.py
+++ b/edb/server/metrics.py
@@ -36,6 +36,11 @@ compiler_process_spawns = registry.new_counter(
     'Total number of compiler processes spawned.'
 )
 
+compiler_process_kills = registry.new_counter(
+    'compiler_process_kills_total',
+    'Total number of compiler processes killed.',
+)
+
 current_compiler_processes = registry.new_gauge(
     'compiler_processes_current',
     'Current number of active compiler processes.'

--- a/edb/server/protocol/notebook_ext.pyx
+++ b/edb/server/protocol/notebook_ext.pyx
@@ -170,6 +170,7 @@ async def execute(db, tenant, queries: list):
         CURRENT_PROTOCOL,
         50,  # implicit limit
         client_id=tenant.client_id,
+        client_name=tenant.get_instance_name(),
     )
     result = []
     bind_data = None

--- a/edb/server/protocol/pg_ext.pyx
+++ b/edb/server/protocol/pg_ext.pyx
@@ -1726,6 +1726,7 @@ cdef class PgConnection(frontend.FrontendConnection):
                 self.dbname,
                 self.username,
                 client_id=self.tenant.client_id,
+                client_name=self.tenant.get_instance_name(),
             )
         finally:
             metrics.query_compilation_duration.observe(

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -760,6 +760,7 @@ cdef class HttpProtocol:
             ):
                 return
 
+            self.server.get_compiler_pool().refresh_metrics()
             # Quoting the Open Metrics spec:
             #    Implementers MUST expose metrics in the OpenMetrics
             #    text format in response to a simple HTTP GET request


### PR DESCRIPTION
The compiler server or a Gel server running a local compiler pool will have the following metrics:

* **COUNTER** `compiler_process_spawns_total`

  Total number of compiler processes spawned

* **COUNTER** `compiler_process_kills_total`

  Total number of compiler processes killed. (memory too high, scaling down, server shutting down)

* **GAUGE** `compiler_processes_current`

  Current number of active compiler processes

* **GAUGE** `compiler_process_memory_bytes`

  Current memory usage of compiler processes in bytes.

  Grouped by tags:

  * `pid`: the compiler worker process ID in the OS

* **GAUGE** `compiler_process_schema_size_bytes`

  Current size of compiler process schema cache in bytes. This is pickled Python objects and only includes the user schemas of branches (also database config and reflection cache), so it's usually smaller than (but correlated to) the actual worker memory usage.

  Grouped by tags:

  * `pid`: the compiler worker process ID in the OS
  * `client`: the client (a.k.a. the Gel server) IPv4 address for compiler server, or the tenant instance name for multitenant server

* **GAUGE** `compiler_process_branches`

  Total number of branches cached in each compiler process. This is usually capped at `--compiler-worker-branch-limit`.

  Grouped by tags:

  * `pid`: the compiler worker process ID in the OS
  * `client`: the client (a.k.a. the Gel server) IPv4 address for compiler server, or the tenant instance name for multitenant server

* **COUNTER** `compiler_process_branch_actions_total`

  Number of different branch actions happened in each compiler process. See the `action` tag below.

  Grouped by tags:

  * `pid`: the compiler worker process ID in the OS
  * `client`: the client (a.k.a. the Gel server) IPv4 address for compiler server, or the tenant instance name for multitenant server
  * `action`:
    * `request`: total number of `compile()`, `compile_sql()`, `compile_notebook()` or `compile_graphql()` calls that uses the branch schema cache, can be used as the base for calculating cache hit rate
    * `cache-hit`: the number of above compilation when the compiler worker process has up-to-date branch schema cache
    * `cache-add`: how many times we send a new schema of a branch to this worker
    * `cache-udpate`: how many times we send an updated schema of a branch to this worker
    * `cache-evict`: how many times we evicted the schema of a branch from this worker

* **COUNTER** `compiler_process_client_actions_total`

  Number of different client actions happened in each compiler process. This reflects when we turn over the cache of a client/tenant as a whole, including all its branches. This reflects how the option `--compiler-pool-tenant-cache-size` or `--client-schema-cache-size` is effective.

  Grouped by tags:

  * `pid`: the compiler worker process ID in the OS
  * `action`:
    * `cache-hit`: the worker has up-to-date cache for the client/tenant
    * `cache-add`: how many times we added a new client/tenant to this worker
    * `cache-udpate`: how many times we updated the client/tenant cache in this worker
    * `cache-evict`: how many times we evicted the cache of a whole client/tenant from this worker

* **HISTOGRAM** `compiler_pool_wait_time`

  Time it takes to acquire a compiler process in seconds. This should be usually very short, unless the compiler pool is fully busy and the compilation requests start to queue up.
