### PR TITLE
Prohibit with_config/with_globals in the testbase gel client

### DIFF
--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -605,12 +605,8 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
     async def test_edgeql_globals_composite(self):
         # Test various composite global variables.
 
-        # HACK: Using with_globals on testbase.Connection doesn't
-        # work, and I timed out on understanding why; I got the state
-        # plumbed into the real client library code, where the state
-        # codec was not encoding it.
-        # It isn't actually important for that to work, so for now
-        # we create a connection with the real honest client library.
+        # with_globals isn't supported in the testbase client, so use
+        # the stock client instead
         con = edgedb.create_async_client(
             **self.get_connect_args(database=self.con.dbname)
         )


### PR DESCRIPTION
I've known they were broken for a while and finally took the time to
track down why: we override encode_state in our custom subclass of the
protocol (in cython in edb.protocol.protocol.Protocol) to ignore any
passed in state. I think the reason for this is because (unlike the
stock client) our test client supports (and our tests use a lot of)
explicit CONFIGURE SESSION and SET GLOBAL commands, and it would take
a bunch of work to make those play nicely together.

(Probably not *that* much? We'd have to decode state sent by the server
and then try overlaying the context configured state.)

Anyway, prohibit it, update some comments and some call sites.