### PR TITLE
Gel-ls: parse on change, but compile only on save

### DIFF
--- a/edb/language_server/completion.py
+++ b/edb/language_server/completion.py
@@ -73,7 +73,7 @@ def _get_completion_in_ql(
     # compile the stmt that now contains the qlast.Cursor,
     # which should halt compilation, when it gets to the cursor
     try:
-        diagnostics, _ir_stmts = ls_server.compile(ls, document, [ql_stmt])
+        diagnostics, _ir_stmts = ls_server.compile_ql(ls, document, [ql_stmt])
     except qlcompiler.expr.IdentCompletionException as e:
         return [
             lsp_types.CompletionItem(

--- a/edb/language_server/definition.py
+++ b/edb/language_server/definition.py
@@ -82,7 +82,7 @@ def _get_definition_in_ql(
 ) -> lsp_types.Location | None:
     # compile the whole doc
     # TODO: search ql ast before compiling all stmts
-    _, ir_stmts = ls_server.compile(ls, document, ql_ast)
+    _, ir_stmts = ls_server.compile_ql(ls, document, ql_ast)
 
     # find the ir node at the position
     node_path = None

--- a/edb/language_server/main.py
+++ b/edb/language_server/main.py
@@ -73,11 +73,15 @@ def init(options_json: str | None) -> ls_server.GelLanguageServer:
 
     @ls.feature(lsp_types.TEXT_DOCUMENT_DID_OPEN)
     def text_document_did_open(params: lsp_types.DidOpenTextDocumentParams):
-        ls_server.document_updated(ls, params.text_document.uri)
+        ls_server.document_updated(ls, params.text_document.uri, compile=True)
+
+    @ls.feature(lsp_types.TEXT_DOCUMENT_DID_CHANGE)
+    def text_document_did_change(params: lsp_types.DidChangeTextDocumentParams):
+        ls_server.document_updated(ls, params.text_document.uri, compile=False)
 
     @ls.feature(lsp_types.TEXT_DOCUMENT_DID_SAVE)
     def text_document_did_save(params: lsp_types.DidChangeTextDocumentParams):
-        ls_server.document_updated(ls, params.text_document.uri)
+        ls_server.document_updated(ls, params.text_document.uri, compile=True)
 
     @ls.feature(lsp_types.TEXT_DOCUMENT_DEFINITION)
     def text_document_definition(

--- a/edb/language_server/schema.py
+++ b/edb/language_server/schema.py
@@ -167,7 +167,7 @@ def _determine_schema_dir(
         # no manifest: don't infer any schema dir
         return None, err_msg
 
-    if manifest.project:
+    if manifest.project and manifest.project.schema_dir:
         schema_dir = project_dir / manifest.project.schema_dir
     else:
         schema_dir = project_dir / "dbschema"
@@ -246,9 +246,10 @@ def _compile_schema(
             do = ls.state.schema_docs[0]
 
         # convert error
-        diagnostics.by_doc[do].append(ls_utils.error_to_lsp(error))
+        diagnostics.append(do, ls_utils.error_to_lsp(error))
 
     ls.state.schema = schema
+    ls.state.schema_diagnostics = diagnostics
     return (schema, diagnostics)
 
 

--- a/edb/language_server/utils.py
+++ b/edb/language_server/utils.py
@@ -50,6 +50,10 @@ class DiagnosticsSet:
             self.by_doc[doc] = []
         self.by_doc[doc].extend(diagnostics)
 
+    def merge(self, other: 'DiagnosticsSet'):
+        for doc, diags in other.by_doc.items():
+            self.extend(doc, diags)
+
     def has_any(self) -> bool:
         for diags in self.by_doc.values():
             if len(diags) != 0:

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -323,18 +323,6 @@ class TestLanguageServer(unittest.TestCase):
                     "jsonrpc": "2.0",
                     "method": "textDocument/publishDiagnostics",
                     "params": {
-                        "uri": runner.get_uri("dbschema/default.gel"),
-                        "diagnostics": [],
-                    },
-                },
-            )
-
-            self.assertEqual(
-                runner.recv(timeout_sec=5),
-                {
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/publishDiagnostics",
-                    "params": {
                         "diagnostics": [
                             {
                                 "message": (
@@ -353,6 +341,117 @@ class TestLanguageServer(unittest.TestCase):
                     },
                 },
             )
+            self.assertEqual(
+                runner.recv(timeout_sec=5),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": runner.get_uri("dbschema/default.gel"),
+                        "diagnostics": [],
+                    },
+                },
+            )
+
+        finally:
+            runner.finish()
+
+    def test_language_server_diagnostics_04(self):
+        # Test that on didChange we only parse and we compile on didSave
+        runner = LspRunner()
+        try:
+            runner.add_file("gel.toml", "")
+            runner.add_file("dbschema/default.gel", "")
+            runner.send_init()
+
+            # 1. Open an empty file
+            file_uri = runner.get_uri("invalid_save_test.edgeql")
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": file_uri,
+                            "languageId": "edgeql",
+                            "version": 1,
+                            "text": "",
+                        }
+                    },
+                }
+            )
+            # Expect empty diagnostics on open of an empty (valid) file
+            self.assertEqual(
+                runner.recv(),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": file_uri,
+                        "version": 1,
+                        "diagnostics": [],
+                    },
+                },
+            )
+
+            # 2. Syntactically correct, but semantically invalid
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didChange",
+                    "params": {
+                        "textDocument": {"uri": file_uri, "version": 2},
+                        "contentChanges": [{"text": """select '3' + 2"""}],
+                    },
+                }
+            )
+            # Expect empty diagnostics, since we only parsed
+            self.assertEqual(
+                runner.recv(),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": file_uri,
+                        "version": 2,
+                        "diagnostics": [],
+                    },
+                },
+            )
+
+            # 3. Save the file
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didSave",
+                    "params": {"textDocument": {"uri": file_uri}},
+                }
+            )
+            self.assertEqual(
+                runner.recv(),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": file_uri,
+                        "version": 2,
+                        "diagnostics": [
+                            {
+                                "message": (
+                                    "operator '+' cannot be applied to operands"
+                                    " of type 'std::str' and 'std::int64'"
+                                ),
+                                "range": {
+                                    "start": {"character": 7, "line": 0},
+                                    "end": {"character": 14, "line": 0},
+                                },
+                                "severity": 1,
+                            }
+                        ],
+                    },
+                },
+            )
+
         finally:
             runner.finish()
 
@@ -397,20 +496,20 @@ class TestLanguageServer(unittest.TestCase):
                     "jsonrpc": "2.0",
                     "method": "textDocument/publishDiagnostics",
                     "params": {
-                        "uri": runner.get_uri("dbschema/default.gel"),
                         "diagnostics": [],
+                        "uri": "file://myquery.edgeql",
+                        "version": 1,
                     },
                 },
             )
             self.assertEqual(
-                runner.recv(timeout_sec=5),
+                runner.recv(timeout_sec=1),
                 {
                     "jsonrpc": "2.0",
                     "method": "textDocument/publishDiagnostics",
                     "params": {
+                        "uri": runner.get_uri("dbschema/default.gel"),
                         "diagnostics": [],
-                        "uri": "file://myquery.edgeql",
-                        "version": 1,
                     },
                 },
             )
@@ -1104,99 +1203,6 @@ class TestLanguageServer(unittest.TestCase):
                             {'kind': 14, 'label': 'start'},
                             {'kind': 14, 'label': 'update'},
                             {'kind': 14, 'label': 'with'},
-                        ],
-                    },
-                },
-            )
-
-        finally:
-            runner.finish()
-
-    def test_language_server_11(self):
-        # Test diagnostics are only published on save after change.
-        runner = LspRunner()
-        try:
-            runner.send_init()
-
-            # 1. Open an empty file
-            file_uri = runner.get_uri("invalid_save_test.edgeql")
-            runner.send(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/didOpen",
-                    "params": {
-                        "textDocument": {
-                            "uri": file_uri,
-                            "languageId": "edgeql",
-                            "version": 1,
-                            "text": "",
-                        }
-                    },
-                }
-            )
-            # Expect empty diagnostics on open of an empty (valid) file
-            self.assertEqual(
-                runner.recv(),
-                {
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/publishDiagnostics",
-                    "params": {
-                        "uri": file_uri,
-                        "version": 1,
-                        "diagnostics": [],
-                    },
-                },
-            )
-
-            # 2. Change the file to invalid syntax
-            invalid_text = """select Hello world }"""
-            runner.send(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/didChange",
-                    "params": {
-                        "textDocument": {
-                            "uri": file_uri,
-                            "version": 2,
-                        },
-                        "contentChanges": [{"text": invalid_text}],
-                    },
-                }
-            )
-            # Expect no diagnostics on change (testing the new behavior)
-            # Use a very short timeout as we expect no response
-            with self.assertRaises(TimeoutError):
-                runner.recv(timeout_sec=0.1)
-
-            # 3. Save the file
-            runner.send(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/didSave",
-                    "params": {
-                        "textDocument": {
-                            "uri": file_uri,
-                        }
-                    },
-                }
-            )
-            self.assertEqual(
-                runner.recv(),
-                {
-                    "jsonrpc": "2.0",
-                    "method": "textDocument/publishDiagnostics",
-                    "params": {
-                        "uri": file_uri,
-                        "version": 2,
-                        "diagnostics": [
-                            {
-                                "message": "Missing '{'",
-                                "range": {
-                                    "start": {"character": 12, "line": 0},
-                                    "end": {"character": 13, "line": 0},
-                                },
-                                "severity": 1,
-                            }
                         ],
                     },
                 },


### PR DESCRIPTION
Follow up for #8682

That PR made is so we don't parse or compile on every document change,
but only when document is saved. This was needed because large schemas
resulted in a lot of lag of diagnostics.

This PR does parsing on every change but recompiles only on saves.
This gives syntactical diagnostics during typing. This is feasible
because they are cheap performance wise. Compilation of EdgeQL or schema
is done only on save.

But still, there is something bad going on with schema compilation.
Name errors are quick to show (<1 sec), but successful compilations are
slow. We should investigate.
