### PR TITLE
Fix schema type inconsistencies with collection aliases

### DIFF
--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -64,6 +64,10 @@ class Alias(
         so.ObjectSet[s_types.Type],
         default=so.DEFAULT_CONSTRUCTOR,
     )
+    existing_types = so.SchemaField(
+        so.ObjectSet[s_types.Type],
+        default=so.DEFAULT_CONSTRUCTOR,
+    )
 
 
 class AliasCommandContext(
@@ -218,6 +222,7 @@ class AliasLikeCommand(
         s_types.TypeShell[s_types.Type],
         s_expr.Expression,
         set[so.ObjectShell[s_types.Type]],
+        set[so.ObjectShell[s_types.Type]],
     ]:
         pschema = schema
 
@@ -242,7 +247,7 @@ class AliasLikeCommand(
 
         is_global = (self.get_schema_metaclass().
                      get_schema_class_displayname() == 'global')
-        cmd, type_shell, created_types = _create_alias_types(
+        cmd, type_shell, created_types, existing_types = _create_alias_types(
             expr=expr,
             classname=classname,
             schema=schema,
@@ -252,7 +257,7 @@ class AliasLikeCommand(
         if drop_old_types_cmd:
             cmd.prepend(drop_old_types_cmd)
 
-        return cmd, type_shell, expr, created_types
+        return cmd, type_shell, expr, created_types, existing_types
 
 
 class AliasCommand(
@@ -323,18 +328,21 @@ class CreateAliasLike(
                 vn = other_obj.get_verbosename(schema, with_parent=True)
                 raise errors.SchemaError(f'{vn} already exists')
 
-            type_cmd, type_shell, expr, created_types = self._handle_alias_op(
-                expr=self.get_attribute_value('expr'),
-                classname=alias_name,
-                schema=schema,
-                context=context,
-                span=self.get_attribute_span('expr'),
+            type_cmd, type_shell, expr, created_types, existing_types = (
+                    self._handle_alias_op(
+                    expr=self.get_attribute_value('expr'),
+                    classname=alias_name,
+                    schema=schema,
+                    context=context,
+                    span=self.get_attribute_span('expr'),
+                )
             )
             self.add_prerequisite(type_cmd)
             self.set_attribute_value('expr', expr)
             self.set_attribute_value(
                 self.TYPE_FIELD_NAME, type_shell, computed=True)
             self.set_attribute_value('created_types', created_types)
+            self.set_attribute_value('existing_types', existing_types)
 
         return super()._create_begin(schema, context)
 
@@ -396,13 +404,15 @@ class AlterAliasLike(
             is_computable = self._is_computable(self.scls, schema)
             if expr:
                 alias_name = self._get_alias_name(self.classname)
-                type_cmd, type_shell, expr, created_tys = self._handle_alias_op(
-                    expr=expr,
-                    classname=alias_name,
-                    schema=schema,
-                    context=context,
-                    is_alter=is_computable,
-                    span=self.get_attribute_span('expr'),
+                type_cmd, type_shell, expr, created_tys, existing_types = (
+                        self._handle_alias_op(
+                        expr=expr,
+                        classname=alias_name,
+                        schema=schema,
+                        context=context,
+                        is_alter=is_computable,
+                        span=self.get_attribute_span('expr'),
+                    )
                 )
 
                 self.add_prerequisite(type_cmd)
@@ -412,6 +422,7 @@ class AlterAliasLike(
                     self.TYPE_FIELD_NAME, type_shell, computed=True)
 
                 self.set_attribute_value('created_types', created_tys)
+                self.set_attribute_value('existing_types', existing_types)
 
                 # Clear out the type field in the schema *now*,
                 # before we call the parent _alter_begin, which will
@@ -516,6 +527,7 @@ def _create_alias_types(
     sd.Command,
     s_types.TypeShell[s_types.Type],
     set[so.ObjectShell[s_types.Type]],
+    set[so.ObjectShell[s_types.Type]],
 ]:
     from . import ordering as s_ordering
     from edb.ir import utils as irutils
@@ -526,14 +538,23 @@ def _create_alias_types(
     derived_delta = sd.DeltaRoot()
 
     created_type_shells: set[so.ObjectShell[s_types.Type]] = set()
+    existing_type_shells: set[so.ObjectShell[s_types.Type]] = set()
 
     for ty_id in irutils.collect_schema_types(ir.expr):
-        if schema.has_object(ty_id):
-            # this is not a new type, skip
-            continue
         ty = new_schema.get_by_id(ty_id, type=s_types.Type)
-
         name = ty.get_name(new_schema)
+
+        if schema.has_object(ty_id):
+            # This is not a new type.
+            # Track non-alias types separately to add to an alias or global's
+            # `existing_types`. This adds a "use" and ensures that they are
+            # preserved as other types are added/removed from the schema.
+            if not ty.get_from_alias(schema):
+                existing_type_shells.add(
+                    so.ObjectShell(name=name, schemaclass=type(ty))
+                )
+            continue
+
         if (
             not isinstance(ty, s_types.Collection)
             and not _has_alias_name_prefix(classname, name)
@@ -606,7 +627,7 @@ def _create_alias_types(
         schemaclass=type_cmd.get_schema_metaclass(),
         span=span,
     )
-    return result, type_shell, created_type_shells
+    return result, type_shell, created_type_shells, existing_type_shells
 
 
 def _has_alias_name_prefix(

--- a/edb/schema/expraliases.py
+++ b/edb/schema/expraliases.py
@@ -542,13 +542,33 @@ def _create_alias_types(
             # need to be created in the schema
             continue
 
+        # Schema views in derive an alias subtype for their expressions, which
+        # are stored in the schema with `from_alias` set to True. Aliases will
+        # also store any new types from their expressions into the schema.
+        #
+        # This is not an issue for most derived types since they are used only
+        # in their alias expression.
+        #
+        # However, collections which are not expr aliases that are created in
+        # an alias expression may be used in other places and should be
+        # not be created as `from_alias` or other alias/global associated
+        # fields.
+        if (
+            not isinstance(ty, s_types.Collection)
+            or isinstance(ty, s_types.CollectionExprAlias)
+        ):
+            new_schema = ty.update(
+                new_schema,
+                dict(
+                    alias_is_persistent=True,
+                    expr_type=s_types.ExprType.Select,
+                    from_alias=True,
+                    from_global=is_global,
+                ),
+            )
         new_schema = ty.update(
             new_schema,
             dict(
-                alias_is_persistent=True,
-                expr_type=s_types.ExprType.Select,
-                from_alias=True,
-                from_global=is_global,
                 internal=False,
                 builtin=False,
             ),

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -97,10 +97,6 @@ class Global(
         so.ObjectSet[s_types.Type],
         default=so.DEFAULT_CONSTRUCTOR,
     )
-    existing_types = so.SchemaField(
-        so.ObjectSet[s_types.Type],
-        default=so.DEFAULT_CONSTRUCTOR,
-    )
 
     def is_computable(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_expr(schema))

--- a/edb/schema/globals.py
+++ b/edb/schema/globals.py
@@ -97,6 +97,10 @@ class Global(
         so.ObjectSet[s_types.Type],
         default=so.DEFAULT_CONSTRUCTOR,
     )
+    existing_types = so.SchemaField(
+        so.ObjectSet[s_types.Type],
+        default=so.DEFAULT_CONSTRUCTOR,
+    )
 
     def is_computable(self, schema: s_schema.Schema) -> bool:
         return bool(self.get_expr(schema))

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -8345,6 +8345,266 @@ class TestEdgeQLDDL(tb.DDLTestCase):
 
     async def test_edgeql_ddl_global_type_changes_19(self):
         # Create computed global
+        # Create reference to type
+        # Delete computed global
+        # Delete reference to type
+
+        await self._check_ddl_global_type_changes([
+            (
+                'create global foo := ((1,),)',
+                [
+                    {
+                        'name': 'default::foo@default|foo@global',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'create function bar() -> array<tuple<int64>> using([(1,)])',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'default::foo@default|foo@global',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'drop global foo',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            ('drop function bar()', []),
+        ])
+
+    async def test_edgeql_ddl_global_type_changes_20(self):
+        # Create reference to type
+        # Create computed global
+        # Delete reference to type
+        # Delete computed global
+
+        await self._check_ddl_global_type_changes([
+            (
+                'create function foo() -> array<tuple<int64>> using([(1,)])',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'create global bar := ((1,),)',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'default::bar@default|bar@global',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'drop function foo()',
+                [
+                    {
+                        'name': 'default::bar@default|bar@global',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            ('drop global bar', []),
+        ])
+
+    async def test_edgeql_ddl_global_type_changes_21(self):
+        # Create non-computed global
+        # Create reference to type
+        # Delete non-computed global
+        # Delete reference to type
+
+        await self._check_ddl_global_type_changes([
+            (
+                'create global foo: tuple<tuple<int64>>',
+                [
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'create function bar() -> array<tuple<int64>> using([(1,)])',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'drop global foo',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            ('drop function bar()', []),
+        ])
+
+    async def test_edgeql_ddl_global_type_changes_22(self):
+        # Create reference to type
+        # Create non-computed global
+        # Delete reference to type
+        # Delete non-computed global
+
+        await self._check_ddl_global_type_changes([
+            (
+                'create function foo() -> array<tuple<int64>> using([(1,)])',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'create global bar: tuple<tuple<int64>>',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'drop function foo()',
+                [
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            ('drop global bar', []),
+        ])
+
+    async def test_edgeql_ddl_global_type_changes_23(self):
+        # Create computed global
         # Alter expr, same type
         # Delete global
 
@@ -8382,7 +8642,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    async def test_edgeql_ddl_global_type_changes_20(self):
+    async def test_edgeql_ddl_global_type_changes_24(self):
         # Create computed global
         # Alter expr, different type
         # Delete global
@@ -8421,7 +8681,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    async def test_edgeql_ddl_global_type_changes_21(self):
+    async def test_edgeql_ddl_global_type_changes_25(self):
         # Create computed global
         # Alter to non-computed, same type
         # Delete global
@@ -8460,7 +8720,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    async def test_edgeql_ddl_global_type_changes_22(self):
+    async def test_edgeql_ddl_global_type_changes_26(self):
         # Create computed global
         # Alter to non-computed, different type
         # Delete global
@@ -8499,7 +8759,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    async def test_edgeql_ddl_global_type_changes_23(self):
+    async def test_edgeql_ddl_global_type_changes_27(self):
         # Create non-computed global
         # Alter target type
         # Delete global
@@ -8532,7 +8792,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    async def test_edgeql_ddl_global_type_changes_24(self):
+    async def test_edgeql_ddl_global_type_changes_28(self):
         # Create non-computed global
         # Alter to computed, same type
         # Delete global
@@ -8573,7 +8833,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    async def test_edgeql_ddl_global_type_changes_25(self):
+    async def test_edgeql_ddl_global_type_changes_29(self):
         # Create non-computed global
         # Alter to computed, different type
         # Delete global
@@ -11765,6 +12025,146 @@ type default::Foo {
 
     async def test_edgeql_ddl_alias_type_changes_10(self):
         # Create alias
+        # Create reference to type
+        # Delete alias
+        # Delete reference to type
+
+        await self._check_ddl_global_type_changes([
+            (
+                'create alias foo := ((1,),)',
+                [
+                    {
+                        'name': 'default::foo',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'create function bar() -> array<tuple<int64>> using([(1,)])',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'default::foo',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'drop alias foo',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            ('drop function bar()', []),
+        ])
+
+    async def test_edgeql_ddl_alias_type_changes_11(self):
+        # Create reference to type
+        # Create alias
+        # Delete reference to type
+        # Delete alias
+
+        await self._check_ddl_global_type_changes([
+            (
+                'create function foo() -> array<tuple<int64>> using([(1,)])',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'create alias bar := ((1,),)',
+                [
+                    {
+                        'name': 'array<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Array',
+                    },
+                    {
+                        'name': 'default::bar',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            (
+                'drop function foo()',
+                [
+                    {
+                        'name': 'default::bar',
+                        'from_alias': True,
+                        'type_name': 'schema::TupleExprAlias',
+                    },
+                    {
+                        'name': 'tuple<std::int64>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                    {
+                        'name': 'tuple<tuple<std|int64>>',
+                        'from_alias': False,
+                        'type_name': 'schema::Tuple',
+                    },
+                ]
+            ),
+            ('drop alias bar', []),
+        ])
+
+    async def test_edgeql_ddl_alias_type_changes_12(self):
+        # Create alias
         # Alter expr, same type
         # Delete alias
 
@@ -11802,7 +12202,7 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    async def test_edgeql_ddl_alias_type_changes_11(self):
+    async def test_edgeql_ddl_alias_type_changes_13(self):
         # Create alias
         # Alter expr, different type
         # Delete alias

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7802,9 +7802,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail(
-        "from_alias is set on new collection types from computed globals"
-    )
     async def test_edgeql_ddl_global_type_changes_03(self):
         # Create computed global
         # Delete computed global
@@ -7829,9 +7826,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail(
-        "from_alias is set on new collection types from computed globals"
-    )
     async def test_edgeql_ddl_global_type_changes_04(self):
         # Create computed global
         # Delete computed global
@@ -7856,9 +7850,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail(
-        "from_alias is set on new collection types from computed globals"
-    )
     async def test_edgeql_ddl_global_type_changes_05(self):
         # Create computed global
         # Delete computed global
@@ -7888,9 +7879,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail(
-        "from_alias is set on new collection types from computed globals"
-    )
     async def test_edgeql_ddl_global_type_changes_06(self):
         # Create computed global
         # Delete computed global
@@ -7920,9 +7908,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail(
-        "from_alias is set on new collection types from computed globals"
-    )
     async def test_edgeql_ddl_global_type_changes_07(self):
         # Create computed global
         # Delete computed global
@@ -7973,7 +7958,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_10(self):
         # Create non-computed global
         # Delete non-computed global
@@ -7993,7 +7977,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_11(self):
         # Create non-computed global
         # Delete non-computed global
@@ -8013,7 +7996,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_12(self):
         # Create non-computed global
         # Delete non-computed global
@@ -8038,7 +8020,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_13(self):
         # Create non-computed global
         # Delete non-computed global
@@ -8063,7 +8044,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_14(self):
         # Create non-computed global
         # Delete non-computed global
@@ -8083,7 +8063,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_15(self):
         # Create computed global
         # Create non-computed global
@@ -8154,7 +8133,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global bar', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_16(self):
         # Create computed global
         # Create non-computed global
@@ -8230,7 +8208,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_17(self):
         # Create non-computed global
         # Create computed global
@@ -8296,7 +8273,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_18(self):
         # Create non-computed global
         # Create computed global
@@ -8367,7 +8343,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global bar', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_19(self):
         # Create computed global
         # Alter expr, same type
@@ -8407,7 +8382,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_20(self):
         # Create computed global
         # Alter expr, different type
@@ -8447,7 +8421,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_21(self):
         # Create computed global
         # Alter to non-computed, same type
@@ -8487,7 +8460,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_22(self):
         # Create computed global
         # Alter to non-computed, different type
@@ -8527,7 +8499,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_23(self):
         # Create non-computed global
         # Alter target type
@@ -8602,7 +8573,6 @@ class TestEdgeQLDDL(tb.DDLTestCase):
             ('drop global foo', []),
         ])
 
-    @test.xfail("non-computed globals don't tidy up when deleted")
     async def test_edgeql_ddl_global_type_changes_25(self):
         # Create non-computed global
         # Alter to computed, different type
@@ -11503,7 +11473,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_03(self):
         # Create alias
         # Delete alias
@@ -11528,7 +11497,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_04(self):
         # Create alias
         # Delete alias
@@ -11553,7 +11521,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_05(self):
         # Create alias
         # Delete alias
@@ -11583,7 +11550,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_06(self):
         # Create alias
         # Delete alias
@@ -11613,7 +11579,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_07(self):
         # Create alias
         # Delete alias
@@ -11638,7 +11603,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_08(self):
         # Create alias 1
         # Create alias 2
@@ -11719,7 +11683,6 @@ type default::Foo {
             ('drop alias bar', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_09(self):
         # Create alias 1
         # Create alias 2
@@ -11800,7 +11763,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_10(self):
         # Create alias
         # Alter expr, same type
@@ -11840,7 +11802,6 @@ type default::Foo {
             ('drop alias foo', []),
         ])
 
-    @test.xfail("from_alias is set on new collection types from aliases")
     async def test_edgeql_ddl_alias_type_changes_11(self):
         # Create alias
         # Alter expr, different type

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -24,7 +24,6 @@ import unittest
 import edgedb
 
 from edb.testbase import server as tb
-from edb.tools import test
 
 
 class TestEdgeQLGlobals(tb.QueryTestCase):
@@ -492,9 +491,6 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
             ],
         )
 
-    @test.skip(
-        "cannot resolve backend oid for type first created by computed global"
-    )
     async def test_edgeql_globals_18(self):
         await self.con.execute('''
             CREATE GLOBAL foo := ([(f := 1)]);


### PR DESCRIPTION
Related #8691

Aliases and computed globals will create any new types in the schema and marked them as `from_alias`. They do not store the existing types that they use in any existing fields.

This produces the following inconsistencies.

1. `from_alias` types are added to the `new_types` of a delta, and so the server dbview would not update its backend ids

For example:
```
create global foo := [(f := 1)];
create global bar -> array<tuple<f: int64>>;
set global bar := [(f := 1)];
select global bar;
```

The first global creates the types `tuple<f: int64>` and `array<tuple<f: int64>>`. But since these are marked as `from_alias`, they are not added to `new_types` in `TypeCommand._create_begin`.

Then setting then selecting `bar`, the backend oid is unavailable when attempting to recode globals, resulting in an ISE.

2. Types are not always properly tidied up after a non-computed global has its type altered, or is deleted.

For example, after:
```
create global foo -> tuple<hello: int64>;
drop global foo;
```

The query `select schema::Type {*} filter contains(.name, 'hello');` will return a leftover type.

3. Types can be deleted while still being "used" by an alias expression.

For example, after:
```
create type Bar { create property x -> tuple<hello: std::int64>; };
create global foo := (hello := 1);
drop type Bar;
```

The query `select schema::Type {*} filter contains(.name, 'hello');` will return nothing.


These issues were solved by:
1. No longer setting `from_alias` for new collection types from alias expressions (other than the alias expr itself)
2. Ensuring that unused types are deleted after altering or deleting non-computed globals
3. Storing types from an alias expression that already exist in a new `existing_types` field to count them as "used"
