### PR TITLE
Fix issue with some recursive triggers

### DIFF
--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -73,7 +73,9 @@ def compile_trigger(
         new_path = irast.PathId.from_type(
             schema,
             source,
-            typename=sn.QualName(module='__derived__', name='__new__'),
+            typename=sn.QualName(
+                module='__derived__', name=ctx.aliases.get('__new__')
+            ),
             env=ctx.env,
         )
         new_set = setgen.class_set(
@@ -85,7 +87,9 @@ def compile_trigger(
             old_path = irast.PathId.from_type(
                 schema,
                 source,
-                typename=sn.QualName(module='__derived__', name='__old__'),
+                typename=sn.QualName(
+                    module='__derived__', name=ctx.aliases.get('__old__')
+                ),
                 env=ctx.env,
             )
             old_set = setgen.class_set(

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1308,7 +1308,9 @@ def prepare_rewrite_anchors(
         pointer_path_id = irast.PathId.from_type(
             schema,
             bool_type,
-            typename=sn.QualName(module="__derived__", name=pn.name),
+            typename=sn.QualName(
+                module="__derived__", name=ctx.aliases.get(pn.name)
+            ),
             namespace=ctx.path_id_namespace,
             env=ctx.env,
         )
@@ -1332,7 +1334,7 @@ def prepare_rewrite_anchors(
 
     # init set for __old__
     if r_ctx.kind == qltypes.RewriteKind.Update:
-        old_name = sn.QualName("__derived__", "__old__")
+        old_name = sn.QualName("__derived__", ctx.aliases.get("__old__"))
         old_path_id = irast.PathId.from_type(
             schema, stype, typename=old_name,
             namespace=ctx.path_id_namespace, env=ctx.env,


### PR DESCRIPTION
We were always creating path ids named __new__ and __old__ and
sometimes they collided.

Fixes #7803.