### PR TITLE
Implement sys::approximate_count()

### DIFF
--- a/docs/reference/stdlib/sys.rst
+++ b/docs/reference/stdlib/sys.rst
@@ -11,6 +11,9 @@ System
 .. list-table::
     :class: funcoptable
 
+    * - :eql:func:`sys::approximate_count`
+      - :eql:func-desc:`sys::approximate_count`
+
     * - :eql:func:`sys::get_version`
       - :eql:func-desc:`sys::get_version`
 
@@ -31,6 +34,43 @@ System
 
     * - :eql:func:`sys::reset_query_stats`
       - :eql:func-desc:`sys::reset_query_stats`
+
+
+----------
+
+
+.. eql:function:: sys::approximate_count( \
+                      type: schema::ObjectType, \
+                      NAMED ONLY ignore_subtypes: std::bool=false, \
+                  ) -> int64
+
+    Return an approximate count of the number of objects belonging to
+    a given type.
+
+    The ``type`` argument is a ``schema::ObjectType`` representing the
+    type to query.  It can be most easily obtained with the
+    :eql:op:`introspect` operator.
+
+    By default, the count includes all subtypes of the provided type as well.
+    If ``ignore_subtypes`` is true, then it includes only the type itself.
+
+    The value is based on postgres statistics, and may not be accurate.
+
+    .. code-block:: edgeql-repl
+
+        db> select sys::approximate_count(introspect schema::Type);
+        {278}
+        db> select sys::approximate_count(introspect schema::Type, ignore_subtypes:=True);
+        {0}
+        db> select schema::ObjectType {
+        ... name,
+        ... cnt := sys::approximate_count(schema::ObjectType, ignore_subtypes:=True),
+        ... };
+        {
+           schema::ObjectType {name: 'default::Issue', cnt: 4},
+           schema::ObjectType {name: 'default::User', cnt: 2},
+           ...
+        }
 
 
 ----------

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_05_09_00_00
+EDGEDB_CATALOG_VERSION = 2025_05_09_00_01
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -405,3 +405,15 @@ sys::__pg_or(a: OPTIONAL std::bool, b: OPTIONAL std::bool) -> std::bool
         SELECT a OR b;
     $$;
 };
+
+
+CREATE FUNCTION
+sys::approximate_count(
+    type: schema::ObjectType,
+    NAMED ONLY ignore_subtypes: std::bool=false,
+) -> int64
+{
+    SET volatility := 'Stable';
+    USING SQL FUNCTION 'edgedb.approximate_count';
+    set impl_is_strict := false;
+};

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -1528,6 +1528,8 @@ class FunctionCommand(MetaCommand):
             param_type = param.get_type(schema)
             pg_at = self.get_pgtype(cobj, param_type, schema)
             args.append(f'NULL::{qt(pg_at)}')
+            if isinstance(param_type, s_objtypes.ObjectType):
+                args.append(f'NULL::uuid')
 
         return f'{q(*name)}({", ".join(args)})'
 

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -9406,3 +9406,26 @@ class TestEdgeQLFunctions(tb.DDLTestCase):
             ['https://edgedb.com', '~/screenshot.png'],
             sort=True,
         )
+
+    async def test_edgeql_functions_approximate_count(self):
+        await self.assert_query_result(
+            '''
+            select sys::approximate_count(introspect Issue);
+            ''',
+            [int],
+        )
+
+        await self.assert_query_result(
+            '''
+            select sys::approximate_count(
+                introspect schema::Object, ignore_subtypes := True);
+            ''',
+            [0],
+        )
+
+        val = await self.con.query_single(
+            '''
+            select sys::approximate_count(introspect schema::Object);
+            '''
+        )
+        self.assertGreater(val, 0)


### PR DESCRIPTION
It takes a schema::ObjectType, so it is called like
`sys::approximate_count(introspect Card)`.
This is because the implementation works by querying the `reltuples`
field of `pg_class`, and it really only makes sense for getting a
full table. Having it take `anytype` and special casing would
create weird discontinuities where the simple case worked like this
and complex cases have a correctness or performance cliff.

Maybe we want to name it something different?

By default it includes all descendant types too; the ignore_subtypes
parameter changes that.

Fixes #4164.