### PR TITLE
Make patch system more capable of adding things to reflection schema

### DIFF
--- a/edb/pgsql/patches.py
+++ b/edb/pgsql/patches.py
@@ -22,7 +22,11 @@
 from __future__ import annotations
 
 
-def get_version_key(num_patches: int):
+def get_patch_level(num_patches: int) -> int:
+    return sum(p.startswith('edgeql+schema') for p, _ in PATCHES[:num_patches])
+
+
+def get_version_key(num_patches: int) -> str:
     """Produce a version key to add to instdata keys after major patches.
 
     Patches that modify the schema class layout and introspection queries
@@ -35,12 +39,11 @@ def get_version_key(num_patches: int):
     the key based on the number of schema layout patches that we can
     *see*, we still compute the right key.
     """
-    num_major = sum(
-        p.startswith('edgeql+schema') for p, _ in PATCHES[:num_patches])
-    if num_major == 0:
+    level = get_patch_level(num_patches)
+    if level == 0:
         return ''
     else:
-        return f'_v{num_major}'
+        return f'_v{level}'
 
 
 """
@@ -51,6 +54,9 @@ The current kinds are:
  * metaschema-sql - create a function from metaschema
  * edgeql - runs an edgeql DDL command
  * edgeql+schema - runs an edgeql DDL command and updates the std schemas
+ *                 NOTE: objects and fields added to the reflschema must
+ *                 have their patch_level set to the `get_patch_level` value
+ *                 for this patch.
  * edgeql+user_ext|<extname> - updates extensions installed in user databases
  *                           - should be paired with an ext-pkg patch
  * ...+config - updates config views

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -346,8 +346,10 @@ class Field(struct.ProtoField, Generic[T]):
     #: this specifies a (ProxyType, linkname) pair of a proxy object type
     #: and the name of the link within that proxy type.
     reflection_proxy: Optional[tuple[str, str]]
-    #: Which patch for the current major version this field was introduced in.
-    #: Ensures that the data tuples always get extended strictly at the end.
+    #: Which edgeql+schema patch for the current major version this
+    #: field was introduced in.  Ensures that the data tuples always
+    #: get extended strictly at the end and filters out the field when
+    #: applying earlier patches.
     patch_level: int
     #: Interpret any assigned object names as strings.
     obj_names_as_string: bool
@@ -658,6 +660,11 @@ class ObjectMeta(type):
     #: standpoint of persistent data.  In other words, changes to the
     #: object are fully reversible without possible data loss.
     _data_safe: bool
+    #: Which edgeql+schema patch for the current major version this
+    #: object was introduced in.  Ensures that the data tuples always
+    #: get extended strictly at the end and filters out the field when
+    #: applying earlier patches.
+    _patch_level: int
 
     #: Whether the type should be abstract in EdgeDB schema.
     #: This only applies if the type wasn't specified in schema.edgeql.
@@ -674,6 +681,7 @@ class ObjectMeta(type):
         reflection_link: Optional[str] = None,
         data_safe: bool = False,
         abstract: Optional[bool] = None,
+        patch_level: int = -1,
         **kwargs: Any,
     ) -> ObjectMeta:
         refdicts: collections.OrderedDict[str, RefDict]
@@ -732,6 +740,7 @@ class ObjectMeta(type):
 
         cls._data_safe = data_safe
         cls._abstract = abstract
+        cls._patch_level = patch_level
         cls._fields = fields
         cls._schema_fields = {
             fn: f

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -984,7 +984,9 @@ def prepare_patch(
         # in the public schema and to discover the new introspection
         # query.
         reflection = s_refl.generate_structure(
-            reflschema, make_funcs=False,
+            reflschema,
+            make_funcs=False,
+            patch_level=patches.get_patch_level(num),
         )
 
         reflschema, plan, tplan = _process_delta_params(

--- a/tests/patch-testing/upgrade.patch
+++ b/tests/patch-testing/upgrade.patch
@@ -187,10 +187,10 @@ index 3a9effaa5..145a472cd 100644
      pass
  
 diff --git a/edb/pgsql/patches.py b/edb/pgsql/patches.py
-index 9d63263a9..0a6f9eca6 100644
+index 12c627df8..df6773aeb 100644
 --- a/edb/pgsql/patches.py
 +++ b/edb/pgsql/patches.py
-@@ -60,4 +60,38 @@ The current kinds are:
+@@ -66,4 +66,41 @@ The current kinds are:
   * ...+testmode - only run the patch in testmode. Works with any patch kind.
  """
  PATCHES: list[tuple[str, str]] = [
@@ -204,13 +204,16 @@ index 9d63263a9..0a6f9eca6 100644
 +};
 +'''),
 +    ('edgeql+schema', '''
++# Empty edgeql+schema patch to make sure that non-initial
++# edgeql+schema patches can add things publically. (They didn't
++# use to be able to.)
++    '''),
++    ('edgeql+schema', '''
 +CREATE TYPE schema::Blobal EXTENDING schema::AnnotationSubject {
 +    CREATE PROPERTY required -> std::bool;
 +};
-+# ASDF! We can't apply these separately because it gets picked up from
-+# the present schema nonsense!
-+# The patch system is so janky.
-+# Worse, adding these publically only works in the *first* +schema patch.
++'''),
++    ('edgeql+schema', '''
 +ALTER TYPE schema::Function
 +{
 +    CREATE PROPERTY test_field_a -> std::str;
@@ -230,7 +233,7 @@ index 9d63263a9..0a6f9eca6 100644
 +    ('metaschema-sql', 'SysConfigFullFunction'),
  ]
 diff --git a/edb/schema/functions.py b/edb/schema/functions.py
-index 48baa30be..c903d58fc 100644
+index 48baa30be..a3c238a7c 100644
 --- a/edb/schema/functions.py
 +++ b/edb/schema/functions.py
 @@ -1252,6 +1252,31 @@ class Function(
@@ -243,7 +246,7 @@ index 48baa30be..c903d58fc 100644
 +        default=None,
 +        compcoef=0.4,
 +        allow_ddl_set=True,
-+        patch_level=1,
++        patch_level=2,
 +    )
 +
 +    test_field_b = so.SchemaField(
@@ -251,14 +254,14 @@ index 48baa30be..c903d58fc 100644
 +        default=None,
 +        compcoef=0.4,
 +        allow_ddl_set=True,
-+        patch_level=1,
++        patch_level=2,
 +    )
 +
 +    test_nativecode_size = so.SchemaField(
 +        int,
 +        default=None,
 +        compcoef=0.99,
-+        patch_level=1,
++        patch_level=2,
 +    )
 +    ##
 +
@@ -277,10 +280,10 @@ index 48baa30be..c903d58fc 100644
          # volatility, so force it to happen as part of
          # canonicalization of attributes.
 diff --git a/edb/schema/globals.py b/edb/schema/globals.py
-index 0bac4f113..9754274cd 100644
+index 0bac4f113..7ff961aa6 100644
 --- a/edb/schema/globals.py
 +++ b/edb/schema/globals.py
-@@ -637,3 +637,60 @@ class DeleteGlobal(
+@@ -637,3 +637,61 @@ class DeleteGlobal(
                  self.add_caused(op)
  
          return schema
@@ -291,6 +294,7 @@ index 0bac4f113..9754274cd 100644
 +    s_anno.AnnotationSubject,
 +    qlkind=qltypes.SchemaObjectClass.GLOBAL,
 +    data_safe=True,
++    patch_level=1,
 +):
 +
 +    required = so.SchemaField(


### PR DESCRIPTION
Currently new schema types and fields can only be added to the publicly
visible reflection schema in the *first* edgeql+schema patch applied.  This
is because the changes get *implicitly* picked up by
`reflection.structure.generate_structure` when running the first
edgeql+schema patch, and so already exist when a later patch tries to add
them *explicitly*.

Fix this by using the patch_level attr of fields and a new patch_level attr
of ObjectMeta to filter out fields/types belong to later patches.

I don't think this is needed imminently, though if we want to push
something like `load_strategy` to 6.x (see #8757), we would need it.

I think this is safe to backport to 6.x without trouble, since we
don't use patch_level there at all yet.