### PR TITLE
Fix "Tests with reflection validation" CI

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -16,29 +16,5 @@ all: workflows/nightly.yml \
 	workflows/tests-inplace.yml \
 	workflows/tests-reflection.yml \
 
-workflows/%.yml: workflows.src/%.tpl.yml workflows.src/%.targets.yml workflows.src/build.inc.yml workflows.src/ls-build.inc.yml
+workflows/%.yml: workflows.src/%.tpl.yml workflows.src/%.targets.yml workflows.src/build.inc.yml workflows.src/tests.inc.yml workflows.src/ls-build.inc.yml
 	$(ROOT)/workflows.src/render.py $* $*.targets.yml
-
-workflows.src/tests.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests.tpl.yml
-
-workflows.src/tests-pool.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests-pool.tpl.yml
-
-workflows.src/tests-managed-pg.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests-managed-pg.tpl.yml
-
-workflows.src/tests-ha.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests-ha.tpl.yml
-
-workflows.src/tests-pg-versions.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests-pg-versions.tpl.yml
-
-workflows.src/tests-patches.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests-patches.tpl.yml
-
-workflows.src/tests-inplace.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests-inplace.tpl.yml
-
-workflows.src/tests-reflection.tpl.yml: workflows.src/tests.inc.yml
-	touch $(ROOT)/workflows.src/tests-inplace.tpl.yml

--- a/.github/workflows/tests-reflection.yml
+++ b/.github/workflows/tests-reflection.yml
@@ -66,6 +66,8 @@ jobs:
       run: |
         python -c "import sys; print(sys.prefix)"
         python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
+        # 80.9.0 breaks our sphinx, and it keeps sneaking in
+        uv pip install setuptools==80.8.0
 
     - name: Compute cache keys
       env:
@@ -345,7 +347,10 @@ jobs:
         key: edb-requirements-${{ hashFiles('pyproject.toml') }}
 
     - name: Install Python dependencies
-      run: python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
+      run: |
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
+        # 80.9.0 breaks our sphinx, and it keeps sneaking in
+        uv pip install setuptools==80.8.0
 
     # Restore the artifacts and environment variables
 


### PR DESCRIPTION
When regenerating the workflows in #8742, one of them got missed by the
Makefile.

I don't 100% understand why, but the Makefile was handling
dependencies on tests.inc.yml in a dodgy way (by triggering a touch of
another source file). Simplify that, and it worked.