### PR TITLE
Fix `IN` when left hand side is a SQL NULL

### DIFF
--- a/tests/test_edgeql_expressions.py
+++ b/tests/test_edgeql_expressions.py
@@ -782,6 +782,12 @@ class TestExpressions(tb.QueryTestCase):
         )
 
         await self.assert_query_result(
+            r'''SELECT <optional int64>$0 IN <int64>{};''',
+            [],
+            variables=(None,),
+        )
+
+        await self.assert_query_result(
             r'''SELECT {1, 2, 3} IN <int64>{};''',
             [False, False, False],
         )


### PR DESCRIPTION
Doing `SELECT (<optional int64>$0 IN <int64>{})` and passing None
was giving false.
We need to filter the NULL in this case.