### PR TITLE
Fix error when using computed pointer in ai index.

### DIFF
--- a/edb/pgsql/delta_ext_ai.py
+++ b/edb/pgsql/delta_ext_ai.py
@@ -502,7 +502,11 @@ def _get_dep_cols(
     dep_cols = []
     assert index_expr.refs is not None
     for obj in index_expr.refs.objects(schema):
-        if isinstance(obj, s_props.Property):
+        if (
+            isinstance(obj, s_props.Property)
+            # Exclude computed pointers, they don't actually have columns
+            and obj.get_expr(schema) is None
+        ):
             ptrinfo = types.get_pointer_storage_info(obj, schema=schema)
             dep_cols.append(ptrinfo.column_name)
 

--- a/tests/schemas/ext_ai.esdl
+++ b/tests/schemas/ext_ai.esdl
@@ -34,10 +34,17 @@ type Astronomy {
         on (.content);
 };
 
-type Stuff extending Astronomy {
+type OnExpression extending Astronomy {
     content2: str;
     deferred index ext::ai::index(embedding_model := 'text-embedding-test')
         on ({.content} ++ {.content2});
+};
+
+type OnComputed extending Astronomy {
+    content2: str;
+    combined := .content ++ .content2;
+    deferred index ext::ai::index(embedding_model := 'text-embedding-test')
+        on (.combined);
 };
 
 type Truncated {


### PR DESCRIPTION
Exclude computed pointers when checking dependent columns for ai indexes. Since they are computed on demand, they don't have an actual column.

Also renamed `Stuff` in ai tests to `OnExpression` for clarity.

close #7775