### PR TITLE
Add prompt param to discord's `get_code_url`

### DIFF
--- a/edb/server/protocol/auth_ext/discord.py
+++ b/edb/server/protocol/auth_ext/discord.py
@@ -45,6 +45,7 @@ class DiscordProvider(base.BaseProvider):
             "state": state,
             "redirect_uri": redirect_uri,
             "response_type": "code",
+            "prompt": "none"
         }
         encoded = urllib.parse.urlencode(params)
         return f"{self.auth_domain}/oauth2/authorize?{encoded}"


### PR DESCRIPTION
Default behaviour of Discord reprompts user for authorization of scopes every time (even if nothing changed when user initially authorized the requested scopes).

This change will set the `prompt` param to `none` in the request and will have the following effect:

- When the user is first redirected to discord, they get a prompt to authorize the scopes requested by the application
- When the user is redirected to discord and no scopes have changed, no prompt is shown to the user
- When the user is redirected to discord and the scopes have changes since the user authorized the application, the prompt is shown again to re-authorize the request