### PR TITLE
Support creating indexes concurrently

### DIFF
--- a/dev-notes/concurrent-indexes.py
+++ b/dev-notes/concurrent-indexes.py
@@ -6,7 +6,7 @@ def create_concurrent_indexes(db, msg_callback=print):
     '''Actually create all "create concurrently" indexes
 
     The protocol here is to find all the indexes that need created,
-    and create them with `administer concurrent_index_create()`.
+    and create them with `administer concurrent_index_build()`.
     It's possible that the database will shut down after an index
     creation but before the metadata is updated, in which case
     we might rerun the command later, which is harmless.
@@ -18,7 +18,7 @@ def create_concurrent_indexes(db, msg_callback=print):
         select schema::Index {
             id, expr, subject_name := .<indexes[is schema::ObjectType].name
         }
-        filter .create_concurrently and not .active
+        filter .build_concurrently and not .active
     ''')
     for index in indexes:
         msg_callback(
@@ -26,7 +26,7 @@ def create_concurrent_indexes(db, msg_callback=print):
             f"with expr ({index.expr})"
         )
         db.execute(f'''
-            administer concurrent_index_create("{index.id}")
+            administer concurrent_index_build("{index.id}")
         ''')
 
 

--- a/dev-notes/concurrent-indexes.py
+++ b/dev-notes/concurrent-indexes.py
@@ -2,7 +2,19 @@
 
 import gel
 
-def create_concurrent_indexes(db):
+def create_concurrent_indexes(db, msg_callback=print):
+    '''Actually create all "create concurrently" indexes
+
+    The protocol here is to call `administer concurrent_index_update()`
+    to make sure that the `active` properties match database reality
+    (since concurrent_index_create can't update them atomically),
+    then find all the indexes that need created,
+    create them with `administer concurrent_index_create()`,
+    and then run `administer concurrent_index_update()` again.
+
+    If we stick with this ADMINISTER-based schemed, I figure this code
+    would live in the CLI.
+    '''
     db.execute('''
         administer concurrent_index_update();
     ''')
@@ -13,7 +25,7 @@ def create_concurrent_indexes(db):
         filter .create_concurrently and not .active
     ''')
     for index in indexes:
-        print(
+        msg_callback(
             f"Creating concurrent index on '{index.subject_name}' "
             f"with expr ({index.expr})"
         )

--- a/dev-notes/concurrent-indexes.py
+++ b/dev-notes/concurrent-indexes.py
@@ -26,7 +26,7 @@ def create_concurrent_indexes(db, msg_callback=print):
             f"with expr ({index.expr})"
         )
         db.execute(f'''
-            administer concurrent_index_build("{index.id}")
+            administer concurrent_index_build("<uuid>{index.id}")
         ''')
 
 

--- a/dev-notes/concurrent-indexes.py
+++ b/dev-notes/concurrent-indexes.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import gel
+
+def create_concurrent_indexes(db):
+    db.execute('''
+        administer concurrent_index_update();
+    ''')
+    indexes = db.query('''
+        select schema::Index {
+            id, expr, subject_name := .<indexes[is schema::ObjectType].name
+        }
+        filter .create_concurrently and not .active
+    ''')
+    for index in indexes:
+        print(
+            f"Creating concurrent index on '{index.subject_name}' "
+            f"with expr ({index.expr})"
+        )
+        db.execute(f'''
+            administer concurrent_index_create("{index.id}")
+        ''')
+    db.execute('''
+        administer concurrent_index_update();
+    ''')
+
+
+def main():
+    with gel.create_client() as db:
+        create_concurrent_indexes(db)
+
+
+if __name__ == '__main__':
+    main()

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_06_26_00_00
+EDGEDB_CATALOG_VERSION = 2025_06_26_00_01
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_06_26_00_01
+EDGEDB_CATALOG_VERSION = 2025_06_30_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
+++ b/edb/edgeql-parser/edgeql-parser-python/src/normalize.rs
@@ -156,7 +156,7 @@ pub fn normalize(text: &str) -> Result<Entry, Error> {
             }
             Kind::Keyword(Keyword(kw))
             if (
-                matches!(kw, "configure"|"create"|"alter"|"drop"|"start"|"analyze")
+                matches!(kw, "administer"|"configure"|"create"|"alter"|"drop"|"start"|"analyze")
                 || (last_was_set && kw == "global")
             ) => {
                 let processed_source = serialize_tokens(&tokens);

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -275,6 +275,8 @@ CREATE TYPE schema::Index
     CREATE PROPERTY except_expr -> std::str;
     CREATE PROPERTY deferrability -> schema::IndexDeferrability;
     CREATE PROPERTY deferred -> std::bool;
+    CREATE PROPERTY active -> std::bool;
+    CREATE PROPERTY create_concurrently -> std::bool;
     CREATE MULTI LINK params EXTENDING schema::ordered -> schema::Parameter {
         ON TARGET DELETE ALLOW;
     };

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -276,7 +276,7 @@ CREATE TYPE schema::Index
     CREATE PROPERTY deferrability -> schema::IndexDeferrability;
     CREATE PROPERTY deferred -> std::bool;
     CREATE PROPERTY active -> std::bool;
-    CREATE PROPERTY create_concurrently -> std::bool;
+    CREATE PROPERTY build_concurrently -> std::bool;
     CREATE MULTI LINK params EXTENDING schema::ordered -> schema::Parameter {
         ON TARGET DELETE ALLOW;
     };

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3427,7 +3427,7 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
         index: s_indexes.Index,
         schema: s_schema.Schema,
         context: sd.CommandContext,
-    ):
+    ) -> dbops.Command:
         from .compiler import astutils
 
         options = get_index_compile_options(
@@ -3540,7 +3540,12 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
                 'kwargs': sql_kwarg_exprs,
             }
         )
-        return dbops.CreateIndex(pg_index)
+        concurrently = index.get_create_concurrently(schema)
+        return dbops.CreateIndex(
+            pg_index,
+            concurrently=concurrently,
+            builtin_conditional=concurrently,
+        )
 
     def _create_innards(
         self,
@@ -3552,6 +3557,9 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
 
         if index.get_abstract(schema):
             # Don't do anything for abstract indexes
+            return schema
+
+        if index.get_create_concurrently(schema):
             return schema
 
         with errors.ensure_span(self.span):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3540,7 +3540,7 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
                 'kwargs': sql_kwarg_exprs,
             }
         )
-        concurrently = index.get_create_concurrently(schema)
+        concurrently = index.get_build_concurrently(schema)
         return dbops.CreateIndex(
             pg_index,
             concurrently=concurrently,
@@ -3559,7 +3559,7 @@ class CreateIndex(IndexCommand, adapts=s_indexes.CreateIndex):
             # Don't do anything for abstract indexes
             return schema
 
-        if index.get_create_concurrently(schema):
+        if index.get_build_concurrently(schema):
             return schema
 
         with errors.ensure_span(self.span):

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -1085,6 +1085,13 @@ class CreateIndex(
                     span=astnode.span,
                 )
 
+            if cmd.get_attribute_span('create_concurrently'):
+                cmd.set_attribute_value(
+                    'active',
+                    False,
+                    span=astnode.span,
+                )
+
         return cmd
 
     @classmethod

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -1695,6 +1695,24 @@ class AlterIndex(
     astnode = [qlast.AlterConcreteIndex, qlast.AlterIndex]
     referenced_astnode = qlast.AlterConcreteIndex
 
+    def validate_object(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> None:
+        super().validate_object(schema, context)
+
+        vn = self.scls.get_verbosename(schema, with_parent=True)
+        if (
+            not self.scls.get_create_concurrently(schema)
+            and not self.scls.get_active(schema)
+        ):
+            raise errors.SchemaDefinitionError(
+                f'{vn} is not active, so create_concurrently may '
+                f'not be cleared',
+                span=self.span,
+            )
+
     def canonicalize_alter_from_external_ref(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -342,14 +342,14 @@ class Index(
     )
 
     # Whether the index is created and populated in pg. Relevant if
-    # create_concurrently is true?
+    # build_concurrently is true?
     active = so.SchemaField(
         bool,
         default=True,
     )
 
     # XXX: I am not sure this is what I want to do.
-    create_concurrently = so.SchemaField(
+    build_concurrently = so.SchemaField(
         bool,
         default=False,
         compcoef=0.803,
@@ -1085,7 +1085,7 @@ class CreateIndex(
                     span=astnode.span,
                 )
 
-            if cmd.get_attribute_span('create_concurrently'):
+            if cmd.get_attribute_span('build_concurrently'):
                 cmd.set_attribute_value(
                     'active',
                     False,
@@ -1704,11 +1704,11 @@ class AlterIndex(
 
         vn = self.scls.get_verbosename(schema, with_parent=True)
         if (
-            not self.scls.get_create_concurrently(schema)
+            not self.scls.get_build_concurrently(schema)
             and not self.scls.get_active(schema)
         ):
             raise errors.SchemaDefinitionError(
-                f'{vn} is not active, so create_concurrently may '
+                f'{vn} is not active, so build_concurrently may '
                 f'not be cleared',
                 span=self.span,
             )

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -341,6 +341,21 @@ class Index(
         merge_fn=merge_deferred,
     )
 
+    # Whether the index is created and populated in pg. Relevant if
+    # create_concurrently is true?
+    active = so.SchemaField(
+        bool,
+        default=True,
+    )
+
+    # XXX: I am not sure this is what I want to do.
+    create_concurrently = so.SchemaField(
+        bool,
+        default=False,
+        compcoef=0.803,
+        allow_ddl_set=True,
+    )
+
     def __repr__(self) -> str:
         cls = self.__class__
         return '<{}.{} {!r} at 0x{:x}>'.format(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1746,26 +1746,32 @@ def _compile_ql_administer(
     script_info: Optional[irast.ScriptInfo] = None,
 ) -> dbstate.BaseQuery:
     if ql.expr.func == 'statistics_update':
-        return ddl.administer_statistics_update(ctx, ql)
+        res = ddl.administer_statistics_update(ctx, ql)
     elif ql.expr.func == 'schema_repair':
-        return ddl.administer_repair_schema(ctx, ql)
+        res = ddl.administer_repair_schema(ctx, ql)
     elif ql.expr.func == 'reindex':
-        return ddl.administer_reindex(ctx, ql)
+        res = ddl.administer_reindex(ctx, ql)
     elif ql.expr.func == 'vacuum':
-        return ddl.administer_vacuum(ctx, ql)
+        res = ddl.administer_vacuum(ctx, ql)
     elif ql.expr.func == 'prepare_upgrade':
-        return ddl.administer_prepare_upgrade(ctx, ql)
+        res = ddl.administer_prepare_upgrade(ctx, ql)
     elif ql.expr.func == '_remove_pointless_triggers':
-        return ddl.administer_remove_pointless_triggers(ctx, ql)
+        res = ddl.administer_remove_pointless_triggers(ctx, ql)
     elif ql.expr.func == 'create_concurrent_index':
-        return ddl.administer_create_concurrent_index(ctx, ql)
+        res = ddl.administer_create_concurrent_index(ctx, ql)
     elif ql.expr.func == 'update_concurrent_index':
-        return ddl.administer_update_concurrent_index(ctx, ql)
+        res = ddl.administer_update_concurrent_index(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',
             span=ql.expr.span,
         )
+
+    if debug.flags.delta_execute or debug.flags.delta_execute_ddl:
+        debug.header('ADMINISTER script')
+        debug.dump_code(res.sql, lexer='sql')
+
+    return res
 
 
 def _compile_ql_query(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1760,8 +1760,6 @@ def _compile_ql_administer(
         res = ddl.administer_remove_pointless_triggers(ctx, ql)
     elif ql.expr.func == 'concurrent_index_create':
         res = ddl.administer_concurrent_index_create(ctx, ql)
-    elif ql.expr.func == 'concurrent_index_update':
-        res = ddl.administer_concurrent_index_update(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',
@@ -3244,6 +3242,7 @@ def _make_query_unit(
     elif isinstance(comp, dbstate.MaintenanceQuery):
         unit.sql = comp.sql
         unit.database_config = comp.reload_schema
+        unit.early_non_tx_sql = comp.early_non_tx_sql
 
     elif isinstance(comp, dbstate.NullQuery):
         pass

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1758,8 +1758,8 @@ def _compile_ql_administer(
         res = ddl.administer_prepare_upgrade(ctx, ql)
     elif ql.expr.func == '_remove_pointless_triggers':
         res = ddl.administer_remove_pointless_triggers(ctx, ql)
-    elif ql.expr.func == 'concurrent_index_create':
-        res = ddl.administer_concurrent_index_create(ctx, ql)
+    elif ql.expr.func == 'concurrent_index_build':
+        res = ddl.administer_concurrent_index_build(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -3095,6 +3095,7 @@ def _make_query_unit(
         unit.create_db_template = comp.create_db_template
         unit.create_db_mode = comp.create_db_mode
         unit.ddl_stmt_id = comp.ddl_stmt_id
+        unit.early_non_tx_sql = comp.early_non_tx_sql
         if not ctx.dump_restore_mode:
             if comp.user_schema is not None:
                 final_user_schema = comp.user_schema
@@ -3241,8 +3242,6 @@ def _make_query_unit(
 
     elif isinstance(comp, dbstate.MaintenanceQuery):
         unit.sql = comp.sql
-        unit.database_config = comp.reload_schema
-        unit.early_non_tx_sql = comp.early_non_tx_sql
 
     elif isinstance(comp, dbstate.NullQuery):
         pass

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1757,6 +1757,10 @@ def _compile_ql_administer(
         return ddl.administer_prepare_upgrade(ctx, ql)
     elif ql.expr.func == '_remove_pointless_triggers':
         return ddl.administer_remove_pointless_triggers(ctx, ql)
+    elif ql.expr.func == 'create_concurrent_index':
+        return ddl.administer_create_concurrent_index(ctx, ql)
+    elif ql.expr.func == 'update_concurrent_index':
+        return ddl.administer_update_concurrent_index(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1508,6 +1508,7 @@ def compile_schema_storage_in_delta(
 def _compile_schema_storage_stmt(
     ctx: CompileContext,
     eql: str,
+    output_format: enums.OutputFormat = enums.OutputFormat.JSON,
 ) -> tuple[str, Sequence[dbstate.Param]]:
 
     schema = ctx.state.current_tx().get_schema(ctx.compiler_state.std_schema)
@@ -1529,7 +1530,7 @@ def _compile_schema_storage_stmt(
             state=ctx.state,
             json_parameters=True,
             schema_reflection_mode=True,
-            output_format=enums.OutputFormat.JSON,
+            output_format=output_format,
             expected_cardinality_one=False,
             bootstrap_mode=ctx.bootstrap_mode,
             protocol_version=ctx.protocol_version,
@@ -1757,10 +1758,10 @@ def _compile_ql_administer(
         res = ddl.administer_prepare_upgrade(ctx, ql)
     elif ql.expr.func == '_remove_pointless_triggers':
         res = ddl.administer_remove_pointless_triggers(ctx, ql)
-    elif ql.expr.func == 'create_concurrent_index':
-        res = ddl.administer_create_concurrent_index(ctx, ql)
-    elif ql.expr.func == 'update_concurrent_index':
-        res = ddl.administer_update_concurrent_index(ctx, ql)
+    elif ql.expr.func == 'concurrent_index_create':
+        res = ddl.administer_concurrent_index_create(ctx, ql)
+    elif ql.expr.func == 'concurrent_index_update':
+        res = ddl.administer_concurrent_index_update(ctx, ql)
     else:
         raise errors.QueryError(
             'Unknown ADMINISTER function',
@@ -3242,6 +3243,7 @@ def _make_query_unit(
 
     elif isinstance(comp, dbstate.MaintenanceQuery):
         unit.sql = comp.sql
+        unit.database_config = comp.reload_schema
 
     elif isinstance(comp, dbstate.NullQuery):
         pass

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -174,6 +174,7 @@ class DDLQuery(BaseQuery):
     db_op_trailer: tuple[bytes, ...] = ()
     ddl_stmt_id: Optional[str] = None
     config_ops: list[config.Operation] = dataclasses.field(default_factory=list)
+    early_non_tx_sql: Optional[tuple[bytes, ...]] = None
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -209,8 +210,7 @@ class MigrationControlQuery(BaseQuery):
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class MaintenanceQuery(BaseQuery):
-    early_non_tx_sql: Optional[tuple[bytes, ...]] = None
-    reload_schema: bool = False
+    pass
 
 
 @dataclasses.dataclass(frozen=True)

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -209,7 +209,7 @@ class MigrationControlQuery(BaseQuery):
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class MaintenanceQuery(BaseQuery):
-    pass
+    reload_schema: bool = False
 
 
 @dataclasses.dataclass(frozen=True)

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -209,6 +209,7 @@ class MigrationControlQuery(BaseQuery):
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class MaintenanceQuery(BaseQuery):
+    early_non_tx_sql: Optional[tuple[bytes, ...]] = None
     reload_schema: bool = False
 
 
@@ -250,6 +251,9 @@ class QueryUnit:
     # True if all statements in *sql* can be executed inside a transaction.
     # If False, they will be executed separately.
     is_transactional: bool = True
+
+    # SQL to run *before* the main command, non transactionally
+    early_non_tx_sql: Optional[tuple[bytes, ...]] = None
 
     # Capabilities used in this query
     capabilities: enums.Capability = enums.Capability(0)

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1853,14 +1853,23 @@ def _get_index(
     # This is janky, and we shouldn't do it.
     arg = ql.expr.args[0]
     match arg:
-        case qlast.Constant(
-            kind=qlast.ConstantKind.STRING,
-            value=id_string,
+        case qlast.TypeCast(
+            type=qlast.TypeName(
+                maintype=qlast.ObjectRef(
+                    name='uuid',
+                    module='std' | None,
+                ),
+                subtypes=None,
+            ),
+            expr=qlast.Constant(
+                kind=qlast.ConstantKind.STRING,
+                value=id_string,
+            )
         ):
             pass
         case _:
             raise errors.QueryError(
-                f'argument to {ql.expr.func}() must be a string literal',
+                f'argument to {ql.expr.func}() must be a uuid literal',
                 span=arg.span,
             )
 

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1960,7 +1960,6 @@ def administer_concurrent_index_update(
         statements = subblock.commands[0].get_statements()
         _, comments = statements
 
-
         # Update the schema::Index
         eql = f'''
             update schema::Index filter .id = <uuid>"{index.id}"

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -67,7 +67,6 @@ from edb.pgsql import delta as pg_delta
 from edb.pgsql import dbops as pg_dbops
 
 from . import dbstate
-from . import enums
 from . import compiler
 
 

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1882,13 +1882,13 @@ def _get_index(
     return index, schema
 
 
-def administer_concurrent_index_create(
+def administer_concurrent_index_build(
     ctx: compiler.CompileContext,
     ql: qlast.AdministerStmt,
 ) -> dbstate.BaseQuery:
     index, schema = _get_index(ctx, ql)
 
-    if not index.get_create_concurrently(schema):
+    if not index.get_build_concurrently(schema):
         raise errors.QueryError("Index was not created concurrently")
     if index.get_active(schema):
         raise errors.QueryError("Index is already active")
@@ -1926,7 +1926,7 @@ def administer_concurrent_index_create(
     sql = block.to_string().encode('utf-8')
 
     if debug.flags.delta_execute_ddl:
-        debug.header('ADMINISTER concurrent_index_create(...)')
+        debug.header('ADMINISTER concurrent_index_build(...)')
         debug.dump_code(index_command, lexer='sql')
         debug.dump_code(sql, lexer='sql')
 

--- a/edb/server/protocol/execute.pyx
+++ b/edb/server/protocol/execute.pyx
@@ -286,6 +286,13 @@ async def execute(
                 dbv.dbname,
                 close_frontend_conns=query_unit.drop_db_reset_connections,
             )
+
+        if query_unit.early_non_tx_sql:
+            # Sync state non transactionally
+            await be_conn.sql_fetch(b'select 1', state=state)
+            for sql in query_unit.early_non_tx_sql:
+                await be_conn.sql_execute(sql)
+
         if query_unit.system_config:
             # execute_system_config() always sync state in a separate tx,
             # so we don't need to pass down the needs_commit_state here

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -20266,19 +20266,15 @@ class TestDDLNonIsolated(tb.DDLTestCase):
 async def create_concurrent_indexes(db, msg_callback=print):
     '''Actually create all "create concurrently" indexes
 
-    The protocol here is to call `administer concurrent_index_update()`
-    to make sure that the `active` properties match database reality
-    (since concurrent_index_create can't update them atomically),
-    then find all the indexes that need created,
-    create them with `administer concurrent_index_create()`,
-    and then run `administer concurrent_index_update()` again.
+    The protocol here is to find all the indexes that need created,
+    and create them with `administer concurrent_index_create()`.
+    It's possible that the database will shut down after an index
+    creation but before the metadata is updated, in which case
+    we might rerun the command later, which is harmless.
 
     If we stick with this ADMINISTER-based schemed, I figure this code
     would live in the CLI.
     '''
-    await db.execute('''
-        administer concurrent_index_update();
-    ''')
     indexes = await db.query('''
         select schema::Index {
             id, expr, subject_name := .<indexes[is schema::ObjectType].name
@@ -20293,8 +20289,5 @@ async def create_concurrent_indexes(db, msg_callback=print):
         await db.execute(f'''
             administer concurrent_index_create("{index.id}")
         ''')
-    await db.execute('''
-        administer concurrent_index_update();
-    ''')
 
     return len(indexes)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -20287,7 +20287,7 @@ async def create_concurrent_indexes(db, msg_callback=print):
             f"with expr ({index.expr})"
         )
         await db.execute(f'''
-            administer concurrent_index_build("{index.id}")
+            administer concurrent_index_build(<uuid>"{index.id}")
         ''')
 
     return len(indexes)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -20174,13 +20174,13 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         ''')
         await self.con.execute('''
             alter type T {
-                create index on (.n) { set create_concurrently := true; }
+                create index on (.n) { set build_concurrently := true; }
             };
         ''')
         with self.assertRaisesRegex(edgedb.SchemaDefinitionError, 'not active'):
             await self.con.execute('''
                 alter type T {
-                    alter index on (.n) { set create_concurrently := false; }
+                    alter index on (.n) { set build_concurrently := false; }
                 };
             ''')
 
@@ -20192,7 +20192,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
 
         await self.con.execute('''
             alter type T {
-                alter index on (.n) { set create_concurrently := false; }
+                alter index on (.n) { set build_concurrently := false; }
             };
         ''')
 
@@ -20201,8 +20201,8 @@ class TestDDLNonIsolated(tb.DDLTestCase):
             create type T {
                 create required property n -> str;
                 create required property s -> int64;
-                create index on (.n) { set create_concurrently := true; };
-                create index on (.s) { set create_concurrently := true; };
+                create index on (.n) { set build_concurrently := true; };
+                create index on (.s) { set build_concurrently := true; };
             };
         ''')
 
@@ -20223,7 +20223,7 @@ class TestDDLNonIsolated(tb.DDLTestCase):
         ''')
         await self.con.execute('''
             alter type T {
-                create index on (.n) { set create_concurrently := true; }
+                create index on (.n) { set build_concurrently := true; }
             };
         ''')
 
@@ -20267,7 +20267,7 @@ async def create_concurrent_indexes(db, msg_callback=print):
     '''Actually create all "create concurrently" indexes
 
     The protocol here is to find all the indexes that need created,
-    and create them with `administer concurrent_index_create()`.
+    and create them with `administer concurrent_index_build()`.
     It's possible that the database will shut down after an index
     creation but before the metadata is updated, in which case
     we might rerun the command later, which is harmless.
@@ -20279,7 +20279,7 @@ async def create_concurrent_indexes(db, msg_callback=print):
         select schema::Index {
             id, expr, subject_name := .<indexes[is schema::ObjectType].name
         }
-        filter .create_concurrently and not .active
+        filter .build_concurrently and not .active
     ''')
     for index in indexes:
         msg_callback(
@@ -20287,7 +20287,7 @@ async def create_concurrent_indexes(db, msg_callback=print):
             f"with expr ({index.expr})"
         )
         await db.execute(f'''
-            administer concurrent_index_create("{index.id}")
+            administer concurrent_index_build("{index.id}")
         ''')
 
     return len(indexes)


### PR DESCRIPTION
The implementation in this PR works well and is solid, but there is plenty of room for us to argue about whether the interface is good enough.

The core idea, though, is to have an index field called `create_concurrently` that indicates that an index should be created concurrently, and then there will be a separate CLI command used to actually trigger and wait for the concurrent creation.

The crux of the complication here is that CREATE INDEX CONCURRENTLY cannot be run from inside a transaction or a pl/pgsql script, and so it can't be transactionally packaged with anything else, like updating our metadata.

The approach, then, is to have three separate components:
 * The actual DDL, generated by `migration create`, which will put the index
   into our schema but not actually create any indexes.
   The `create_concurrently` flag is exposed, as well as a new `active` flag
   that indicates whether the backing index actually exists.
 * `ADMINISTER concurrent_index_create(<uuid>)`, which takes the `id` of
    an index and runs `CREATE INDEX CONCURRENTLY IF NOT EXISTS` for it,
    and then sets `active := true` on the schema object (and populates postgres
    schema comments). 
    It does *not* do these things transactionally, though, so we could crash or
    shutdown after creating the index but before updating the schema. That's fine,
    though: once the command is run again, it will skip the CREATE INDEX then update
    metadata.

Fixes #8175

------

The big questions here are:
 * Is it acceptable to have create_concurrently as a schema flag?
   I chose that because users have a very schema-driven workflow,
   and the alternative seemed to be to force them to edit the migrations
   to add it.
 * Is outsourcing the state machine processing for actually creating
   the indexes to the CLI invoking ADMINISTER commands reasonable?
   It was quite straightforward to build.


I didn't try to make use of any of the `deferred` mechanism, because
that seems like it solving a different issue.
