### PR TITLE
In LSP, compile on save instead of change

### DIFF
--- a/edb/language_server/main.py
+++ b/edb/language_server/main.py
@@ -75,7 +75,7 @@ def init(options_json: str | None) -> ls_server.GelLanguageServer:
     def text_document_did_open(params: lsp_types.DidOpenTextDocumentParams):
         ls_server.document_updated(ls, params.text_document.uri)
 
-    @ls.feature(lsp_types.TEXT_DOCUMENT_DID_CHANGE)
+    @ls.feature(lsp_types.TEXT_DOCUMENT_DID_SAVE)
     def text_document_did_change(params: lsp_types.DidChangeTextDocumentParams):
         ls_server.document_updated(ls, params.text_document.uri)
 

--- a/edb/language_server/main.py
+++ b/edb/language_server/main.py
@@ -76,7 +76,7 @@ def init(options_json: str | None) -> ls_server.GelLanguageServer:
         ls_server.document_updated(ls, params.text_document.uri)
 
     @ls.feature(lsp_types.TEXT_DOCUMENT_DID_SAVE)
-    def text_document_did_change(params: lsp_types.DidChangeTextDocumentParams):
+    def text_document_did_save(params: lsp_types.DidChangeTextDocumentParams):
         ls_server.document_updated(ls, params.text_document.uri)
 
     @ls.feature(lsp_types.TEXT_DOCUMENT_DEFINITION)


### PR DESCRIPTION
The `DID_CHANGE` callback is called for every edit to the document, so it would try to re-parse on every keystroke. We plan on debouncing this as the full fix for the DX issue, but for now, we can switch to re-parsing on save.