### PR TITLE
Drop the spaces after field names in Tuple names

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_06_04_00_00
+EDGEDB_CATALOG_VERSION = 2025_06_05_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1649,7 +1649,7 @@ class Tuple(
     ) -> s_name.UnqualName:
         if named:
             st_names = ', '.join(
-                f'{n}:{st}' for n, st in element_names.items()
+                f'{n}: {st}' for n, st in element_names.items()
             )
         else:
             st_names = ', '.join(str(st) for st in element_names.values())

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -7869,7 +7869,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Create computed global
         # Delete computed global
 
-        # tuple<f:int64>
+        # tuple<f: int64>
         await self._check_ddl_global_type_changes([
             (
                 'create global foo := (f := 1)',
@@ -7880,7 +7880,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         'type_name': 'schema::TupleExprAlias',
                     },
                     {
-                        'name': 'tuple<f:std::int64>',
+                        'name': 'tuple<f: std::int64>',
                         'from_alias': False,
                         'type_name': 'schema::Tuple',
                     },
@@ -7922,13 +7922,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Create computed global
         # Delete computed global
 
-        # array<tuple<f:array<int64>>>
+        # array<tuple<f: array<int64>>>
         await self._check_ddl_global_type_changes([
             (
                 'create global foo := [(f := [1])]',
                 [
                     {
-                        'name': 'array<tuple<f:array<std::int64>>>',
+                        'name': 'array<tuple<f: array<std::int64>>>',
                         'from_alias': False,
                         'type_name': 'schema::Array',
                     },
@@ -7938,7 +7938,7 @@ class TestEdgeQLDDL(tb.DDLTestCase):
                         'type_name': 'schema::ArrayExprAlias',
                     },
                     {
-                        'name': 'tuple<f:array<std::int64>>',
+                        'name': 'tuple<f: array<std::int64>>',
                         'from_alias': False,
                         'type_name': 'schema::Tuple',
                     },
@@ -8020,13 +8020,13 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Create non-computed global
         # Delete non-computed global
 
-        # tuple<f:int64>
+        # tuple<f: int64>
         await self._check_ddl_global_type_changes([
             (
-                'create global foo: tuple<f:int64>',
+                'create global foo: tuple<f: int64>',
                 [
                     {
-                        'name': 'tuple<f:std::int64>',
+                        'name': 'tuple<f: std::int64>',
                         'from_alias': False,
                         'type_name': 'schema::Tuple',
                     },
@@ -8063,18 +8063,18 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         # Create non-computed global
         # Delete non-computed global
 
-        # array<tuple<f:array<int64>>>
+        # array<tuple<f: array<int64>>>
         await self._check_ddl_global_type_changes([
             (
-                'create global foo: array<tuple<f:array<int64>>>',
+                'create global foo: array<tuple<f: array<int64>>>',
                 [
                     {
-                        'name': 'array<tuple<f:array<std::int64>>>',
+                        'name': 'array<tuple<f: array<std::int64>>>',
                         'from_alias': False,
                         'type_name': 'schema::Array',
                     },
                     {
-                        'name': 'tuple<f:array<std::int64>>',
+                        'name': 'tuple<f: array<std::int64>>',
                         'from_alias': False,
                         'type_name': 'schema::Tuple',
                     },
@@ -12370,7 +12370,7 @@ type default::Foo {
                         'type_name': 'schema::TupleExprAlias',
                     },
                     {
-                        'name': 'tuple<f:std::int64>',
+                        'name': 'tuple<f: std::int64>',
                         'from_alias': False,
                         'type_name': 'schema::Tuple',
                     },
@@ -12412,13 +12412,13 @@ type default::Foo {
         # Create alias
         # Delete alias
 
-        # array<tuple<f:array<int64>>>
+        # array<tuple<f: array<int64>>>
         await self._check_ddl_alias_type_changes([
             (
                 'create alias foo := [(f := [1])]',
                 [
                     {
-                        'name': 'array<tuple<f:array<std::int64>>>',
+                        'name': 'array<tuple<f: array<std::int64>>>',
                         'from_alias': False,
                         'type_name': 'schema::Array',
                     },
@@ -12428,7 +12428,7 @@ type default::Foo {
                         'type_name': 'schema::ArrayExprAlias',
                     },
                     {
-                        'name': 'tuple<f:array<std::int64>>',
+                        'name': 'tuple<f: array<std::int64>>',
                         'from_alias': False,
                         'type_name': 'schema::Tuple',
                     },


### PR DESCRIPTION
I used copilot to fix the tests, and it only took
me about ten times longer than doing it manually.
Copilot also kept wanting to suggest that it did
well, when writing this commit message.

One downside of this simple approach is that it
will change the ids of tuple types across versions
and even after a dump/restore (since the ids are
associated with names in dumps). The alternate
approach would be to apply a regex to fix the
names up when computing displaynames.