### PR TITLE
[6.x] Add proper remote compiler protocol versioning (#8667)

### DIFF
--- a/edb/server/compiler_pool/multitenant_worker.py
+++ b/edb/server/compiler_pool/multitenant_worker.py
@@ -341,7 +341,6 @@ def call_for_client(
     client_id: int,
     pickled_schema: Optional[bytes],
     invalidation: Sequence[int],
-    client_version: int,
     msg: Optional[bytes],
     *args: Any,
 ) -> Any:
@@ -351,38 +350,21 @@ def call_for_client(
     else:
         assert args == ()
         methname, args = pickle.loads(msg)
-        match client_version:
-            case 1:
-                # compatible with pre-#8621 clients
-                (
-                    dbname,
+        (
+            dbname,
 
-                    user_schema,
-                    reflection_cache,
-                    global_schema,
-                    database_config,
-                    system_config,
+            # These are pass-thru arguments from Gel server, they are already
+            # utilized in the compiler server and forwarded to us through
+            # "pickled_schema" argument, so we don't need them here.
+            evicted_dbs,
+            user_schema,
+            reflection_cache,
+            global_schema,
+            database_config,
+            system_config,
 
-                    *compile_args,
-                ) = args
-
-            case _:
-                (
-                    dbname,
-
-                    # These are pass-thru arguments from Gel server, they are
-                    # already utilized in the compiler server and forwarded to
-                    # us through "pickled_schema" argument, so we don't need
-                    # them here
-                    evicted_dbs,
-                    user_schema,
-                    reflection_cache,
-                    global_schema,
-                    database_config,
-                    system_config,
-
-                    *compile_args,
-                ) = args
+            *compile_args,
+        ) = args
 
     if methname == "compile":
         meth = compile

--- a/edb/server/compiler_pool/pool.py
+++ b/edb/server/compiler_pool/pool.py
@@ -59,9 +59,9 @@ KILL_TIMEOUT: float = 10.0
 ADAPTIVE_SCALE_UP_WAIT_TIME: float = 3.0
 ADAPTIVE_SCALE_DOWN_WAIT_TIME: float = 60.0
 WORKER_PKG: str = __name__.rpartition('.')[0] + '.'
-CALL_FOR_CLIENT_VERSION = 2
 DEFAULT_CLIENT: str = 'default'
 HIGH_RSS_GRACE_PERIOD: tuple[int, int] = (20 * 3600, 30 * 3600)
+CURRENT_COMPILER_PROTOCOL = 2
 
 
 logger = logging.getLogger("edb.server")
@@ -1202,11 +1202,10 @@ class SimpleAdaptivePool(BaseLocalPool):
 
 
 class RemoteWorker(BaseWorker):
-    def __init__(self, con, secret, *args, server_version: int):
+    def __init__(self, con, secret, *args):
         super().__init__(*args)
         self._con = con
         self._secret = secret
-        self._server_version = server_version
 
     def close(self):
         if self._closed:
@@ -1218,21 +1217,6 @@ class RemoteWorker(BaseWorker):
         msg = pickle.dumps((method_name, args))
         digest = hmac.digest(self._secret, msg, "sha256")
         return await self._con.request(digest + msg)
-
-    def prepare_evict_db(self, keep: int) -> list[str]:
-        match self._server_version:
-            case 1:
-                return []
-            case _:
-                return super().prepare_evict_db(keep)
-
-    def evict_db(self, name: str) -> None:
-        match self._server_version:
-            case 1:
-                # shouldn't happen, but just in case
-                raise RuntimeError("evict_db is not supported by this server")
-            case _:
-                super().evict_db(name)
 
 
 @srvargs.CompilerPoolMode.Remote.assign_implementation
@@ -1251,7 +1235,6 @@ class RemotePool(AbstractPool):
                 "is not set"
             )
         self._secret = secret.encode()
-        self._server_version = CALL_FOR_CLIENT_VERSION
 
     async def start(self, retry=False):
         if self._worker is None:
@@ -1293,14 +1276,7 @@ class RemotePool(AbstractPool):
         std_args = (
             self._std_schema, self._refl_schema, self._schema_class_layout
         )
-        client_args: tuple[Any, ...]
-        match self._server_version:
-            case 1:
-                # compatible with pre-#8621 servers
-                client_args = (immutables.Map(), self._backend_runtime_params)
-            case _:
-                client_args = (self._backend_runtime_params,)
-
+        client_args = (self._backend_runtime_params,)
         return init_args, (
             pickle.dumps(std_args, -1),
             pickle.dumps(client_args, -1),
@@ -1311,47 +1287,20 @@ class RemotePool(AbstractPool):
     async def _connection_made(self, retry, protocol, transport, _pid, version):
         if self._worker is None:
             return
-        # Note: `version` is worker not `self._server_version`; `version` is
-        # `_template_proc_version` in FixedPool and is not used here.
-        con = amsg.HubConnection(transport, protocol, self._loop, version)
+        compiler_protocol = CURRENT_COMPILER_PROTOCOL
         try:
-            while True:
-                init_args, init_args_pickled = self._get_init_args()
-                worker = RemoteWorker(
-                    con,
-                    self._secret,
-                    *init_args,
-                    server_version=self._server_version,
-                )
-
-                try:
-                    await worker.call(
-                        '__init_server__',
-                        defines.EDGEDB_CATALOG_VERSION,
-                        init_args_pickled,
-                    )
-                except ValueError:
-                    # Here we depend on a ValueError in v1 server trying to
-                    # unpack `client_args` into `(dbs, backend_runtime_params)`
-                    # while we attempt to send only `(backend_runtime_params,)`
-                    # (both supported in v2 server) first, in order to detect
-                    # the server version. We cannot use the method_name prefix
-                    # hack for detection because v1 server will hang until it's
-                    # called with exactly `__init_server__` with no prefix.
-                    if self._server_version > 1:
-                        self._server_version -= 1
-                        lru.clear_lru_caches()
-                        logger.info(
-                            f"falling back to compiler server protocol "
-                            f"version {self._server_version}"
-                        )
-                    else:
-                        raise state.IncompatibleClient(
-                            "the compiler server's version is incompatible"
-                        )
-                else:
-                    break
-
+            init_args, init_args_pickled = self._get_init_args()
+            worker = RemoteWorker(
+                amsg.HubConnection(transport, protocol, self._loop, version),
+                self._secret,
+                *init_args,
+            )
+            await worker.call(
+                '__init_server__',
+                compiler_protocol,
+                defines.EDGEDB_CATALOG_VERSION,
+                init_args_pickled,
+            )
         except state.IncompatibleClient as ex:
             transport.abort()
             if self._worker is not None:
@@ -1461,13 +1410,6 @@ class RemotePool(AbstractPool):
             else:
                 # Case 2: no state sync needed, release the lock immediately.
                 self._sync_lock.release()
-
-        if self._server_version == 1:
-            # Old server doesn't support the `evicted_dbs` param
-            method_name, dbname, evicted_dbs, *rem = preargs
-            assert evicted_dbs == []
-            preargs = (method_name, dbname, *rem)
-
         return preargs, callback, fini
 
     def get_debug_info(self):
@@ -1475,7 +1417,6 @@ class RemotePool(AbstractPool):
             address="{}:{}".format(*self._pool_addr),
             size=self._semaphore._bound_value,  # type: ignore
             free=self._semaphore._value,  # type: ignore
-            server_version=self._server_version,
         )
 
     def get_size_hint(self) -> int:
@@ -1907,7 +1848,6 @@ class MultiTenantPool(FixedPool):
             client_id,
             pickled_schema,
             worker.get_invalidation(),
-            CALL_FOR_CLIENT_VERSION,
             None,  # forwarded msg is only used in remote compiler server
             method_name,
             dbname,

--- a/edb/server/compiler_pool/server.py
+++ b/edb/server/compiler_pool/server.py
@@ -166,7 +166,6 @@ class MultiSchemaPool(pool_mod.FixedPool):
     _worker_mod = "multitenant_worker"
     _workers: dict[int, Worker]  # type: ignore
     _clients: dict[int, ClientSchema]
-    _client_versions: dict[int, int]
     _client_names: dict[int, str]
 
     def __init__(self, cache_size, *, secret, **kwargs):
@@ -175,7 +174,6 @@ class MultiSchemaPool(pool_mod.FixedPool):
         self._inited = asyncio.Event()
         self._cache_size = cache_size
         self._clients = {}
-        self._client_versions = {}
         self._client_names = {}
         self._secret = secret
 
@@ -207,37 +205,20 @@ class MultiSchemaPool(pool_mod.FixedPool):
         self,
         client_id: int,
         client_name: str,
+        compiler_protocol: int,
         catalog_version: int,
         init_args_pickled: tuple[bytes, bytes, bytes, bytes],
     ):
+        if compiler_protocol > pool_mod.CURRENT_COMPILER_PROTOCOL:
+            raise state_mod.IncompatibleClient("compiler_protocol")
+
         (
             std_args_pickled,
             client_args_pickled,
             global_schema_pickle,
             system_config_pickled,
         ) = init_args_pickled
-        client_args = pickle.loads(client_args_pickled)
-        dbs_arg: immutables.Map[str, PickledState]
-        if len(client_args) == 1:
-            # This is a new v2 client
-            backend_runtime_params, = client_args
-            dbs_arg = immutables.Map()
-            client_version = 2
-        else:
-            # be compatible with pre-#8621 clients
-            dbs, backend_runtime_params = client_args
-            dbs_arg = immutables.Map(
-                (
-                    dbname,
-                    PickledState(
-                        state.user_schema_pickle,
-                        pickle.dumps(state.reflection_cache, -1),
-                        pickle.dumps(state.database_config, -1),
-                    ),
-                )
-                for dbname, state in dbs.items()
-            )
-            client_version = 1
+        backend_runtime_params, = pickle.loads(client_args_pickled)
         if self._inited.is_set():
             logger.debug("New client %d connected.", client_id)
             assert self._catalog_version is not None
@@ -260,12 +241,11 @@ class MultiSchemaPool(pool_mod.FixedPool):
                 client_id,
             )
         self._clients[client_id] = ClientSchema(
-            dbs=dbs_arg,
+            dbs=immutables.Map(),
             global_schema=global_schema_pickle,
             instance_config=system_config_pickled,
             dropped_dbs=(),
         )
-        self._client_versions[client_id] = client_version
         self._client_names[client_id] = client_name
 
     def _sync(
@@ -455,7 +435,6 @@ class MultiSchemaPool(pool_mod.FixedPool):
                 client_id,
                 diff,
                 invalidation,
-                self._client_versions[client_id],
                 msg,
                 *extra_args,
             )
@@ -550,32 +529,16 @@ class MultiSchemaPool(pool_mod.FixedPool):
                 "compile_graphql",
                 "compile_sql",
             }:
-                match self._client_versions.get(client_id):
-                    case 1:
-                        # compatible with pre-#8621 clients
-                        evicted_dbs = []
-                        (
-                            dbname,
-                            user_schema,
-                            reflection_cache,
-                            global_schema,
-                            database_config,
-                            system_config,
-                            *args,
-                        ) = args
-
-                    case _:
-                        (
-                            dbname,
-                            evicted_dbs,
-                            user_schema,
-                            reflection_cache,
-                            global_schema,
-                            database_config,
-                            system_config,
-                            *args,
-                        ) = args
-
+                (
+                    dbname,
+                    evicted_dbs,
+                    user_schema,
+                    reflection_cache,
+                    global_schema,
+                    database_config,
+                    system_config,
+                    *args,
+                ) = args
                 pickled = await self._call_for_client(
                     client_id=client_id,
                     method_name=method_name,
@@ -611,7 +574,6 @@ class MultiSchemaPool(pool_mod.FixedPool):
     def client_disconnected(self, client_id):
         logger.debug("Client %d disconnected, invalidating cache.", client_id)
         self._clients.pop(client_id, None)
-        self._client_versions.pop(client_id, None)
         self._client_names.pop(client_id, None)
         for worker in self._workers.values():
             worker.invalidate(client_id)


### PR DESCRIPTION
This is currently just a placeholder, but allows future implementation to hook into old server/client with non-hacky compatibility support.

This reverts the compat hacks added in #8621