### PR TITLE
Rename gel-ls publish workflow followup

### DIFF
--- a/.github/workflows/ls-nightly.yml
+++ b/.github/workflows/ls-nightly.yml
@@ -1,4 +1,4 @@
-name: 'edgedb-ls: Build and Publish Nightly Packages'
+name: 'ls: Build and Publish Nightly Packages'
 
 on:
   schedule:


### PR DESCRIPTION
This is just `make -C .github` as a followup for #8709
