### PR TITLE
Move access policy filter scope subtrees to the right part of the tree

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -201,6 +201,18 @@ class Anchor(Expr):
 
 class IRAnchor(Anchor):
     has_dml: bool = False
+    # Whether, when the anchor is referenced, to move the entire
+    # referenced scope tree of the anchor to wherever it is referenced.
+    #
+    # This is important when the anchor is being used to substitute an
+    # expression in, being used only once, and we want it to behave
+    # like it was written at the point it is being substituted.
+    #
+    # (Sometimes we have anchors that get used repeatedly and which we
+    # *want* to have be bound above, basically. I'd like to get rid of
+    # all of those uses, though.)
+    # (And also the scope tree.)
+    move_scope: bool = False
 
 
 class SpecialAnchor(Anchor):

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -807,15 +807,23 @@ class ContextLevel(compiler.ContextLevel):
         return self.new(ContextSwitchMode.DETACHED)
 
     def create_anchor(
-        self, ir: irast.Set, name: str = 'v', *, check_dml: bool = False
+        self,
+        ir: irast.Set,
+        name: str = 'v', *,
+        check_dml: bool = False,
+        move_scope: bool = False,
     ) -> qlast.Path:
         alias = self.aliases.get(name)
         # TODO: We should probably always check for DML, but I'm
         # concerned about perf, since we don't cache it at all.
         has_dml = check_dml and irutils.contains_dml(ir)
         self.anchors[alias] = ir
+        if move_scope:
+            assert ir.path_scope_id is not None
         return qlast.Path(
-            steps=[qlast.IRAnchor(name=alias, has_dml=has_dml)],
+            steps=[qlast.IRAnchor(
+                name=alias, has_dml=has_dml, move_scope=move_scope
+            )],
         )
 
     def maybe_create_anchor(


### PR DESCRIPTION
Because of heavy uses of anchors, we compile access policy filter
scopes on their own, before then sticking them into the FILTER clause
we create.

This was causing annoying problems involving cardinality inference of
arguments that were compiled with `prefer_subquery_args`, since having
the extra BRANCH scope in the wrong place caused them to look in the
wrong places in the scope tree.

Fix this by creating a mechanism to ask for IRAnchor's to *move* their
original scope subtree to wherever in the tree they are used, instead.

There is one other place currently where we need to do this, and it
was easy to convert it to this mechanism.

We might want to use this in more places, too. (Or, better, rip out
the scope tree.)