### PR TITLE
Implement `splat_strategy` qualifier for pointers

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_06_24_00_00
+EDGEDB_CATALOG_VERSION = 2025_06_26_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -995,7 +995,7 @@ def _raise_on_missing(
             if pn.name in next(iter(rewrites.by_type.values())):
                 continue
 
-        if ptrcls.is_property(ctx.env.schema):
+        if ptrcls.is_property():
             # If the target is a sequence, there's no need
             # for an explicit value.
             ptrcls_target = ptrcls.get_target(ctx.env.schema)
@@ -1809,7 +1809,7 @@ def _normalize_view_ptr_expr(
                 ]
 
                 ercls: type[errors.EdgeDBError]
-                if ptrcls.is_property(ctx.env.schema):
+                if ptrcls.is_property():
                     ercls = errors.InvalidPropertyTargetError
                 else:
                     ercls = errors.InvalidLinkTargetError

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -47,6 +47,7 @@ from edb.ir import typeutils
 from edb.ir import utils as irutils
 import edb.ir.typeutils as irtypeutils
 
+from edb.schema import futures as s_futures
 from edb.schema import links as s_links
 from edb.schema import name as sn
 from edb.schema import objtypes as s_objtypes
@@ -778,7 +779,13 @@ def _expand_splat(
             splat_strat == qltypes.SplatStrategy.Explicit
             or (
                 splat_strat == qltypes.SplatStrategy.Default
-                and ptr.get_linkful(ctx.env.schema)
+                and (
+                    ptr.get_linkful(ctx.env.schema)
+                    if s_futures.future_enabled(
+                        ctx.env.schema, 'no_linkful_computed_splats'
+                    )
+                    else isinstance(ptr, s_links.Link)
+                )
             )
         ):
             continue

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -775,8 +775,15 @@ def _expand_splat(
             continue
         if ptr.get_secret(ctx.env.schema):
             continue
-        # if ptr.get_lazy(ctx.env.schema):
-        #     continue
+        splat_strat = ptr.get_splat_strategy(ctx.env.schema)
+        if (
+            splat_strat == qltypes.SplatStrategy.Explicit
+            or (
+                splat_strat == qltypes.SplatStrategy.Default
+                and ptr.get_linkful(ctx.env.schema)
+            )
+        ):
+            continue
         sname = ptr.get_shortname(ctx.env.schema)
         # Skip any dunder properties; these are injected properties like
         # __tid__ and __tname__, and we want to manage injecting them
@@ -824,8 +831,9 @@ def _expand_splat(
                 continue
             if ptr.get_secret(ctx.env.schema):
                 continue
-            # if ptr.get_lazy(ctx.env.schema):
-            #     continue
+            splat_strat = ptr.get_splat_strategy(ctx.env.schema)
+            if splat_strat == qltypes.SplatStrategy.Explicit:
+                continue
             pn = ptr.get_shortname(ctx.env.schema)
             if (
                 (pn.name.startswith('__') and pn.name.endswith('__'))

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -773,8 +773,10 @@ def _expand_splat(
     for ptr in pointers.objects(ctx.env.schema):
         if not isinstance(ptr, s_props.Property):
             continue
-        if ptr.get_secret(ctx.env.schema) or ptr.get_lazy(ctx.env.schema):
+        if ptr.get_secret(ctx.env.schema):
             continue
+        # if ptr.get_lazy(ctx.env.schema):
+        #     continue
         sname = ptr.get_shortname(ctx.env.schema)
         # Skip any dunder properties; these are injected properties like
         # __tid__ and __tname__, and we want to manage injecting them
@@ -820,8 +822,10 @@ def _expand_splat(
         for ptr in pointers.objects(ctx.env.schema):
             if not isinstance(ptr, s_links.Link):
                 continue
-            if ptr.get_secret(ctx.env.schema) or ptr.get_lazy(ctx.env.schema):
+            if ptr.get_secret(ctx.env.schema):
                 continue
+            # if ptr.get_lazy(ctx.env.schema):
+            #     continue
             pn = ptr.get_shortname(ctx.env.schema)
             if (
                 (pn.name.startswith('__') and pn.name.endswith('__'))

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -773,7 +773,7 @@ def _expand_splat(
     for ptr in pointers.objects(ctx.env.schema):
         if not isinstance(ptr, s_props.Property):
             continue
-        if ptr.get_secret(ctx.env.schema):
+        if ptr.get_secret(ctx.env.schema) or ptr.get_lazy(ctx.env.schema):
             continue
         sname = ptr.get_shortname(ctx.env.schema)
         # Skip any dunder properties; these are injected properties like
@@ -819,6 +819,8 @@ def _expand_splat(
     if depth > 1:
         for ptr in pointers.objects(ctx.env.schema):
             if not isinstance(ptr, s_links.Link):
+                continue
+            if ptr.get_secret(ctx.env.schema) or ptr.get_lazy(ctx.env.schema):
                 continue
             pn = ptr.get_shortname(ctx.env.schema)
             if (

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -771,8 +771,6 @@ def _expand_splat(
     if intersection is not None:
         path.append(intersection)
     for ptr in pointers.objects(ctx.env.schema):
-        if not isinstance(ptr, s_props.Property):
-            continue
         if ptr.get_secret(ctx.env.schema):
             continue
         splat_strat = ptr.get_splat_strategy(ctx.env.schema)

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -649,7 +649,7 @@ def _trace_item_layout(
                     for pn, p in base_pointers.items(ctx.schema):
                         PointerType = (
                             qltracer.Property
-                            if p.is_property(ctx.schema) else
+                            if p.is_property() else
                             qltracer.Link
                         )
                         base_obj.pointers[pn] = PointerType(

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -259,6 +259,12 @@ class RewriteKind(s_enum.StrEnum):
     Insert = 'Insert'
 
 
+class SplatStrategy(s_enum.StrEnum):
+    Default = 'Default'
+    Explicit = 'Explicit'
+    Implicit = 'Implicit'
+
+
 class DescribeLanguage(s_enum.StrEnum):
     DDL = 'DDL'
     SDL = 'SDL'

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -590,3 +590,10 @@ def collect_schema_types(stmt: irast.Base) -> set[uuid.UUID]:
     visitor = CollectSchemaTypesVisitor()
     visitor.visit(stmt)
     return visitor.types
+
+
+def is_linkful(ir: irast.Base) -> bool:
+    def flt(p: irast.Pointer) -> bool:
+        return typeutils.is_object(p.typeref)
+
+    return bool(ast.find_children(ir, irast.Pointer, flt, terminate_early=True))

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -298,6 +298,7 @@ CREATE ABSTRACT TYPE schema::Pointer
     CREATE PROPERTY default -> std::str;
     CREATE PROPERTY expr -> std::str;
     CREATE PROPERTY secret -> std::bool;
+    CREATE PROPERTY lazy -> std::bool;
 };
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -67,6 +67,9 @@ CREATE SCALAR TYPE schema::MigrationGeneratedBy
 CREATE SCALAR TYPE schema::IndexDeferrability
     EXTENDING enum<Prohibited, Permitted, `Required`>;
 
+CREATE SCALAR TYPE schema::SplatStrategy
+    EXTENDING enum<Default, Explicit, Implicit>;
+
 # Base type for all schema entities.
 CREATE ABSTRACT TYPE schema::Object EXTENDING std::BaseObject {
     CREATE REQUIRED PROPERTY name -> std::str;
@@ -298,7 +301,8 @@ CREATE ABSTRACT TYPE schema::Pointer
     CREATE PROPERTY default -> std::str;
     CREATE PROPERTY expr -> std::str;
     CREATE PROPERTY secret -> std::bool;
-    CREATE PROPERTY lazy -> std::bool;
+    CREATE PROPERTY splat_strategy -> schema::SplatStrategy;
+    CREATE PROPERTY linkful -> std::bool;
 };
 
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4984,7 +4984,7 @@ class LinkMetaCommand(PointerMetaCommand[s_links.Link]):
                 table_name=new_table_name,
                 columns=[src_col, tgt_col]))
 
-        if not link.is_non_concrete(schema) and link.scalar():
+        if not link.is_non_concrete(schema) and link.is_property():
             tgt_prop = link.getptr(schema, sn.UnqualName('target'))
             tgt_ptr = types.get_pointer_storage_info(
                 tgt_prop, schema=schema)

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4043,7 +4043,7 @@ class PointerMetaCommand(
         is_lprop = ptr.is_link_property(schema)
         is_multi = ptr_table and not is_lprop
         is_required = ptr.get_required(schema)
-        is_scalar = ptr.is_property(schema)
+        is_scalar = ptr.is_property()
 
         ref_ctx = self.get_referrer_context_or_die(context)
         ref_op = ref_ctx.op

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -133,12 +133,6 @@ class Link(
     def is_link_property(self, schema: s_schema.Schema) -> bool:
         return False
 
-    def is_property(self, schema: s_schema.Schema) -> bool:
-        return False
-
-    def scalar(self) -> bool:
-        return False
-
     def has_user_defined_properties(self, schema: s_schema.Schema) -> bool:
         return bool([p for p in self.get_pointers(schema).objects(schema)
                      if not p.is_special_pointer(schema)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -52,6 +52,7 @@ from . import constraints
 from . import delta as sd
 from . import expr as s_expr
 from . import expraliases as s_expraliases
+from . import futures as s_futures
 from . import inheriting
 from . import name as sn
 from . import objects as so
@@ -3310,3 +3311,15 @@ def get_or_create_intersection_pointer(
         )
 
     return schema, result
+
+
+@s_futures.register_handler('no_linkful_computed_splats')
+def toggle_no_linkful_computed_splats(
+    cmd: s_futures.FutureBehaviorCommand,
+    schema: s_schema.Schema,
+    context: sd.CommandContext,
+    on: bool,
+) -> tuple[s_schema.Schema, sd.Command]:
+    # Nothing to do because splats can't appear in functions
+    group = sd.CommandGroup()
+    return schema, group

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -811,7 +811,7 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         } and (self.is_id_pointer(schema) or self.is_endpoint_pointer(schema))
 
     @classmethod
-    def is_property(cls, schema: Optional[s_schema.Schema]=None) -> bool:
+    def is_property(cls) -> bool:
         # Property overloads
         return False
 
@@ -1860,7 +1860,7 @@ class PointerCommand(
                 s_pointer = schema.get_by_id(pointer.ptrref.id, type=Pointer)
                 card = s_pointer.get_cardinality(schema)
 
-                if s_pointer.is_property(schema) and card.is_multi():
+                if s_pointer.is_property() and card.is_multi():
                     raise errors.SchemaDefinitionError(
                         f"default expression cannot refer to multi properties "
                         "of inserted object",
@@ -1868,7 +1868,7 @@ class PointerCommand(
                         hint="this is a temporary implementation restriction",
                     )
 
-                if not s_pointer.is_property(schema):
+                if not s_pointer.is_property():
                     raise errors.SchemaDefinitionError(
                         f"default expression cannot refer to links "
                         "of inserted object",
@@ -2589,7 +2589,7 @@ class SetPointerType(
                 action=self.get_friendly_description(schema=schema),
             )
 
-            if orig_target is not None and scls.is_property(schema):
+            if orig_target is not None and scls.is_property():
                 if cleanup_op := orig_target.as_type_delete_if_unused(schema):
                     parent_op = self.get_parent_op(context)
                     parent_op.add_caused(cleanup_op)

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -187,25 +187,25 @@ def merge_readonly(
     return current
 
 
-def merge_lazy(
-    ptr: Pointer,
-    bases: list[Pointer],
-    field_name: str,
-    *,
-    ignore_local: bool = False,
-    schema: s_schema.Schema,
-) -> Optional[bool]:
-    """Merge function for pointer laziness."""
+# def merge_lazy(
+#     ptr: Pointer,
+#     bases: list[Pointer],
+#     field_name: str,
+#     *,
+#     ignore_local: bool = False,
+#     schema: s_schema.Schema,
+# ) -> Optional[bool]:
+#     """Merge function for pointer laziness."""
 
-    return utils.merge_reduce(
-        ptr,
-        bases,
-        field_name=field_name,
-        ignore_local=ignore_local,
-        schema=schema,
-        f=operator.and_,
-        type=bool,
-    )
+#     return utils.merge_reduce(
+#         ptr,
+#         bases,
+#         field_name=field_name,
+#         ignore_local=ignore_local,
+#         schema=schema,
+#         f=operator.and_,
+#         type=bool,
+#     )
 
 
 def merge_required(
@@ -480,15 +480,16 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         merge_fn=merge_readonly,
     )
 
-    lazy = so.SchemaField(
-        bool,
+    splat_strategy = so.SchemaField(
+        qltypes.SplatStrategy,
         allow_ddl_set=True,
         describe_visibility=(
             so.DescribeVisibilityPolicy.SHOW_IF_EXPLICIT_OR_DERIVED_NOT_DEFAULT
         ),
+        coerce=True,
         default=False,
         compcoef=0.909,
-        merge_fn=merge_lazy,
+        # merge_fn=merge_splat,
     )
 
     secret = so.SchemaField(
@@ -501,6 +502,12 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         bool,
         default=False,
         compcoef=0.909,
+    )
+
+    linkful = so.SchemaField(
+        bool,
+        default=False,
+        compcoef=0.99,
     )
 
     # For non-derived pointers this is strongly correlated with

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -187,6 +187,27 @@ def merge_readonly(
     return current
 
 
+def merge_lazy(
+    ptr: Pointer,
+    bases: list[Pointer],
+    field_name: str,
+    *,
+    ignore_local: bool = False,
+    schema: s_schema.Schema,
+) -> Optional[bool]:
+    """Merge function for pointer laziness."""
+
+    return utils.merge_reduce(
+        ptr,
+        bases,
+        field_name=field_name,
+        ignore_local=ignore_local,
+        schema=schema,
+        f=operator.and_,
+        type=bool,
+    )
+
+
 def merge_required(
     ptr: Pointer,
     bases: list[Pointer],
@@ -457,6 +478,17 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         default=False,
         compcoef=0.909,
         merge_fn=merge_readonly,
+    )
+
+    lazy = so.SchemaField(
+        bool,
+        allow_ddl_set=True,
+        describe_visibility=(
+            so.DescribeVisibilityPolicy.SHOW_IF_EXPLICIT_OR_DERIVED_NOT_DEFAULT
+        ),
+        default=False,
+        compcoef=0.909,
+        merge_fn=merge_lazy,
     )
 
     secret = so.SchemaField(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -187,27 +187,6 @@ def merge_readonly(
     return current
 
 
-# def merge_lazy(
-#     ptr: Pointer,
-#     bases: list[Pointer],
-#     field_name: str,
-#     *,
-#     ignore_local: bool = False,
-#     schema: s_schema.Schema,
-# ) -> Optional[bool]:
-#     """Merge function for pointer laziness."""
-
-#     return utils.merge_reduce(
-#         ptr,
-#         bases,
-#         field_name=field_name,
-#         ignore_local=ignore_local,
-#         schema=schema,
-#         f=operator.and_,
-#         type=bool,
-#     )
-
-
 def merge_required(
     ptr: Pointer,
     bases: list[Pointer],
@@ -489,7 +468,6 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         coerce=True,
         default=qltypes.SplatStrategy.Default,
         compcoef=0.909,
-        # merge_fn=merge_splat,
     )
 
     secret = so.SchemaField(

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -128,10 +128,8 @@ class Property(
         # because we create new properties with distinct types.
         return not self.is_endpoint_pointer(schema)
 
-    def is_property(self, schema: s_schema.Schema) -> bool:
-        return True
-
-    def scalar(self) -> bool:
+    @classmethod
+    def is_property(cls, schema: Optional[s_schema.Schema]=None) -> bool:
         return True
 
     def has_user_defined_properties(self, schema: s_schema.Schema) -> bool:

--- a/edb/server/compiler/ddl.py
+++ b/edb/server/compiler/ddl.py
@@ -1590,7 +1590,7 @@ def administer_reindex(
         })
 
         # For links, collect any single link indexes and any link table indexes
-        if not ptrcls.is_property(schema):
+        if not ptrcls.is_property():
             ptrclses = {ptrcls} | {
                 desc for desc in ptrcls.descendants(schema)
                 if isinstance(
@@ -1714,7 +1714,7 @@ def _identify_administer_tables_and_cols(
                 card.is_multi() or ptrcls.has_user_defined_properties(schema)
             ):
                 vn = ptrcls.get_verbosename(schema, with_parent=True)
-                if ptrcls.is_property(schema):
+                if ptrcls.is_property():
                     raise errors.QueryError(
                         f'{vn} is not a valid argument to vacuum() '
                         f'because it is not a multi property',

--- a/edb/server/compiler/sertypes.py
+++ b/edb/server/compiler/sertypes.py
@@ -549,7 +549,7 @@ def _describe_object_shape(
         subtypes.append(subtype_id)
         element_names.append(name)
         link_props.append(False)
-        links.append(not ptr.is_property(ctx.schema))
+        links.append(not ptr.is_property())
         cardinalities.append(cardinality_from_ptr(ptr, ctx.schema))
         ctx.schema, material_ptr = ptr.material_type(ctx.schema)
         ptr_source = material_ptr.get_source(ctx.schema)

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -85,6 +85,10 @@ type Issue extending Named, Owned, Text {
     priority: Priority;
 
     optional multi watchers: User;
+    num_watchers {
+      using (count(.watchers));
+      lazy := true;
+    }
 
     optional time_estimate: int64;
 
@@ -97,13 +101,17 @@ type Issue extending Named, Owned, Text {
     }
     due_date: datetime;
 
-    multi related_to: Issue;
+    multi related_to: Issue {
+        lazy := true;
+    }
 
     multi references: File | URL | Publication {
         list_order: int64;
     };
 
-    tags: array<str>;
+    tags: array<str> {
+        lazy := true;
+    }
 
     index fts::index on ((
         fts::with_options(.name, language := fts::Language.eng),

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -87,7 +87,6 @@ type Issue extending Named, Owned, Text {
     optional multi watchers: User;
     num_watchers {
       using (count(.watchers));
-      lazy := true;
     }
 
     optional time_estimate: int64;
@@ -102,7 +101,7 @@ type Issue extending Named, Owned, Text {
     due_date: datetime;
 
     multi related_to: Issue {
-        lazy := true;
+        splat_strategy := 'Explicit';
     }
 
     multi references: File | URL | Publication {
@@ -110,7 +109,7 @@ type Issue extending Named, Owned, Text {
     };
 
     tags: array<str> {
-        lazy := true;
+        splat_strategy := 'Explicit';
     }
 
     index fts::index on ((

--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -82,7 +82,9 @@ type Issue extending Named, Owned, Text {
     }
     required status: Status;
 
-    priority: Priority;
+    priority: Priority {
+      splat_strategy := 'Implicit';
+    }
 
     optional multi watchers: User;
     num_watchers {

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -3436,6 +3436,29 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
             }],
         )
 
+    async def test_edgeql_migration_computed_07(self):
+        await self.migrate(r'''
+            type T;
+            type S {
+                multi ts: T;
+                val := count(.ts);
+            };
+        ''', module='default')
+        await self.migrate(r'''
+            type T;
+            type S {
+                multi ts: T;
+                val := 0;
+            };
+        ''', module='default')
+        await self.migrate(r'''
+            type T;
+            type S {
+                multi ts: T;
+                val := count(.ts);
+            };
+        ''', module='default')
+
     async def test_edgeql_migration_reject_prop_01(self):
         await self.migrate('''
             type User {

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -17,6 +17,7 @@
 #
 
 
+import json
 import os.path
 
 import edgedb
@@ -1890,7 +1891,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 "due_date": None,
                 "number": None,
                 "start_date": None,
-                "tags": None,
                 "time_estimate": None,
             },
             {
@@ -1900,7 +1900,6 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 "due_date": None,
                 "number": "1",
                 "start_date": str,
-                "tags": None,
                 "time_estimate": 3000,
             },
         ]
@@ -1992,6 +1991,20 @@ class TestEdgeQLSelect(tb.QueryTestCase):
                 {'x': {'a': 1, '@a': 2}}
             ]),
         )
+
+    async def test_edgeql_select_splat_07(self):
+        res = json.loads(await self.con.query_json(
+            r'''
+            select Issue {
+                **,
+            }
+            filter .number = "1"
+            '''
+        ))
+        # Make sure the lazy properties aren't included
+        self.assertNotIn('tags', res[0])
+        self.assertNotIn('related_to', res[0])
+        self.assertNotIn('num_watchers', res[0])
 
     async def test_edgeql_select_id_01(self):
         # allow assigning id to a computed (#4781)

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -1753,14 +1753,15 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             select Issue { * }
             filter .number = "1"
             ''',
-            tb.bag([
+            [
                 {
                     "number": "1",
                     "name": "Release EdgeDB",
                     "body": "Initial public release of EdgeDB.",
                     "time_estimate": 3000,
+                    "priority": None,
                 },
-            ]),
+            ],
         )
 
     async def test_edgeql_select_splat_02(self):

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2005,6 +2005,24 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         # Make sure the explicit properties aren't included
         self.assertNotIn('tags', res[0])
         self.assertNotIn('related_to', res[0])
+        # num_watchers should be included, without the future!
+        self.assertIn('num_watchers', res[0])
+
+        await self.con.execute('''
+            create future no_linkful_computed_splats
+        ''')
+
+        res = json.loads(await self.con.query_json(
+            r'''
+            select Issue {
+                **,
+            }
+            filter .number = "1"
+            '''
+        ))
+        # With the future, none should exist
+        self.assertNotIn('tags', res[0])
+        self.assertNotIn('related_to', res[0])
         self.assertNotIn('num_watchers', res[0])
 
     async def test_edgeql_select_id_01(self):

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -2002,7 +2002,7 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             filter .number = "1"
             '''
         ))
-        # Make sure the lazy properties aren't included
+        # Make sure the explicit properties aren't included
         self.assertNotIn('tags', res[0])
         self.assertNotIn('related_to', res[0])
         self.assertNotIn('num_watchers', res[0])


### PR DESCRIPTION
Basically implement Yury's proposal.

I haven't added a future yet, though, so this changes splat behavior in a backward incompatible way.
We can add a future if we want.

Fixes #8601.