### PR TITLE
Gel-ls: improve go to definiton of with binding

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -1284,7 +1284,12 @@ def fini_stmt(
             view = view_obj
         else:
             view = schemactx.derive_view(
-                t, derived_name=view_name, preserve_shape=True, ctx=parent_ctx)
+                t,
+                derived_name=view_name,
+                preserve_shape=True,
+                attrs={'span': irstmt.span},
+                ctx=parent_ctx
+            )
         path_id = pathctx.get_path_id(view, ctx=parent_ctx)
     else:
         view = None

--- a/edb/language_server/__init__.py
+++ b/edb/language_server/__init__.py
@@ -41,6 +41,15 @@ def is_edgeql_file(path: str) -> bool:
 def dump_to_str(node: Any) -> str:
     import io
     from edb.common import markup
+
     buf = io.StringIO()
     markup.dump(node, file=buf)
     return buf.getvalue()
+
+
+def dump_to_local_file(path: str, node: Any):
+    import pathlib
+    from edb.common import markup
+
+    with ('.' / pathlib.Path(path)).open('w') as file:
+        markup.dump(node, file=file)

--- a/edb/language_server/main.py
+++ b/edb/language_server/main.py
@@ -62,6 +62,7 @@ def init(options_json: str | None) -> ls_server.GelLanguageServer:
 
     # construct server
     ls = ls_server.GelLanguageServer(config)
+    debug_init(ls)
 
     # register hooks
     @ls.feature(
@@ -97,3 +98,18 @@ def init(options_json: str | None) -> ls_server.GelLanguageServer:
         return ls_completion.get_completion(ls, params)
 
     return ls
+
+
+# Last gel-ls instance initialed. Use ONLY for debugging purposes.
+__gel_ls: ls_server.GelLanguageServer | None = None
+
+
+def debug_init(ls: ls_server.GelLanguageServer):
+    global __gel_ls
+    __gel_ls = ls
+
+
+def send_log_message(message: str):
+    global __gel_ls
+    assert __gel_ls, 'GelLanguageServer has not be started yet'
+    __gel_ls.show_message_log(message)


### PR DESCRIPTION
Support for "go to definition of with binding" in EdgeQL. I had this
partially implemented before, but not tested. So it was not actually
working and had problems when a with binding type was used in a shape,
which created another, derived subtype of it. That subtype does not have
a span set, so we cannot jump to it's definition.

My solution was to 'walk up the inheritance tree' for such types that
do not have a span and are derived views.

I've also added a few debugging tools, needed to get debug messages
over LSP (or written to disk).
