### PR TITLE
Add note about `init` and basic alias doc

### DIFF
--- a/docs/intro/localdev.rst
+++ b/docs/intro/localdev.rst
@@ -16,7 +16,7 @@ It's easy to get started with a local Gel instance. Navigate to the root of your
 
 .. code-block:: bash
 
-  $ gel init
+  $ gel project init
 
 This command takes care of several things for you:
 

--- a/docs/intro/localdev.rst
+++ b/docs/intro/localdev.rst
@@ -16,13 +16,9 @@ It's easy to get started with a local Gel instance. Navigate to the root of your
 
 .. code-block:: bash
 
-  $ gel project init
+  $ gel init
 
-This command takes care of several things for you:
-
-* It downloads and installs the latest version of the Gel server.
-* It configures a local Postgres cluster.
-* It manages the instance through your operating system's background task launcher.
+Creates a database tied to the current directory and to the :ref:`gel.toml <ref_reference_gel_toml>` file in it. This simplifies connection configuration and installation for you. Alias for :ref:`gel project init <ref_cli_gel_project_init>`.
 
 To conserve resources, Gel automatically puts inactive local development instances to sleep. This means you can have multiple instances running without them draining your system's resources when not in use.
 

--- a/docs/reference/using/cli/gel_init.rst
+++ b/docs/reference/using/cli/gel_init.rst
@@ -1,0 +1,11 @@
+.. _ref_cli_gel_init:
+
+========
+gel init
+========
+
+.. code-block:: bash
+
+  $ gel init
+
+This is an alias for :ref:`gel project init <ref_cli_gel_project_init>`, and takes all of the same arguments.

--- a/docs/reference/using/cli/index.rst
+++ b/docs/reference/using/cli/index.rst
@@ -127,6 +127,7 @@ The ``cli.toml`` has the following structure. All fields are optional:
     gel_connopts
     network
     gel
+    gel_init
     gel_project/index
     gel_ui
     gel_watch


### PR DESCRIPTION
~~`init` isn't yet documented or used consistently throughout the docs, so prefer the current command instead of the upcoming style.~~

Discussed internally and this is the change we decided was the best first step.