### PR TITLE
Add proper remote compiler protocol versioning

### DIFF
--- a/edb/server/compiler_pool/multitenant_worker.py
+++ b/edb/server/compiler_pool/multitenant_worker.py
@@ -350,36 +350,21 @@ def call_for_client(
     else:
         assert args == ()
         methname, args = pickle.loads(msg)
-        is_v2 = (methname != (methname := methname.removeprefix("v2_")))
-        if is_v2:
-            (
-                dbname,
+        (
+            dbname,
 
-                # These are pass-thru arguments from Gel server, they are
-                # already utilized in the compiler server and forwarded to us
-                # through "pickled_schema" argument, so we don't need them here
-                evicted_dbs,
-                user_schema,
-                reflection_cache,
-                global_schema,
-                database_config,
-                system_config,
+            # These are pass-thru arguments from Gel server, they are already
+            # utilized in the compiler server and forwarded to us through
+            # "pickled_schema" argument, so we don't need them here.
+            evicted_dbs,
+            user_schema,
+            reflection_cache,
+            global_schema,
+            database_config,
+            system_config,
 
-                *compile_args,
-            ) = args
-        else:
-            # compatible with pre-#8621 clients
-            (
-                dbname,
-
-                user_schema,
-                reflection_cache,
-                global_schema,
-                database_config,
-                system_config,
-
-                *compile_args,
-            ) = args
+            *compile_args,
+        ) = args
 
     if methname == "compile":
         meth = compile
@@ -398,7 +383,6 @@ def call_for_client(
 
 def get_handler(methname: str) -> Callable[..., Any]:
     meth: Callable[..., Any]
-    methname = methname.removeprefix("v2_")
     if methname == "__init_worker__":
         meth = __init_worker__
     else:

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -1508,7 +1508,7 @@ class RemoteWorker(BaseWorker):
         method_name: str,
         args: tuple[Any, ...],
     ) -> memoryview:
-        msg = pickle.dumps(("v2_" + method_name, args))
+        msg = pickle.dumps((method_name, args))
         digest = hmac.digest(self._secret, msg, "sha256")
         return await self._con.request(digest + msg)
 

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -110,6 +110,7 @@ WORKER_PKG: str = __name__.rpartition('.')[0] + '.'
 CALL_FOR_CLIENT_VERSION = 2
 DEFAULT_CLIENT: str = 'default'
 HIGH_RSS_GRACE_PERIOD: tuple[int, int] = (20 * 3600, 30 * 3600)
+CURRENT_COMPILER_PROTOCOL = 2
 
 
 logger = logging.getLogger("edb.server")
@@ -1607,6 +1608,7 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
     ) -> None:
         if self._worker is None:
             return
+        compiler_protocol = CURRENT_COMPILER_PROTOCOL
         try:
             init_args, init_args_pickled = self._get_init_args()
             worker = RemoteWorker(
@@ -1616,6 +1618,7 @@ class RemotePool(AbstractPool[RemoteWorker, InitArgs, RemoteInitArgsPickle]):
             )
             await worker.call(
                 '__init_server__',
+                compiler_protocol,
                 defines.EDGEDB_CATALOG_VERSION,
                 init_args_pickled,
             )

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -179,7 +179,6 @@ class MultiSchemaPool(
     _catalog_version: Optional[int]
     _inited: asyncio.Event
     _clients: dict[int, ClientSchema]
-    _client_versions: dict[int, int]
     _client_names: dict[int, str]
     _secret: bytes
 
@@ -189,7 +188,6 @@ class MultiSchemaPool(
         self._inited = asyncio.Event()
         self._cache_size = cache_size
         self._clients = {}
-        self._client_versions = {}
         self._client_names = {}
         self._secret = secret
 
@@ -223,6 +221,8 @@ class MultiSchemaPool(
         client_name: str,
         catalog_version: int,
         init_args_pickled: pool_mod.RemoteInitArgsPickle,
+        *,
+        is_v2: bool,
     ) -> None:
         (
             std_args_pickled,
@@ -230,16 +230,12 @@ class MultiSchemaPool(
             global_schema_pickle,
             system_config_pickled,
         ) = init_args_pickled
-        client_args = pickle.loads(client_args_pickled)
         dbs_arg: immutables.Map[str, PickledState]
-        if len(client_args) == 1:
-            # This is a new v2 client
-            backend_runtime_params, = client_args
+        if is_v2:
+            backend_runtime_params, = pickle.loads(client_args_pickled)
             dbs_arg = immutables.Map()
-            client_version = 2
         else:
-            # be compatible with pre-#8621 clients
-            dbs, backend_runtime_params = client_args
+            dbs, backend_runtime_params = pickle.loads(client_args_pickled)
             dbs_arg = immutables.Map(
                 (
                     dbname,
@@ -251,7 +247,6 @@ class MultiSchemaPool(
                 )
                 for dbname, state in dbs.items()
             )
-            client_version = 1
         if self._inited.is_set():
             logger.debug("New client %d connected.", client_id)
             assert self._catalog_version is not None
@@ -279,7 +274,6 @@ class MultiSchemaPool(
             instance_config=system_config_pickled,
             dropped_dbs=(),
         )
-        self._client_versions[client_id] = client_version
         self._client_names[client_id] = client_name
 
     def _sync(
@@ -471,7 +465,6 @@ class MultiSchemaPool(
                 client_id,
                 diff,
                 invalidation,
-                self._client_versions[client_id],
                 msg_arg,
                 *extra_args,
             )
@@ -561,10 +554,13 @@ class MultiSchemaPool(
                 raise AssertionError("message signature verification failed")
 
             method_name, args = pickle.loads(msg)
+            is_v2 = (
+                method_name != (method_name := method_name.removeprefix("v2_"))
+            )
             if method_name != "__init_server__":
                 await self._ready_evt.wait()
             if method_name == "__init_server__":
-                await self._init_server(client_id, protocol.client_name, *args)
+                await self._init_server(client_id, protocol.client_name, *args, is_v2=is_v2)
                 pickled = pickle.dumps((0, None), -1)
             elif method_name in {
                 "compile",
@@ -572,32 +568,29 @@ class MultiSchemaPool(
                 "compile_graphql",
                 "compile_sql",
             }:
-                match self._client_versions.get(client_id):
-                    case 1:
-                        # compatible with pre-#8621 clients
-                        evicted_dbs = []
-                        (
-                            dbname,
-                            user_schema,
-                            reflection_cache,
-                            global_schema,
-                            database_config,
-                            system_config,
-                            *args,
-                        ) = args
-
-                    case _:
-                        (
-                            dbname,
-                            evicted_dbs,
-                            user_schema,
-                            reflection_cache,
-                            global_schema,
-                            database_config,
-                            system_config,
-                            *args,
-                        ) = args
-
+                if is_v2:
+                    (
+                        dbname,
+                        evicted_dbs,
+                        user_schema,
+                        reflection_cache,
+                        global_schema,
+                        database_config,
+                        system_config,
+                        *args,
+                    ) = args
+                else:
+                    # compatible with pre-#8621 clients
+                    evicted_dbs = []
+                    (
+                        dbname,
+                        user_schema,
+                        reflection_cache,
+                        global_schema,
+                        database_config,
+                        system_config,
+                        *args,
+                    ) = args
                 pickled = await self._call_for_client(
                     client_id=client_id,
                     method_name=method_name,
@@ -633,7 +626,6 @@ class MultiSchemaPool(
     def client_disconnected(self, client_id: int) -> None:
         logger.debug("Client %d disconnected, invalidating cache.", client_id)
         self._clients.pop(client_id, None)
-        self._client_versions.pop(client_id, None)
         self._client_names.pop(client_id, None)
         for worker in self._workers.values():
             worker.invalidate(client_id)

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -219,16 +219,19 @@ class MultiSchemaPool(
         self,
         client_id: int,
         client_name: str,
+        compiler_protocol: int,
         catalog_version: int,
         init_args_pickled: pool_mod.RemoteInitArgsPickle,
     ) -> None:
+        if compiler_protocol > pool_mod.CURRENT_COMPILER_PROTOCOL:
+            raise state_mod.IncompatibleClient("compiler_protocol")
+
         (
             std_args_pickled,
             client_args_pickled,
             global_schema_pickle,
             system_config_pickled,
         ) = init_args_pickled
-        dbs_arg: immutables.Map[str, PickledState]
         backend_runtime_params, = pickle.loads(client_args_pickled)
         if self._inited.is_set():
             logger.debug("New client %d connected.", client_id)


### PR DESCRIPTION
This is currently just a placeholder, but allows future implementation
to hook into old server/client with non-hacky compatibility support.

This reverts the compat hacks added in #8621