### PR TITLE
Allow (most) unparenthesized statements in calls, etc

### DIFF
--- a/edb/edgeql/parser/grammar/ddl.py
+++ b/edb/edgeql/parser/grammar/ddl.py
@@ -513,7 +513,7 @@ class UsingStmt(Nonterm):
 
 class SetFieldStmt(Nonterm):
     # field := <expr>
-    def reduce_SET_Identifier_ASSIGN_Expr(self, *kids):
+    def reduce_SET_Identifier_ASSIGN_GenExpr(self, *kids):
         self.val = qlast.SetField(
             name=kids[1].val.lower(),
             value=kids[3].val,
@@ -536,7 +536,7 @@ class ResetFieldStmt(Nonterm):
 
 
 class CreateAnnotationValueStmt(Nonterm):
-    def reduce_CREATE_ANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
+    def reduce_CREATE_ANNOTATION_NodeName_ASSIGN_GenExpr(self, *kids):
         self.val = qlast.CreateAnnotationValue(
             name=kids[2].val,
             value=kids[4].val,
@@ -544,7 +544,7 @@ class CreateAnnotationValueStmt(Nonterm):
 
 
 class AlterAnnotationValueStmt(Nonterm):
-    def reduce_ALTER_ANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
+    def reduce_ALTER_ANNOTATION_NodeName_ASSIGN_GenExpr(self, *kids):
         self.val = qlast.AlterAnnotationValue(
             name=kids[2].val,
             value=kids[4].val,
@@ -2041,7 +2041,7 @@ class CreateConcretePropertyStmt(Nonterm):
 
     def reduce_CreateComputableProperty(self, *kids):
         """%reduce
-            CREATE OptPtrQuals PROPERTY UnqualifiedPointerName ASSIGN Expr
+            CREATE OptPtrQuals PROPERTY UnqualifiedPointerName ASSIGN GenExpr
         """
         self.val = qlast.CreateConcreteProperty(
             name=kids[3].val,
@@ -2382,7 +2382,7 @@ class CreateConcreteLinkStmt(Nonterm):
 
     def reduce_CreateComputableLink(self, *kids):
         """%reduce
-            CREATE OptPtrQuals LINK UnqualifiedPointerName ASSIGN Expr
+            CREATE OptPtrQuals LINK UnqualifiedPointerName ASSIGN GenExpr
         """
         self.val = qlast.CreateConcreteLink(
             name=kids[3].val,
@@ -2816,7 +2816,7 @@ commands_block(
 class CreateAliasStmt(Nonterm):
     def reduce_CreateAliasShortStmt(self, *kids):
         r"""%reduce
-            CREATE ALIAS NodeName ASSIGN Expr
+            CREATE ALIAS NodeName ASSIGN GenExpr
         """
         self.val = qlast.CreateAlias(
             name=kids[2].val,
@@ -3518,7 +3518,7 @@ class CreateGlobalStmt(Nonterm):
 
     def reduce_CreateComputableGlobal(self, *kids):
         """%reduce
-            CREATE OptPtrQuals GLOBAL NodeName ASSIGN Expr
+            CREATE OptPtrQuals GLOBAL NodeName ASSIGN GenExpr
         """
         self.val = qlast.CreateGlobal(
             name=kids[3].val,

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -945,7 +945,7 @@ class OptPtrQuals(Nonterm):
 # by a keyword).
 class ComputableShapePointer(Nonterm):
 
-    def reduce_OPTIONAL_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_OPTIONAL_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.required = False
@@ -954,7 +954,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_REQUIRED_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_REQUIRED_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.required = True
@@ -963,7 +963,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_MULTI_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.cardinality = qltypes.SchemaCardinality.Many
@@ -972,7 +972,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_SINGLE_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.cardinality = qltypes.SchemaCardinality.One
@@ -981,7 +981,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_OPTIONAL_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_OPTIONAL_MULTI_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = False
@@ -991,7 +991,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_OPTIONAL_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_OPTIONAL_SINGLE_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = False
@@ -1001,7 +1001,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_REQUIRED_MULTI_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_REQUIRED_MULTI_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = True
@@ -1011,7 +1011,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_REQUIRED_SINGLE_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_REQUIRED_SINGLE_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = True
@@ -1021,7 +1021,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_SimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_SimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[0].val
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(
@@ -1029,7 +1029,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[1].span),
         )
 
-    def reduce_SimpleShapePointer_ADDASSIGN_Expr(self, *kids):
+    def reduce_SimpleShapePointer_ADDASSIGN_GenExpr(self, *kids):
         self.val = kids[0].val
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(
@@ -1037,7 +1037,7 @@ class ComputableShapePointer(Nonterm):
             span=assert_non_null(kids[1].span),
         )
 
-    def reduce_SimpleShapePointer_REMASSIGN_Expr(self, *kids):
+    def reduce_SimpleShapePointer_REMASSIGN_GenExpr(self, *kids):
         self.val = kids[0].val
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(
@@ -1049,7 +1049,7 @@ class ComputableShapePointer(Nonterm):
 # This is the same as the above ComputableShapePointer, except using
 # FreeSimpleShapePointer and not allowing +=/-=.
 class FreeComputableShapePointer(Nonterm):
-    def reduce_OPTIONAL_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_OPTIONAL_FreeSimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.required = False
@@ -1058,7 +1058,7 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_REQUIRED_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_REQUIRED_FreeSimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.required = True
@@ -1067,7 +1067,7 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_MULTI_FreeSimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.cardinality = qltypes.SchemaCardinality.Many
@@ -1076,7 +1076,7 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_SINGLE_FreeSimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[1].val
         self.val.compexpr = kids[3].val
         self.val.cardinality = qltypes.SchemaCardinality.One
@@ -1085,7 +1085,9 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[2].span),
         )
 
-    def reduce_OPTIONAL_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_OPTIONAL_MULTI_FreeSimpleShapePointer_ASSIGN_GenExpr(
+        self, *kids
+    ):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = False
@@ -1095,7 +1097,9 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_OPTIONAL_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_OPTIONAL_SINGLE_FreeSimpleShapePointer_ASSIGN_GenExpr(
+        self, *kids
+    ):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = False
@@ -1105,7 +1109,9 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_REQUIRED_MULTI_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_REQUIRED_MULTI_FreeSimpleShapePointer_ASSIGN_GenExpr(
+        self, *kids
+    ):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = True
@@ -1115,7 +1121,9 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_REQUIRED_SINGLE_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_REQUIRED_SINGLE_FreeSimpleShapePointer_ASSIGN_GenExpr(
+        self, *kids
+    ):
         self.val = kids[2].val
         self.val.compexpr = kids[4].val
         self.val.required = True
@@ -1125,7 +1133,7 @@ class FreeComputableShapePointer(Nonterm):
             span=assert_non_null(kids[3].span),
         )
 
-    def reduce_FreeSimpleShapePointer_ASSIGN_Expr(self, *kids):
+    def reduce_FreeSimpleShapePointer_ASSIGN_GenExpr(self, *kids):
         self.val = kids[0].val
         self.val.compexpr = kids[2].val
         self.val.operation = qlast.ShapeOperation(

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -513,6 +513,9 @@ class AliasDecl(Nonterm):
     def reduce_AliasedExpr(self, *kids):
         pass
 
+    def reduce_Identifier_ASSIGN_ExprStmtSimple(self, *kids):
+        self.val = qlast.AliasedExpr(alias=kids[0].val, expr=kids[2].val)
+
 
 class WithDecl(Nonterm):
     @parsing.inline(0)

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -136,6 +136,22 @@ class ExprStmtAnnoyingCore(Nonterm):
         pass
 
 
+# A "generalized expression" that can be either an expression or
+# *most* unparenthesized statements.
+#
+# (Note that a number of places that are *approximately* using this
+# instead need to spell it out more explicitly because it doesn't
+# exactly fit.)
+class GenExpr(Nonterm):
+    @parsing.inline(0)
+    def reduce_Expr(self, *kids):
+        pass
+
+    @parsing.inline(0)
+    def reduce_ExprStmtSimpleCore(self, *kids):
+        pass
+
+
 class AliasedExpr(Nonterm):
     val: qlast.AliasedExpr
 
@@ -1650,7 +1666,7 @@ class CompareOp(Nonterm):
 
 
 class Tuple(Nonterm):
-    def reduce_LPAREN_Expr_COMMA_OptExprList_RPAREN(self, *kids):
+    def reduce_LPAREN_GenExpr_COMMA_OptExprList_RPAREN(self, *kids):
         self.val = qlast.Tuple(elements=[kids[1].val] + kids[3].val)
 
     def reduce_LPAREN_RPAREN(self, *kids):
@@ -1663,7 +1679,7 @@ class NamedTuple(Nonterm):
 
 
 class NamedTupleElement(Nonterm):
-    def reduce_ShortNodeName_ASSIGN_Expr(self, *kids):
+    def reduce_ShortNodeName_ASSIGN_GenExpr(self, *kids):
         self.val = qlast.TupleElement(
             name=qlast.Ptr(name=kids[0].val.name, span=kids[0].span),
             val=kids[2].val
@@ -1696,7 +1712,7 @@ class OptExprList(Nonterm):
         self.val = []
 
 
-class ExprList(ListNonterm, element=Expr, separator=tokens.T_COMMA,
+class ExprList(ListNonterm, element=GenExpr, separator=tokens.T_COMMA,
                allow_trailing_separator=True):
     pass
 

--- a/edb/edgeql/parser/grammar/sdl.py
+++ b/edb/edgeql/parser/grammar/sdl.py
@@ -303,13 +303,13 @@ class Using(Nonterm):
 
 class SetField(Nonterm):
     # field := <expr>
-    def reduce_Identifier_ASSIGN_Expr(self, *kids):
+    def reduce_Identifier_ASSIGN_GenExpr(self, *kids):
         identifier, _, expr = kids
         self.val = qlast.SetField(name=identifier.val, value=expr.val)
 
 
 class SetAnnotation(Nonterm):
-    def reduce_ANNOTATION_NodeName_ASSIGN_Expr(self, *kids):
+    def reduce_ANNOTATION_NodeName_ASSIGN_GenExpr(self, *kids):
         _, name, _, expr = kids
         self.val = qlast.CreateAnnotationValue(name=name.val, value=expr.val)
 
@@ -1064,7 +1064,7 @@ class ConcreteUnknownPointerShort(Nonterm):
 class ConcreteUnknownPointerObjectShort(Nonterm):
     def reduce_CreateComputableUnknownPointer(self, *kids):
         """%reduce
-            PathNodeName ASSIGN Expr
+            PathNodeName ASSIGN GenExpr
         """
         name, _, expr = kids
         self.val = qlast.CreateConcreteUnknownPointer(
@@ -1074,7 +1074,7 @@ class ConcreteUnknownPointerObjectShort(Nonterm):
 
     def reduce_CreateQualifiedComputableUnknownPointer(self, *kids):
         """%reduce
-            PtrQuals PathNodeName ASSIGN Expr
+            PtrQuals PathNodeName ASSIGN GenExpr
         """
         quals, name, _, expr = kids
         self.val = qlast.CreateConcreteUnknownPointer(
@@ -1294,7 +1294,7 @@ class ConcretePropertyShort(Nonterm):
 
     def reduce_CreateComputableProperty(self, *kids):
         """%reduce
-            PROPERTY PathNodeName ASSIGN Expr
+            PROPERTY PathNodeName ASSIGN GenExpr
         """
         _, name, _, expr = kids
         self.val = qlast.CreateConcreteProperty(
@@ -1304,7 +1304,7 @@ class ConcretePropertyShort(Nonterm):
 
     def reduce_CreateQualifiedComputableProperty(self, *kids):
         """%reduce
-            PtrQuals PROPERTY PathNodeName ASSIGN Expr
+            PtrQuals PROPERTY PathNodeName ASSIGN GenExpr
         """
         quals, _, name, _, expr = kids
         self.val = qlast.CreateConcreteProperty(
@@ -1556,7 +1556,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateComputableLink(self, *kids):
         """%reduce
-            LINK PathNodeName ASSIGN Expr
+            LINK PathNodeName ASSIGN GenExpr
         """
         _, name, _, expr = kids
         self.val = qlast.CreateConcreteLink(
@@ -1566,7 +1566,7 @@ class ConcreteLinkShort(Nonterm):
 
     def reduce_CreateQualifiedComputableLink(self, *kids):
         """%reduce
-            PtrQuals LINK PathNodeName ASSIGN Expr
+            PtrQuals LINK PathNodeName ASSIGN GenExpr
         """
         quals, _, name, _, expr = kids
         self.val = qlast.CreateConcreteLink(
@@ -1776,7 +1776,7 @@ class AliasDeclaration(Nonterm):
 class AliasDeclarationShort(Nonterm):
     def reduce_CreateAliasShortStmt(self, *kids):
         r"""%reduce
-            ALIAS NodeName ASSIGN Expr
+            ALIAS NodeName ASSIGN GenExpr
         """
         _, name, _, expr = kids
         self.val = qlast.CreateAlias(
@@ -1938,7 +1938,7 @@ class GlobalDeclarationShort(Nonterm):
 
     def reduce_CreateComputedGlobalShortQuals(self, *kids):
         """%reduce
-            PtrQuals GLOBAL NodeName ASSIGN Expr
+            PtrQuals GLOBAL NodeName ASSIGN GenExpr
         """
         quals, _, name, _, expr = kids
         self.val = qlast.CreateGlobal(
@@ -1950,7 +1950,7 @@ class GlobalDeclarationShort(Nonterm):
 
     def reduce_CreateComputedGlobalShort(self, *kids):
         """%reduce
-            GLOBAL NodeName ASSIGN Expr
+            GLOBAL NodeName ASSIGN GenExpr
         """
         _, name, _, expr = kids
         self.val = qlast.CreateGlobal(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -1834,6 +1834,36 @@ aa';
         };
         """
 
+    def test_edgeql_syntax_shape_73(self):
+        """
+        select Foo {
+            x := select Card { ** } filter .element = 'Air',
+            y := select User { ** } filter .name = 'Alice',
+        };
+
+% OK %
+
+        select Foo {
+            x := (select Card { ** } filter (.element = 'Air')),
+            y := (select User { ** } filter (.name = 'Alice')),
+        };
+        """
+
+    def test_edgeql_syntax_shape_74(self):
+        """
+        select {
+            x := select Card { ** } filter .element = 'Air',
+            y := select User { ** } filter .name = 'Alice',
+        };
+
+% OK %
+
+        select {
+            x := (select Card { ** } filter (.element = 'Air')),
+            y := (select User { ** } filter (.name = 'Alice')),
+        };
+        """
+
     def test_edgeql_syntax_shape_splat_01(self):
         """
         select Foo {

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2823,8 +2823,10 @@ aa';
         SELECT User.name OFFSET Foo.bar LIMIT (Foo.bar * 10);
         """
 
+    # @tb.must_fail(errors.EdgeQLSyntaxError,
+    #               r'Unexpected.+bar', hint=None, line=3, col=24)
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r'Unexpected.+bar', hint=None, line=3, col=24)
+                  r"Missing ','", hint=None, line=3, col=23)
     def test_edgeql_syntax_select_12(self):
         """
         SELECT (
@@ -3330,8 +3332,10 @@ aa';
         } UNLESS CONFLICT ELSE (SELECT Foo);
         """
 
+    # @tb.must_fail(errors.EdgeQLSyntaxError,
+    #               r'Unexpected.+bar', hint=None, line=3, col=24)
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r'Unexpected.+bar', hint=None, line=3, col=24)
+                  r"Missing ','", hint=None, line=3, col=23)
     def test_edgeql_syntax_insert_22(self):
         """
         SELECT (
@@ -3378,8 +3382,10 @@ aa';
         OFFSET 2 LIMIT 5;
         """
 
+    # @tb.must_fail(errors.EdgeQLSyntaxError,
+    #               r'Unexpected.+bar', hint=None, line=3, col=24)
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r'Unexpected.+bar', hint=None, line=3, col=24)
+                  r"Missing ','", hint=None, line=3, col=23)
     def test_edgeql_syntax_delete_06(self):
         """
         SELECT (
@@ -3511,8 +3517,10 @@ aa';
         SELECT x;
         """
 
+    # @tb.must_fail(errors.EdgeQLSyntaxError,
+    #               r'Unexpected.+bad', hint=None, line=3, col=56)
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  r'Unexpected.+bad', hint=None, line=3, col=56)
+                  r"Missing ','", hint=None, line=3, col=55)
     def test_edgeql_syntax_selectfor_04(self):
         """
         WITH x := (
@@ -4068,6 +4076,30 @@ aa';
 % OK %
 
         SELECT (1, 2);
+        """
+
+    def test_edgeql_syntax_tuple_18(self):
+        """
+        SELECT (select Foo, delete Foo, update Foo set { x := 1 },
+                for x in y select x);
+
+% OK %
+
+        SELECT ((select Foo), (delete Foo), (update Foo set { x := 1 }),
+                (for x in y select x));
+        """
+
+    def test_edgeql_syntax_tuple_19(self):
+        """
+        SELECT (x := select Foo, y := delete Foo,
+                z := update Foo set { x := 1 },
+                w := for x in y select x);
+
+% OK %
+
+        SELECT (x := (select Foo), y := (delete Foo),
+                z := (update Foo set { x := 1 }),
+                w := (for x in y select x));
         """
 
     def test_edgeql_syntax_introspect_01(self):

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -5670,12 +5670,22 @@ aa';
         """
         CREATE TYPE Foo {
             CREATE PROPERTY bar := 'something';
+            CREATE PROPERTY baz := select 'something';
+            CREATE LINK quux := select Foo;
+            CREATE PROPERTY foo: str {
+                set default := select 'lol'
+            };
         };
 
 % OK %
 
         CREATE TYPE Foo {
             CREATE PROPERTY bar := ('something');
+            CREATE PROPERTY baz := (select 'something');
+            CREATE LINK quux := (select Foo);
+            CREATE PROPERTY foo: str {
+                set default := (select 'lol');
+            };
         };
         """
 

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -2660,6 +2660,15 @@ aa';
         WITH a AS MODULE `__std__` SELECT Foo;
         """
 
+    def test_edgeql_syntax_with_13(self):
+        """
+        with x := select Card filter .element = 'Air' select x;
+
+% OK %
+
+        with x := (select Card filter (.element = 'Air')) select x;
+        """
+
     def test_edgeql_syntax_detached_01(self):
         """
         WITH F := DETACHED Foo

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -3769,68 +3769,75 @@ aa';
         SELECT baz(x := User.age y := User.name);
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=22)
     def test_edgeql_syntax_function_12(self):
         """
         SELECT count(SELECT 1);
+
+% OK %
+
+        SELECT count((SELECT 1));
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=22)
     def test_edgeql_syntax_function_13(self):
         """
         SELECT count(INSERT Foo);
+
+% OK %
+
+        SELECT count((INSERT Foo));
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=22)
     def test_edgeql_syntax_function_14(self):
         """
         SELECT count(UPDATE Foo SET {bar := 1});
+
+% OK %
+
+        SELECT count((UPDATE Foo SET {bar := 1}));
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=22)
     def test_edgeql_syntax_function_15(self):
         """
         SELECT count(DELETE Foo);
+
+% OK %
+
+        SELECT count((DELETE Foo));
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=22)
     def test_edgeql_syntax_function_16(self):
         """
         SELECT count(FOR X IN {Foo} UNION X);
+
+% OK %
+
+        SELECT count((FOR X IN {Foo} UNION X));
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=22)
     def test_edgeql_syntax_function_17(self):
         """
         SELECT count(WITH X := 1 SELECT Foo FILTER .bar = X);
+
+% OK %
+
+        SELECT count((WITH X := 1 SELECT Foo FILTER (.bar = X)));
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=23)
+                  "Missing ','",
+                  line=2, col=32)
     def test_edgeql_syntax_function_18(self):
         """
         SELECT (count(SELECT 1) 1);
         """
 
-    @tb.must_fail(errors.EdgeQLSyntaxError,
-                  "Missing parentheses around statement used as an expression",
-                  line=2, col=26)
     def test_edgeql_syntax_function_19(self):
         """
         SELECT ((((count(SELECT 1)))));
+
+% OK %
+
+        SELECT count((SELECT 1));
         """
 
     @tb.must_fail(errors.EdgeQLSyntaxError,

--- a/tests/test_schema_syntax.py
+++ b/tests/test_schema_syntax.py
@@ -706,6 +706,27 @@ class TestEdgeSchemaParser(SchemaSyntaxTest):
         };
         """
 
+    def test_eschema_syntax_type_37(self):
+        """
+        module default {
+            type Foo {
+                x1 := select Baz;
+                property x2 := select 5;
+                link x2 := select Baz;
+            };
+        };
+
+% OK %
+
+        module default {
+            type Foo {
+                x1 := (select Baz);
+                property x2 := (select 5);
+                link x2 := (select Baz);
+            };
+        };
+        """
+
     def test_eschema_syntax_link_target_type_01(self):
         """
         module test {


### PR DESCRIPTION
Allow (most) unparenthesized statements basically everywhere we have
comma-separated lists of expressions (or `ident := expr`):
 * Function calls
 * Set literals
 * Tuples and named tuples
 * Computed pointers in shapes
 * On the right-hand-side of basically every `:=` in SDL and DDL

Annoyingly (but unlikely to matter much in practice), it can't be
*all* unparenthesized statements, because the BY clause of GROUP
allows trailing commas (and thus FOR does as well).

To deal with this, we split ExprStmt into ExprStmtSimple and
ExprStmtAnnoying, where ExprStmtSimple contains everything but GROUP
and GROUP-containing FOR.

Fixes #8176.