### PR TITLE
Test running inplace upgrades from instances created with 6.x

### DIFF
--- a/.github/scripts/patches/compute-ipu-versions.py
+++ b/.github/scripts/patches/compute-ipu-versions.py
@@ -1,0 +1,62 @@
+# Compute prior minor versions to test upgrading from
+
+
+import json
+import os
+import pathlib
+import re
+import sys
+from urllib import request
+
+sys.path.append(str(pathlib.Path(__file__).parent.parent.parent.parent))
+
+import edb.buildmeta
+
+base = 'https://packages.edgedb.com'
+u = f'{base}/archive/.jsonindexes/x86_64-unknown-linux-gnu.json'
+data = json.loads(request.urlopen(u).read())
+
+u = f'{base}/archive/.jsonindexes/x86_64-unknown-linux-gnu.testing.json'
+data_testing = json.loads(request.urlopen(u).read())
+
+version = edb.buildmeta.EDGEDB_MAJOR_VERSION - 1
+
+versions = []
+prerelease_versions = []
+for obj in data['packages'] + data_testing['packages']:
+    if (
+        obj['basename'] == 'gel-server'
+        and obj['version_details']['major'] == version
+        and (
+            not obj['version_details']['prerelease']
+            or obj['version_details']['prerelease'][0]['phase'] in ('beta', 'rc')
+        )
+    ):
+        l = (
+            versions if not obj['version_details']['prerelease']
+            else prerelease_versions
+        )
+        l.append((
+            obj['version'],
+            obj['basename'],
+            base + obj['installrefs'][0]['ref'],
+        ))
+
+if not versions:
+    versions = prerelease_versions
+
+versions.sort(key=lambda x: x[0])
+if len(versions) > 1:
+    versions = [versions[0], versions[-1]]
+
+matrix = {
+    "include": [
+        {"edgedb-version": v, "edgedb-url": url, "edgedb-basename": base}
+        for v, base, url in versions
+    ]
+}
+
+print("matrix:", matrix)
+if output := os.getenv('GITHUB_OUTPUT'):
+    with open(output, 'a') as f:
+        print(f'matrix={json.dumps(matrix)}', file=f)

--- a/.github/scripts/patches/compute-ipu-versions.py
+++ b/.github/scripts/patches/compute-ipu-versions.py
@@ -12,7 +12,7 @@ sys.path.append(str(pathlib.Path(__file__).parent.parent.parent.parent))
 
 import edb.buildmeta
 
-base = 'https://packages.edgedb.com'
+base = 'https://packages.geldata.com'
 u = f'{base}/archive/.jsonindexes/x86_64-unknown-linux-gnu.json'
 data = json.loads(request.urlopen(u).read())
 

--- a/.github/workflows.src/tests-inplace.tpl.yml
+++ b/.github/workflows.src/tests-inplace.tpl.yml
@@ -57,6 +57,43 @@ jobs:
       run: |
         ./tests/patch-testing/test.sh test-dir -k test_link_on_target_delete -k test_edgeql_select -k test_edgeql_scope -k test_dump
 
+  compute-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: set-matrix
+      name: Compute versions to run on
+      run: python3 .github/scripts/patches/compute-ipu-versions.py
+
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [build, compute-versions]
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJSON(needs.compute-versions.outputs.matrix)}}
+
+    steps:
+    <<- restore_cache() >>
+
+    # Run the test
+
+    - name: Download an earlier database version
+      run: |
+        wget -q "${{ matrix.edgedb-url }}"
+        tar xzf ${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}.tar.gz
+
+    - name: Make sure a CLI named "edgedb" exists (sigh)
+      run: |
+        ln -s gel $(dirname $(which gel))/edgedb
+
+    - name: Test inplace upgrades from previous major version
+      run: |
+        ./tests/inplace-testing/test-old.sh vt ${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}
+
+
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'
     name: Notify in Slack on failures

--- a/.github/workflows/tests-inplace.yml
+++ b/.github/workflows/tests-inplace.yml
@@ -615,6 +615,183 @@ jobs:
       run: |
         ./tests/patch-testing/test.sh test-dir -k test_link_on_target_delete -k test_edgeql_select -k test_edgeql_scope -k test_dump
 
+  compute-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - uses: actions/checkout@v4
+    - id: set-matrix
+      name: Compute versions to run on
+      run: python3 .github/scripts/patches/compute-ipu-versions.py
+
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [build, compute-versions]
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJSON(needs.compute-versions.outputs.matrix)}}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: false
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 50
+        submodules: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      id: setup-python
+      with:
+        python-version: '3.12.2'
+        cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
+
+    # The below is technically a lie as we are technically not
+    # inside a virtual env, but there is really no reason to bother
+    # actually creating and activating one as below works just fine.
+    - name: Export $VIRTUAL_ENV
+      run: |
+        venv="$(python -c 'import sys; sys.stdout.write(sys.prefix)')"
+        echo "VIRTUAL_ENV=${venv}" >> $GITHUB_ENV
+
+    - name: Set up uv cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: uv-cache-${{ runner.os }}-py-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+    
+    - name: Download requirements.txt
+      uses: actions/cache@v4
+      with:
+        path: requirements.txt
+        key: edb-requirements-${{ hashFiles('pyproject.toml') }}
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install uv~=0.1.0 && uv pip install -U -r requirements.txt
+        # 80.9.0 breaks our sphinx, and it keeps sneaking in
+        uv pip install setuptools==80.8.0
+
+    # Restore the artifacts and environment variables
+
+    - name: Download shared artifacts
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+      with:
+        name: shared-artifacts
+        path: shared-artifacts
+
+    - name: Set environment variables
+      run: |
+        echo POSTGRES_GIT_REV=$(cat shared-artifacts/postgres_git_rev.txt) >> $GITHUB_ENV
+        echo STOLON_GIT_REV=$(cat shared-artifacts/stolon_git_rev.txt) >> $GITHUB_ENV
+        echo BUILD_LIB=$(python setup.py -q ci_helper --type build_lib) >> $GITHUB_ENV
+        echo BUILD_TEMP=$(python setup.py -q ci_helper --type build_temp) >> $GITHUB_ENV
+
+    # Restore build cache
+
+    - name: Restore cached Rust extensions
+      uses: actions/cache@v4
+      id: rust-cache
+      with:
+        path: build/rust_extensions
+        key: edb-rust-v4-${{ hashFiles('shared-artifacts/rust_cache_key.txt') }}
+
+    - name: Restore cached Cython extensions
+      uses: actions/cache@v4
+      id: ext-cache
+      with:
+        path: build/extensions
+        key: edb-ext-v6-${{ hashFiles('shared-artifacts/ext_cache_key.txt') }}
+
+    - name: Restore compiled parsers cache
+      uses: actions/cache@v4
+      id: parsers-cache
+      with:
+        path: build/lib
+        key: edb-parsers-v3-${{ hashFiles('shared-artifacts/parsers_cache_key.txt') }}
+
+    - name: Restore cached PostgreSQL build
+      uses: actions/cache@v4
+      id: postgres-cache
+      with:
+        path: build/postgres/install
+        key: edb-postgres-v3-${{ env.POSTGRES_GIT_REV }}-${{ hashFiles('shared-artifacts/lib_cache_key.txt') }}
+
+    - name: Restore cached Stolon build
+      uses: actions/cache@v4
+      id: stolon-cache
+      with:
+        path: build/stolon/bin
+        key: edb-stolon-v2-${{ env.STOLON_GIT_REV }}
+
+    - name: Restore bootstrap cache
+      uses: actions/cache@v4
+      id: bootstrap-cache
+      with:
+        path: build/cache
+        key: edb-bootstrap-v2-${{ hashFiles('shared-artifacts/bootstrap_cache_key.txt') }}
+
+    - name: Stop if we cannot retrieve the cache
+      if: |
+        steps.rust-cache.outputs.cache-hit != 'true' ||
+        steps.ext-cache.outputs.cache-hit != 'true' ||
+        steps.parsers-cache.outputs.cache-hit != 'true' ||
+        steps.postgres-cache.outputs.cache-hit != 'true' ||
+        steps.stolon-cache.outputs.cache-hit != 'true' ||
+        steps.bootstrap-cache.outputs.cache-hit != 'true'
+      run: |
+        echo ::error::Cannot retrieve build cache.
+        exit 1
+
+    - name: Validate cached binaries
+      run: |
+        # Validate Stolon
+        ./build/stolon/bin/stolon-sentinel --version || exit 1
+        ./build/stolon/bin/stolon-keeper --version || exit 1
+        ./build/stolon/bin/stolon-proxy --version || exit 1
+
+        # Validate PostgreSQL
+        ./build/postgres/install/bin/postgres --version || exit 1
+        ./build/postgres/install/bin/pg_config --version || exit 1
+
+    - name: Restore cache into the source tree
+      run: |
+        rsync -av ./build/rust_extensions/edb/ ./edb/
+        rsync -av ./build/extensions/edb/ ./edb/
+        rsync -av ./build/lib/edb/ ./edb/
+        cp build/postgres/install/stamp build/postgres/
+
+    - name: Install edgedb-server
+      env:
+        BUILD_EXT_MODE: skip
+      run: |
+        # --no-build-isolation because we have explicitly installed all deps
+        # and don't want them to be reinstalled in an "isolated env".
+        pip install --no-build-isolation --no-deps -e .[test,docs]
+
+    # Run the test
+
+    - name: Download an earlier database version
+      run: |
+        wget -q "${{ matrix.edgedb-url }}"
+        tar xzf ${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}.tar.gz
+
+    - name: Make sure a CLI named "edgedb" exists (sigh)
+      run: |
+        ln -s gel $(dirname $(which gel))/edgedb
+
+    - name: Test inplace upgrades from previous major version
+      run: |
+        ./tests/inplace-testing/test-old.sh vt ${{ matrix.edgedb-basename }}-${{ matrix.edgedb-version }}
+
+
   workflow-notifications:
     if: failure() && github.event_name != 'pull_request'
     name: Notify in Slack on failures

--- a/tests/inplace-testing/test-old.sh
+++ b/tests/inplace-testing/test-old.sh
@@ -1,0 +1,148 @@
+#!/bin/bash -ex
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --rollback-and-test)
+        ROLLBACK=1
+        shift
+        ;;
+    --rollback-and-reapply)
+        REAPPLY=1
+        shift
+        ;;
+    --save-tarballs)
+        SAVE_TARBALLS=1
+        shift
+        ;;
+    *)
+        break
+        ;;
+  esac
+done
+
+
+DIR=$(realpath "$1")
+SERVER_INSTALL=$(realpath "$2")
+shift 2
+
+# Setup the test database
+(cd / && GEL_SERVER_SECURITY=insecure_dev_mode $SERVER_INSTALL/bin/python3  -m edb.tools --no-devmode inittestdb --tests-dir $SERVER_INSTALL/share/tests -k test_dump --data-dir "$DIR")
+
+
+if [ "$SAVE_TARBALLS" = 1 ]; then
+    tar cf "$DIR".tar "$DIR"
+fi
+
+
+PORT=12346
+GEL_SERVER_SECURITY=insecure_dev_mode $SERVER_INSTALL/bin/gel-server --testmode -D "$DIR" -P $PORT &
+SPID=$!
+stop_server() {
+    kill $SPID
+    wait $SPID
+    SPID=
+}
+cleanup() {
+    if [ -n "$SPID" ]; then
+        stop_server
+    fi
+}
+trap cleanup EXIT
+
+GEL="gel -H localhost -P $PORT --tls-security insecure --wait-until-available 120sec"
+
+# Wait for the server to come up and see it is working
+$GEL -b dump01 query 'select count(Z)' | grep 2
+
+# Block DDL
+$GEL query 'configure instance set force_database_error := $${"type": "AvailabilityError", "message": "DDL is disabled due to in-place upgrade.", "_scopes": ["ddl"]}$$;'
+
+if $GEL query 'create empty branch asdf'; then
+    echo Unexpected DDL success despite blocking it
+    exit 4
+fi
+
+# Prepare the upgrades
+EDGEDB_PORT=$PORT EDGEDB_CLIENT_TLS_SECURITY=insecure python3 tests/inplace-testing/prep-upgrades.py > "${DIR}/upgrade.json"
+
+# Get the DSN from the debug endpoint
+DSN=$(curl -s http://localhost:$PORT/server-info | jq -r '.pg_addr.dsn')
+
+# Prepare the upgrade, operating against the postgres that the old
+# version server is managing
+edb server --inplace-upgrade-prepare "$DIR"/upgrade.json --backend-dsn="$DSN"
+
+# Check the server is still working
+$GEL -b dump01 query 'select count(Z)' | grep 2
+
+if [ "$ROLLBACK" = 1 ]; then
+    # Inject a failure into our first attempt to rollback
+    if EDGEDB_UPGRADE_ROLLBACK_ERROR_INJECTION=dumpbasics edb server --inplace-upgrade-rollback --backend-dsn="$DSN"; then
+        echo Unexpected rollback success despite failure injection
+        exit 4
+    fi
+
+    # Second try should work
+    edb server --inplace-upgrade-rollback --backend-dsn="$DSN"
+    $GEL query 'configure instance reset force_database_error'
+
+    # XXX: what can we do here???
+    stop_server
+    # patch -R -f -p1 < tests/inplace-testing/upgrade.patch
+    # make parsers
+    # edb test --data-dir "$DIR" --use-data-dir-dbs -v "$@"
+    exit 0
+fi
+
+if [ "$REAPPLY" = 1 ]; then
+    # Rollback and then reapply
+    edb server --inplace-upgrade-rollback --backend-dsn="$DSN"
+
+    edb server --inplace-upgrade-prepare "$DIR"/upgrade.json --backend-dsn="$DSN"
+fi
+
+# Check the server is still working
+$GEL -b dump01 query 'select count(Z)' | grep 2
+
+# Kill the old version so we can finalize the upgrade
+stop_server
+
+if [ "$SAVE_TARBALLS" = 1 ]; then
+    tar cf "$DIR"-prepped.tar "$DIR"
+fi
+
+# Try to finalize the upgrade, but inject a failure
+if EDGEDB_UPGRADE_FINALIZE_ERROR_INJECTION=dumpbasics edb server --inplace-upgrade-finalize --data-dir "$DIR"; then
+    echo Unexpected upgrade success despite failure injection
+    exit 4
+fi
+
+# Try doing a rollback. It should fail, because of the partially
+# succesful finalization.
+if edb server --inplace-upgrade-rollback --data-dir "$DIR"; then
+    echo Unexpected upgrade success
+    exit 5
+fi
+
+# Finalize the upgrade
+edb server --inplace-upgrade-finalize --data-dir "$DIR"
+if [ "$SAVE_TARBALLS" = 1 ]; then
+    tar cf "$DIR"-cooked.tar "$DIR"
+fi
+
+# Start the server again so we can reenable DDL
+edb server -D "$DIR" -P $PORT &
+SPID=$!
+if $GEL query 'create empty branch asdf'; then
+    echo Unexpected DDL success despite blocking it
+    exit 6
+fi
+$GEL query 'configure instance reset force_database_error'
+stop_server
+if [ "$SAVE_TARBALLS" = 1 ]; then
+    tar cf "$DIR"-cooked2.tar "$DIR"
+fi
+
+
+# Test!
+edb test --data-dir "$DIR" --use-data-dir-dbs -v "$@" -k test_dump


### PR DESCRIPTION
It uses the dump tests, since those should (should!) not change
between versions.

We'll test against 6.0 and 6.latest.
Fixes #8776.