### PR TITLE
Update the docs GitHub Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,14 +2,18 @@ name: Deploy Documentation Changes
 
 on:
   push:
+    branches:
+      - master
+      - release/**
     paths:
       - "docs/**"
 
 jobs:
   deploy:
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
-
     steps:
       - name: Trigger vercel deploy hook
-        run: curl -X POST ${{ secrets.VERCEL_DOC_DEPLOY_URL_HOOK }}
+        run: curl \
+          --fail-with-body \
+          --request POST \
+          ${{ secrets.VERCEL_DOC_DEPLOY_URL_HOOK }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - release/**
     paths:
       - "docs/**"
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
- Fail if the deploy hook request fails
- Move the branch filter into the `on` section

See the [relevant GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-workflow-only-when-a-push-to-specific-branches-occurs) for the `on` part:

> If you use both the branches filter and the paths filter, the workflow will only run when both filters are satisfied.