### PR TITLE
Use provided callback URL in OAuth code exchange

### DIFF
--- a/edb/server/protocol/auth_ext/jwt.py
+++ b/edb/server/protocol/auth_ext/jwt.py
@@ -290,11 +290,15 @@ class SessionToken:
 @dataclasses.dataclass
 class OAuthStateToken:
     """
-    The token representing an OAuth state passed to the identity provider.
+    The token representing an OAuth state passed to the identity provider. It
+    allows the auth extension server to reference data from the original
+    authorize request, such as the provider, application redirect URLs, PKCE
+    challenge, and OAuth callback URL.
     """
     provider: str
     redirect_to: str
     challenge: str
+    redirect_uri: str
     redirect_to_on_signup: str | None = None
 
     def sign(
@@ -313,6 +317,7 @@ class OAuthStateToken:
                 "redirect_to": self.redirect_to,
                 "redirect_to_on_signup": self.redirect_to_on_signup,
                 "challenge": self.challenge,
+                "redirect_uri": self.redirect_uri,
             },
             ctx=signing_ctx,
         )
@@ -328,6 +333,7 @@ class OAuthStateToken:
                 cls, claims, 'redirect_to_on_signup'
             ),
             challenge=verify_str(cls, claims, 'challenge'),
+            redirect_uri=verify_str(cls, claims, 'redirect_uri'),
         )
 
 

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -637,6 +637,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=None,
                 redirect_to=None,
                 challenge=None,
+                redirect_uri=None,
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -659,6 +660,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge="1234",
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(
                 auth_jwt.SigningKey(lambda: 'wrong key', self.http_addr),
@@ -679,6 +681,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 redirect_to="https://example.com",
                 redirect_to_on_signup=None,
                 challenge="challenge",
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -800,6 +803,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     provider=provider_name,
                     redirect_to=f"{self.http_addr}/some/path",
                     challenge=challenge,
+                    redirect_uri=f"{self.http_addr}/auth/oauth/code",
                 )
                 state_token = state_claims.sign(self.signing_key())
 
@@ -833,7 +837,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                         "code": "abc123",
                         "client_id": client_id,
                         "client_secret": client_secret,
-                        "redirect_uri": f"{self.http_addr}/callback",
+                        "redirect_uri": f"{self.http_addr}/auth/oauth/code",
                     },
                 )
 
@@ -959,6 +963,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge="challenge",
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1020,6 +1025,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge="challenge",
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1192,6 +1198,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge=challenge,
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1222,7 +1229,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     "code": ["abc123"],
                     "client_id": [client_id],
                     "client_secret": [client_secret],
-                    "redirect_uri": [f"{self.http_addr}/callback"],
+                    "redirect_uri": [f"{self.http_addr}/auth/oauth/code"],
                 },
             )
 
@@ -1337,6 +1344,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge=challenge,
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1371,7 +1379,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     "code": ["abc123"],
                     "client_id": [client_id],
                     "client_secret": [client_secret],
-                    "redirect_uri": [f"{self.http_addr}/callback"],
+                    "redirect_uri": [f"{self.http_addr}/auth/oauth/code"],
                 },
             )
 
@@ -1586,6 +1594,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge=challenge,
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1620,7 +1629,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     "code": ["abc123"],
                     "client_id": [client_id],
                     "client_secret": [client_secret],
-                    "redirect_uri": [f"{self.http_addr}/callback"],
+                    "redirect_uri": [f"{self.http_addr}/auth/oauth/code"],
                 },
             )
 
@@ -1754,6 +1763,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge=challenge,
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1793,7 +1803,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     "code": ["abc123"],
                     "client_id": [client_id],
                     "client_secret": [client_secret],
-                    "redirect_uri": [f"{self.http_addr}/callback"],
+                    "redirect_uri": [f"{self.http_addr}/auth/oauth/code"],
                 },
             )
 
@@ -1851,6 +1861,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 redirect_to=f"{self.http_addr}/some/path",
                 redirect_to_on_signup=f"{self.http_addr}/some/other/path",
                 challenge=challenge,
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1950,6 +1961,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge=challenge,
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -1984,7 +1996,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     "code": ["abc123"],
                     "client_id": [client_id],
                     "client_secret": [client_secret],
-                    "redirect_uri": [f"{self.http_addr}/callback"],
+                    "redirect_uri": [f"{self.http_addr}/auth/oauth/code"],
                 },
             )
 
@@ -2210,6 +2222,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 provider=provider_name,
                 redirect_to=f"{self.http_addr}/some/path",
                 challenge=challenge,
+                redirect_uri=f"{self.http_addr}/auth/oauth/code",
             )
             state_token = state_claims.sign(self.signing_key())
 
@@ -2244,7 +2257,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                     "code": ["abc123"],
                     "client_id": [client_id],
                     "client_secret": [client_secret],
-                    "redirect_uri": [f"{self.http_addr}/callback"],
+                    "redirect_uri": [f"{self.http_addr}/auth/oauth/code"],
                 },
             )
 


### PR DESCRIPTION
We recently updated the auth server to allow proxying the OAuth flow
through the application server to allow customizing the behavior or
keeping the database on a private network. One crucial part of this
proxying is being able to specify the internal `redirect_uri` that is
registered at the Identity Provider and used as part of the code
exchange between the auth server and the identity provider. We were
correctly setting this value on the initial authorize call to the IdP,
but then hardcoding the old direct URL.

In order to pass the correct URL through to this point in the flow, we
need to encode it into the `state`, and then use _that_ value instead of
the hard-coded value.