### PR TITLE
Fix a bug in COPY with inheritance over SQL adapter

### DIFF
--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -104,7 +104,9 @@ def resolve_CopyStmt(stmt: pgast.CopyStmt, *, ctx: Context) -> pgast.CopyStmt:
     where = dispatch.resolve_opt(stmt.where_clause, ctx=ctx)
 
     # COPY will always be top-level, so we must extract CTEs
-    query.ctes = list(ctx.ctes_buffer)
+    if not query.ctes:
+        query.ctes = list()
+    query.ctes.extend(ctx.ctes_buffer)
     ctx.ctes_buffer.clear()
 
     return pgast.CopyStmt(

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1920,6 +1920,27 @@ class TestSQLQuery(tb.SQLQueryTestCase):
             {"Captain Miller", ""}
         )
 
+    async def test_sql_query_copy_06(self):
+        out = io.BytesIO()
+        await self.scon.copy_from_query(
+            """
+            SELECT title, pages FROM public."Book" ORDER BY pages
+            """,
+            output=out,
+            format="csv",
+            delimiter="\t",
+        )
+        out = io.StringIO(out.getvalue().decode("utf-8"))
+        res = list(csv.reader(out, delimiter="\t"))
+
+        self.assertEqual(
+            res,
+            [
+                ['Chronicles of Narnia', '206'],
+                ['Hunger Games', '374'],
+            ]
+        )
+
     async def test_sql_query_error_01(self):
         with self.assertRaisesRegex(
             asyncpg.UndefinedFunctionError,


### PR DESCRIPTION
I had a minor bug with major consequences in COPY command resolving:
I was overwriting `query.ctes` with CTEs from `Context`. When we were
using inheritance CTEs, we were adding these CTEs to query directly,
so they got overwritten.
