### PR TITLE
Fix interaction between inlining, globals, and the HTTP protocols

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -323,6 +323,7 @@ class BytesConstant(BaseConstant):
 
 class Parameter(Expr):
     name: str
+    is_func_param: bool = False
 
 
 class UnaryOp(Expr):

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -756,7 +756,7 @@ def compile_TypeCast(
         else:
             required = True
 
-        if ctx.env.options.json_parameters:
+        if ctx.env.options.json_parameters and not expr.expr.is_func_param:
             if param_name.isdecimal():
                 raise errors.QueryError(
                     'queries compiled to accept JSON parameters do not '

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -2363,7 +2363,7 @@ def get_params_symtable(
     anchors: dict[str, qlast.Expr] = {}
 
     defaults_mask = qlast.TypeCast(
-        expr=qlast.Parameter(name='__defaults_mask__'),
+        expr=qlast.Parameter(name='__defaults_mask__', is_func_param=True),
         type=qlast.TypeName(
             maintype=qlast.ObjectRef(
                 module='std',
@@ -2378,7 +2378,7 @@ def get_params_symtable(
             p.get_typemod(schema) is not ft.TypeModifier.SingletonType
         )
         anchors[p_shortname] = qlast.TypeCast(
-            expr=qlast.Parameter(name=p_shortname),
+            expr=qlast.Parameter(name=p_shortname, is_func_param=True),
             cardinality_mod=(
                 qlast.CardinalityModifier.Optional if p_is_optional else None
             ),
@@ -2647,6 +2647,11 @@ def get_compiler_options(
             inlining_context.env.options.func_params
             if inlining_context is not None else
             params
+        ),
+        json_parameters=(
+            inlining_context.env.options.json_parameters
+            if inlining_context is not None else
+            False
         ),
         apply_query_rewrites=not context.stdmode,
         track_schema_ref_exprs=track_schema_ref_exprs,

--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -163,6 +163,10 @@ optional global test_global_def2 -> str {
     default := ""
 };
 function get_glob() -> optional str using (global test_global_str);
+function get_glob_inline() -> optional str {
+  using (global test_global_str);
+  volatility := 'Modifying';
+};
 
 alias GlobalTest := {
     gstr := global test_global_str,

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -367,6 +367,17 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
                 use_http_post=use_http_post,
             )
 
+    def test_http_edgeql_query_globals_05(self):
+        Q = r'''select get_glob_inline()'''
+
+        for use_http_post in [True, False]:
+            self.assert_edgeql_query_result(
+                Q,
+                ['foo'],
+                globals={'default::test_global_str': 'foo'},
+                use_http_post=use_http_post,
+            )
+
     def test_http_edgeql_query_func_01(self):
         Q = r'''select id_func('foo')'''
 


### PR DESCRIPTION
We weren't preserving json_parameters when compiling the body of
inlined functions, and so globals weren't getting piped in properly.