### PR TITLE
Do better multiplicity inference in nested FOR expressions

### DIFF
--- a/tests/test_edgeql_ir_mult_inference.py
+++ b/tests/test_edgeql_ir_mult_inference.py
@@ -881,3 +881,23 @@ class TestEdgeQLMultiplicityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         UNIQUE
         """
+
+    def test_edgeql_ir_mult_inference_94(self):
+        """
+        FOR user IN User SELECT user {
+          name,
+          asdf := (FOR card IN .deck SELECT card),
+        }
+% OK %
+        UNIQUE
+        """
+
+    def test_edgeql_ir_mult_inference_95(self):
+        """
+        FOR user IN User SELECT user {
+          name,
+          asdf := (FOR card IN .deck SELECT Card filter Card = card),
+        }
+% OK %
+        UNIQUE
+        """


### PR DESCRIPTION
Currently we disable our `disjoint_union` tricks inside nested FOR
expressions (because we need to make sure expressions like
`for x in {1,2} union (for y in {3, 4} union y)`) are DUPLICATE.

This is unnecessarily strict, though, especially because if there is a
shape in between the two fors, whether the inner FOR loop is UNIQUE
can matter, like in:
```
FOR movie IN Movie SELECT movie {
  title,
  actors := (FOR person IN movie.actors SELECT person),
};
```

This is easy to fix by considering the inner iterator but making sure
disjoint_union doesn't leak.

Fixes #8748.