### PR TITLE
pg-ext: fix the command status of BEGIN

### DIFF
--- a/edb/server/compiler/sql.py
+++ b/edb/server/compiler/sql.py
@@ -317,7 +317,11 @@ def _compile_sql(
         elif isinstance(stmt, (pgast.BeginStmt, pgast.StartStmt)):
             unit.tx_action = dbstate.TxAction.START
             unit.command_complete_tag = dbstate.TagPlain(
-                tag=b"START TRANSACTION"
+                tag=(
+                    b"START TRANSACTION"
+                    if isinstance(stmt, pgast.StartStmt)
+                    else b"BEGIN"
+                )
             )
         elif isinstance(stmt, pgast.CommitStmt):
             unit.tx_action = dbstate.TxAction.COMMIT

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -3478,6 +3478,20 @@ class TestSQLQueryNonTransactional(tb.SQLQueryTestCase):
         v2 = await self.scon.fetchval("SHOW transaction_isolation")
         self.assertNotEqual(v1, v2)
 
+    async def test_sql_transaction_03(self):
+        self.assertEqual(
+            await self.scon.execute("BEGIN"),
+            "BEGIN",
+        )
+        await self.scon.execute("ROLLBACK")
+
+    async def test_sql_transaction_04(self):
+        self.assertEqual(
+            await self.scon.execute("START TRANSACTION"),
+            "START TRANSACTION",
+        )
+        await self.scon.execute("ROLLBACK")
+
     async def test_sql_query_error_11(self):
         # extended query protocol
         with self.assertRaisesRegex(


### PR DESCRIPTION
The JDBC driver expects an exact command status of `BEGIN`, while Gel was returning `START TRANSACTION` regardless of whether `START TRANSACTION` or `BEGIN` was issued.

Fixes #8787