### PR TITLE
Move edb.server.cluster to edb.testbase.cluster

### DIFF
--- a/edb/testbase/cluster.py
+++ b/edb/testbase/cluster.py
@@ -34,12 +34,11 @@ from edb import buildmeta
 from edb.common import devmode
 from edb.edgeql import quote
 
+from edb.server import auth
 from edb.server import args as edgedb_args
 from edb.server import defines as edgedb_defines
+from edb.server import pgcluster
 from edb.server import pgconnparams
-from edb.server import auth
-
-from . import pgcluster
 
 
 if TYPE_CHECKING:

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -62,7 +62,7 @@ import edgedb
 
 from edb.edgeql import quote as qlquote
 from edb.server import args as edgedb_args
-from edb.server import cluster as edgedb_cluster
+from edb.testbase import cluster as edgedb_cluster
 from edb.server import pgcluster
 from edb.server import defines as edgedb_defines
 from edb.server import auth

--- a/edb/tools/gen_test_dumps.py
+++ b/edb/tools/gen_test_dumps.py
@@ -31,7 +31,7 @@ import unittest
 import click
 
 from edb import buildmeta
-from edb.server import cluster as edgedb_cluster
+from edb.testbase import cluster as edgedb_cluster
 from edb.testbase import server as tb
 from edb.tools.edb import edbcommands
 

--- a/edb/tools/inittestdb.py
+++ b/edb/tools/inittestdb.py
@@ -29,7 +29,7 @@ import unittest
 import click
 
 from edb.common import devmode
-from edb.server import cluster as edgedb_cluster
+from edb.testbase import cluster as edgedb_cluster
 from edb.testbase import server as tb
 from edb.tools.edb import edbcommands
 

--- a/edb/tools/test/runner.py
+++ b/edb/tools/test/runner.py
@@ -63,7 +63,7 @@ from . import styles
 from . import results
 
 if TYPE_CHECKING:
-    import edb.server.cluster as edb_cluster
+    import edb.testbase.cluster as edb_cluster
 
 result: Optional[unittest.result.TestResult] = None
 coverage_run: Optional[Any] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,7 @@ module = [
     "edb.repl.*",
     "edb.schema.*",
     "edb.schema.reflection.*",
-    "edb.server.cluster",
+    "edb.testbase.cluster",
     "edb.server.compiler.*",
     "edb.server.config",
     "edb.server.connpool.*",

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -32,7 +32,7 @@ import edgedb
 from edb import errors
 from edb import protocol
 from edb.server import args
-from edb.server import cluster as edbcluster
+from edb.testbase import cluster as edbcluster
 from edb.server.auth import JWKSet, generate_gel_token, load_secret_key
 from edb.schema import defines as s_def
 from edb.testbase import server as tb

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -47,7 +47,7 @@ from edb.ir import statypes
 
 
 from edb.server import args
-from edb.server import cluster
+from edb.testbase import cluster
 from edb.server import config
 from edb.server.config import ops
 from edb.server.config import spec

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -48,7 +48,7 @@ from edb import protocol
 from edb.common import devmode
 from edb.protocol import protocol as edb_protocol  # type: ignore
 from edb.server import args, pgcluster
-from edb.server import cluster as edbcluster
+from edb.testbase import cluster as edbcluster
 from edb.testbase import server as tb
 
 


### PR DESCRIPTION
It is only used by testing and tool flows, and I always forget that.