### PR TITLE
Disable DML on instered objects that needed for SQL

### DIFF
--- a/edb/pgsql/compiler/__init__.py
+++ b/edb/pgsql/compiler/__init__.py
@@ -88,6 +88,7 @@ def compile_ir_to_sql_tree(
     versioned_stdlib: bool = True,
     # HACK?
     versioned_singleton: bool = False,
+    sql_dml_mode: bool = False,
 ) -> CompileResult:
     if singleton_mode and not versioned_singleton:
         versioned_stdlib = False
@@ -146,6 +147,7 @@ def compile_ir_to_sql_tree(
             external_rvars=external_rvars,
             backend_runtime_params=backend_runtime_params,
             versioned_stdlib=versioned_stdlib,
+            sql_dml_mode=sql_dml_mode,
         )
 
         ctx = context.CompilerContextLevel(

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -220,8 +220,7 @@ class CompilerContextLevel(compiler.ContextLevel):
     #: Record of DML CTEs generated for the corresponding IR DML.
     #: CTEs generated for DML-containing FOR statements are keyed
     #: by their iterator set.
-    dml_stmts: dict[irast.MutatingStmt | irast.Set,
-                    pgast.CommonTableExpr]
+    dml_stmts: dict[irast.MutatingStmt | irast.Set, pgast.CommonTableExpr]
 
     #: Inline DML functions may require additional CTEs.
     #: Record such CTEs as well as the path used by their iterators.
@@ -545,6 +544,7 @@ class Environment:
     materialized_views: dict[uuid.UUID, irast.Set]
     backend_runtime_params: pgparams.BackendRuntimeParams
     versioned_stdlib: bool
+    sql_dml_mode: bool
 
     #: A list of CTEs that implement constraint validation at the
     #: query level.
@@ -570,6 +570,7 @@ class Environment:
         backend_runtime_params: pgparams.BackendRuntimeParams,
         # XXX: TRAMPOLINE: THIS IS WRONG
         versioned_stdlib: bool = True,
+        sql_dml_mode: bool = False,
     ) -> None:
         self.aliases = alias_generator or pg_aliases.AliasGenerator()
         self.output_format = output_format
@@ -588,6 +589,7 @@ class Environment:
         self.check_ctes = []
         self.backend_runtime_params = backend_runtime_params
         self.versioned_stdlib = versioned_stdlib
+        self.sql_dml_mode = sql_dml_mode
 
 
 # XXX: this context hack is necessary until pathctx is converted

--- a/edb/pgsql/resolver/command.py
+++ b/edb/pgsql/resolver/command.py
@@ -1971,6 +1971,7 @@ def _compile_uncompiled_dml(
             external_rels=external_rels,
             output_format=pgcompiler.OutputFormat.NATIVE_INTERNAL,
             alias_generator=ctx.alias_generator,
+            sql_dml_mode=True,
         )
 
         merge_params(sql_result, ir_stmt, ctx)


### PR DESCRIPTION
Followup for #8582

For DML, I needed updates of objects that were inserted in the same
query. To be exact, I needed only *updates of their links*, which
translate to update of the link table only.

But my fix also affected EdgeQL DML, so this PR disables that.

We could keep this feature, but it would only work when updates really
are on links and multi properties only. Which would be a weird design
choice, so I would prefer not to have this feature in the first place.
