### PR TITLE
Fix `administer schema_repair()`

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -704,7 +704,7 @@ def prepare_repair_patch(
     res = edbcompiler.repair_schema(compilerctx)
     if not res:
         return ""
-    sql, _, _ = res
+    sql, _ = res
 
     return sql.decode('utf-8')
 

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1318,7 +1318,7 @@ def produce_feature_used_metrics(
 
 def repair_schema(
     ctx: compiler.CompileContext,
-) -> Optional[tuple[bytes, s_schema.Schema, Any]]:
+) -> Optional[tuple[bytes, Any]]:
     """Repair inconsistencies in the schema caused by bug fixes
 
     Works by comparing the actual current schema to the schema we get
@@ -1386,7 +1386,7 @@ def repair_schema(
         debug.header('Repair Delta Script')
         debug.dump_code(sql, lexer='sql')
 
-    return sql, reloaded_schema, config_ops
+    return sql, config_ops
 
 
 def administer_repair_schema(
@@ -1404,9 +1404,7 @@ def administer_repair_schema(
     res = repair_schema(ctx)
     if not res:
         return dbstate.MaintenanceQuery(sql=b"")
-    sql, new_schema, config_ops = res
-
-    current_tx.update_schema(new_schema)
+    sql, config_ops = res
 
     return dbstate.DDLQuery(
         sql=sql,

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -18878,16 +18878,6 @@ DDLStatement);
             [{}],
         )
 
-    async def test_edgeql_ddl_schema_repair(self):
-        await self.con.execute('''
-            create type Tgt {
-                create property lol := count(Object)
-            }
-        ''')
-        await self.con.execute('''
-            administer schema_repair()
-        ''')
-
     async def test_edgeql_ddl_alias_and_create_set_required(self):
         await self.con.execute(r"""
             create type T;


### PR DESCRIPTION
`administer schema_repair()` had a bug where, if any repairs were
done, it set the in-memory schema to be the "reloaded_schema" used to
compare against for mismatches. This schema is equivalent to the
original, except that all of the ids were different.

This meant that any queries that were compiled using that schema would
be broken, and would try to query nonexistent tables.

This only affected the `administer` codepath; running `schema_repair`
as part of patches during version upgrades still worked.

If no uncached queries were compiled before the server was restarted,
this might not be noticed, which I suspect is what happened with
previous uses of `administer schema_repair()`.

Previously schema_repair was not really tested, since it typically
only does anything when a bug resulted in a broken schema.

I've added infrastructure for intentionally breaking the schema (by
UPDATEing the reflection schema), and a couple tests.