### PR TITLE
Gel-ls: show hints produced in all stages in diagnostics

### DIFF
--- a/edb/language_server/parsing.py
+++ b/edb/language_server/parsing.py
@@ -77,15 +77,7 @@ def parse(
             result.out, productions, source, doc.filename
         ).val
     except errors.EdgeDBError as e:
-        return Result(
-            err=[
-                lsp_types.Diagnostic(
-                    range=ls_utils.span_to_lsp(source.text(), e.get_span()),
-                    severity=lsp_types.DiagnosticSeverity.Error,
-                    message=e.args[0],
-                )
-            ]
-        )
+        return Result(err=[ls_utils.error_to_lsp(e)])
     if sdl:
         assert isinstance(ast, qlast.Schema), ast
     else:

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -169,7 +169,7 @@ def compile_ql(
                 if isinstance(ir_res, irast.Statement):
                     ir_stmts.append(ir_res)
             else:
-                ls.send_log_message(f"skip compile of {ql_stmt}")
+                ls.show_message_log(f"skip compile of {ql_stmt}")
         except errors.EdgeDBError as error:
             diagnostics.append(ls_utils.error_to_lsp(error))
 

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -169,7 +169,7 @@ def compile_ql(
                 if isinstance(ir_res, irast.Statement):
                     ir_stmts.append(ir_res)
             else:
-                ls.show_message_log(f"skip compile of {ql_stmt}")
+                ls.send_log_message(f"skip compile of {ql_stmt}")
         except errors.EdgeDBError as error:
             diagnostics.append(ls_utils.error_to_lsp(error))
 

--- a/edb/language_server/utils.py
+++ b/edb/language_server/utils.py
@@ -93,6 +93,14 @@ def span_to_lsp(
 
 # Convert EdgeDBError into an LSP Diagnostic
 def error_to_lsp(error: errors.EdgeDBError) -> lsp_types.Diagnostic:
+    message: str = error.args[0]
+
+    from edb.language_server import main
+    main.send_log_message(str(error) + str(error.hint) + str(error.details))
+
+    if hint := error.hint:
+        message += f"\nHint: {hint}"
+
     return lsp_types.Diagnostic(
         range=(
             lsp_types.Range(
@@ -112,7 +120,7 @@ def error_to_lsp(error: errors.EdgeDBError) -> lsp_types.Diagnostic:
             )
         ),
         severity=lsp_types.DiagnosticSeverity.Error,
-        message=error.args[0],
+        message=message,
     )
 
 

--- a/edb/language_server/utils.py
+++ b/edb/language_server/utils.py
@@ -95,9 +95,6 @@ def span_to_lsp(
 def error_to_lsp(error: errors.EdgeDBError) -> lsp_types.Diagnostic:
     message: str = error.args[0]
 
-    from edb.language_server import main
-    main.send_log_message(str(error) + str(error.hint) + str(error.details))
-
     if hint := error.hint:
         message += f"\nHint: {hint}"
 

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -327,7 +327,8 @@ class TestLanguageServer(unittest.TestCase):
                             {
                                 "message": (
                                     "object type 'default::Hello' "
-                                    "has no link or property 'worl'"
+                                    "has no link or property 'worl'\n"
+                                    "Hint: did you mean 'world'?"
                                 ),
                                 "range": {
                                     "start": {"character": 47, "line": 1},
@@ -439,7 +440,9 @@ class TestLanguageServer(unittest.TestCase):
                             {
                                 "message": (
                                     "operator '+' cannot be applied to operands"
-                                    " of type 'std::str' and 'std::int64'"
+                                    " of type 'std::str' and 'std::int64'\n"
+                                    "Hint: Consider using an explicit type "
+                                    "cast or a conversion function."
                                 ),
                                 "range": {
                                     "start": {"character": 7, "line": 0},

--- a/tests/test_language_server.py
+++ b/tests/test_language_server.py
@@ -455,6 +455,150 @@ class TestLanguageServer(unittest.TestCase):
         finally:
             runner.finish()
 
+    def test_language_server_diagnostics_05(self):
+        # Test hints
+        runner = LspRunner()
+        try:
+            runner.add_file("gel.toml", "")
+            runner.add_file("dbschema/default.gel", "")
+            runner.send_init()
+
+            # hint originating from parser
+            file_uri = runner.get_uri("my_query.edgeql")
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": file_uri,
+                            "languageId": "edgeql",
+                            "version": 1,
+                            "text": "explain select 1",
+                        }
+                    },
+                }
+            )
+            self.assertEqual(
+                runner.recv(timeout_sec=10),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": file_uri,
+                        "version": 1,
+                        "diagnostics": [
+                            {
+                                "message": (
+                                    "Unexpected keyword 'EXPLAIN'\n"
+                                    "Hint: Use `analyze` to show query "
+                                    "performance details"
+                                ),
+                                "range": {
+                                    "start": {"character": 0, "line": 0},
+                                    "end": {"character": 7, "line": 0},
+                                },
+                                "severity": 1,
+                            }
+                        ],
+                    },
+                },
+            )
+
+            # hint originating from CST to AST mapper
+            file_uri = runner.get_uri("my_query.edgeql")
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": file_uri,
+                            "languageId": "edgeql",
+                            "version": 2,
+                            "text": "insert 1 if true else 2",
+                        }
+                    },
+                }
+            )
+            self.assertEqual(
+                runner.recv(timeout_sec=10),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": file_uri,
+                        "version": 2,
+                        "diagnostics": [
+                            {
+                                "message": (
+                                    "INSERT only works with object types, not "
+                                    "conditional expressions\n"
+                                    "Hint: To resolve this try surrounding the "
+                                    "INSERT branch of the conditional "
+                                    "expression with parentheses. This way the "
+                                    "INSERT will be triggered conditionally in "
+                                    "one of the branches."
+                                ),
+                                "range": {
+                                    "start": {"character": 7, "line": 0},
+                                    "end": {"character": 23, "line": 0},
+                                },
+                                "severity": 1,
+                            }
+                        ],
+                    },
+                },
+            )
+
+            # hint originating from ql compiler
+            file_uri = runner.get_uri("my_query.edgeql")
+            runner.send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/didOpen",
+                    "params": {
+                        "textDocument": {
+                            "uri": file_uri,
+                            "languageId": "edgeql",
+                            "version": 3,
+                            "text": "select std::len(4)",
+                        }
+                    },
+                }
+            )
+            self.assertEqual(
+                runner.recv(timeout_sec=10),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": {
+                        "uri": file_uri,
+                        "version": 3,
+                        "diagnostics": [
+                            {
+                                "message": (
+                                    'function "std::len(arg0: std::int64)" does'
+                                    ' not exist\n'
+                                    "Hint: Did you want one of the following "
+                                    "functions instead:\n"
+                                    "std::len(array: array<anytype>)\n"
+                                    "std::len(bytes: std::bytes)\n"
+                                    "std::len(str: std::str)"
+                                ),
+                                "range": {
+                                    "start": {"character": 7, "line": 0},
+                                    "end": {"character": 18, "line": 0},
+                                },
+                                "severity": 1,
+                            }
+                        ],
+                    },
+                },
+            )
+        finally:
+            runner.finish()
+
     def test_language_server_definition_01(self):
         # get definition in edgeql
         runner = LspRunner()


### PR DESCRIPTION
We had code that was showing hints from some parts of the compiler.
This PR adds tests for that and fixes error conversion into diagnostics
for CST to AST mapper.