### PR TITLE
Fix having unnecessary constraint triggers after restore

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_04_30_00_00
+EDGEDB_CATALOG_VERSION = 2025_05_09_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -590,3 +590,21 @@ class AlterTableUpdateConstraintTrigger(AlterTableConstraintBase):
         self.drop_constraint_trigger_and_fuction(self._constraint)
         self.create_constraint_trigger_and_fuction(self._constraint)
         super().generate(block)
+
+
+class AlterTableUpdateConstraintTriggerFixup(AlterTableConstraintBase):
+    def __repr__(self):
+        return '<{}.{} {!r}>'.format(
+            self.__class__.__module__, self.__class__.__name__,
+            self._constraint)
+
+    def generate(self, block):
+        # Pre 6.8 versions of gel created needless disabled triggers
+        # in some cases. This path (invoked by administer
+        # remove_pointless_triggers()) deletes them.
+        if (
+            self._constraint.requires_triggers()
+            and self._constraint.can_disable_triggers()
+        ):
+            self.drop_constraint_trigger_and_fuction(self._constraint)
+        super().generate(block)

--- a/edb/pgsql/deltadbops.py
+++ b/edb/pgsql/deltadbops.py
@@ -440,30 +440,6 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
             dbops.DropTrigger(upd_trigger, conditional=True),
         ]
 
-    def enable_constr_trigger(
-        self,
-        table_name: tuple[str, ...],
-        constraint: SchemaConstraintTableConstraint,
-    ) -> list[dbops.DDLOperation]:
-        ins_trigger, upd_trigger = self._get_triggers(table_name, constraint)
-
-        return [
-            dbops.EnableTrigger(ins_trigger),
-            dbops.EnableTrigger(upd_trigger),
-        ]
-
-    def disable_constr_trigger(
-        self,
-        table_name: tuple[str, ...],
-        constraint: SchemaConstraintTableConstraint,
-    ) -> list[dbops.DDLOperation]:
-        ins_trigger, upd_trigger = self._get_triggers(table_name, constraint)
-
-        return [
-            dbops.DisableTrigger(ins_trigger),
-            dbops.DisableTrigger(upd_trigger),
-        ]
-
     def create_constr_trigger_function(
         self, constraint: SchemaConstraintTableConstraint
     ):
@@ -510,7 +486,10 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
         Adds the new function to the trigger.
         Disables the trigger if possible.
         """
-        if constraint.requires_triggers():
+        if (
+            constraint.requires_triggers()
+            and not constraint.can_disable_triggers()
+        ):
             # Create trigger function
             self.add_commands(self.create_constr_trigger_function(constraint))
 
@@ -518,10 +497,6 @@ class AlterTableConstraintBase(dbops.AlterTableBaseMixin, dbops.CommandGroup):
             cr_trigger = self.create_constr_trigger(
                 self.name, constraint, proc_name)
             self.add_commands(cr_trigger)
-
-            if constraint.can_disable_triggers():
-                self.add_commands(
-                    self.disable_constr_trigger(self.name, constraint))
 
     def alter_constraint(
         self,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1754,8 +1754,8 @@ def _compile_ql_administer(
         return ddl.administer_vacuum(ctx, ql)
     elif ql.expr.func == 'prepare_upgrade':
         return ddl.administer_prepare_upgrade(ctx, ql)
-    elif ql.expr.func == 'remove_pointless_triggers':
-        return ddl.remove_pointless_triggers(ctx, ql)
+    elif ql.expr.func == '_remove_pointless_triggers':
+        return ddl.administer_remove_pointless_triggers(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1754,6 +1754,8 @@ def _compile_ql_administer(
         return ddl.administer_vacuum(ctx, ql)
     elif ql.expr.func == 'prepare_upgrade':
         return ddl.administer_prepare_upgrade(ctx, ql)
+    elif ql.expr.func == 'remove_pointless_triggers':
+        return ddl.remove_pointless_triggers(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1418,12 +1418,9 @@ def administer_repair_schema(
 
 
 def remove_pointless_triggers(
-    ctx: compiler.CompileContext,
+    schema: s_schema.Schema,
 ) -> pg_dbops.CommandGroup:
     from edb.pgsql import schemamech
-
-    current_tx = ctx.state.current_tx()
-    schema = current_tx.get_schema(ctx.compiler_state.std_schema)
 
     constraints = schema.get_objects(
         exclude_stdlib=True,
@@ -1466,8 +1463,11 @@ def administer_remove_pointless_triggers(
             span=ql.expr.span,
         )
 
+    current_tx = ctx.state.current_tx()
+    schema = current_tx.get_schema(ctx.compiler_state.std_schema)
+
     block = pg_dbops.PLTopBlock()
-    remove_pointless_triggers(ctx).generate(block)
+    remove_pointless_triggers(schema).generate(block)
     src = block.to_string()
 
     if debug.flags.delta_execute_ddl or debug.flags.delta_execute:

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1417,6 +1417,52 @@ def administer_repair_schema(
     )
 
 
+def remove_pointless_triggers(
+    ctx: compiler.CompileContext,
+    ql: qlast.AdministerStmt,
+) -> dbstate.BaseQuery:
+    from edb.pgsql import schemamech
+
+    if ql.expr.args or ql.expr.kwargs:
+        raise errors.QueryError(
+            'remove_pointless_triggers() does not take arguments',
+            span=ql.expr.span,
+        )
+
+    current_tx = ctx.state.current_tx()
+    schema = current_tx.get_schema(ctx.compiler_state.std_schema)
+
+    constraints = schema.get_objects(
+        exclude_stdlib=True,
+        type=s_constraints.Constraint,
+    )
+
+    block = pg_dbops.PLTopBlock()
+
+    for constraint in constraints:
+        if not pg_delta.ConstraintCommand.constraint_is_effective(
+            schema, constraint
+        ):
+            continue
+
+        subject = constraint.get_subject(schema)
+        bconstr = schemamech.compile_constraint(
+            subject, constraint, schema, None
+        )
+
+        # bconstr.update_trigger_ops().generate(block)
+        bconstr.fixup_trigger_ops().generate(block)
+
+    src = block.to_string()
+    # debug.dump_code(src, lexer='sql')
+
+    return dbstate.DDLQuery(
+        sql=src.encode('utf-8'),
+        user_schema=ctx.state.current_tx().get_user_schema(),
+        feature_used_metrics=None,
+    )
+
+
 def administer_reindex(
     ctx: compiler.CompileContext,
     ql: qlast.AdministerStmt,

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -30,6 +30,10 @@ class TestConstraintsSchema(tb.QueryTestCase):
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'constraints.esdl')
 
+    SETUP = '''
+    administer remove_pointless_triggers();
+    '''
+
     async def _run_link_tests(self, cases, objtype, link, *,
                               values_as_str=True):
         qry = f"""

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -31,7 +31,7 @@ class TestConstraintsSchema(tb.QueryTestCase):
                           'constraints.esdl')
 
     SETUP = '''
-    administer remove_pointless_triggers();
+    administer _remove_pointless_triggers();
     '''
 
     async def _run_link_tests(self, cases, objtype, link, *,


### PR DESCRIPTION
Don't create constraint triggers that we then always disable.
The triggers get enabled while doing a restore, which has real perf
impacts.

In our current implementation, it is totally safe to just stop creating
them. Since #7593, we now no longer ever enable the disabled triggers,
because we always need to recompile them to include new descendants or some
such.

Fixes #8683.

I also added an `ADMINISTER remove_pointless_triggers()` command that
will remove the unneeded triggers from an existing database.

We could also skip that and do it unconditionally as part of a patch,
though.