### PR TITLE
Cache param conversion in HTTP and graphql endpoints

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -810,42 +810,16 @@ def compile_TypeCast(
         else:
             required = True
 
-        if ctx.env.options.json_parameters and not expr.expr.is_func_param:
-            if param_name.isdecimal():
-                raise errors.QueryError(
-                    'queries compiled to accept JSON parameters do not '
-                    'accept positional parameters',
-                    span=expr.expr.span)
-
-            typeref = typegen.type_to_typeref(
-                ctx.env.get_schema_type_and_track(sn.QualName('std', 'json')),
-                env=ctx.env,
-            )
-
-            param = casts.compile_cast(
-                irast.Parameter(
-                    typeref=typeref,
-                    name=param_name,
-                    required=required,
-                    span=expr.expr.span,
-                ),
-                pt,
+        typeref = typegen.type_to_typeref(pt, env=ctx.env)
+        param = setgen.ensure_set(
+            irast.Parameter(
+                typeref=typeref,
+                name=param_name,
+                required=required,
                 span=expr.expr.span,
-                ctx=ctx,
-                cardinality_mod=expr.cardinality_mod,
-            )
-
-        else:
-            typeref = typegen.type_to_typeref(pt, env=ctx.env)
-            param = setgen.ensure_set(
-                irast.Parameter(
-                    typeref=typeref,
-                    name=param_name,
-                    required=required,
-                    span=expr.expr.span,
-                ),
-                ctx=ctx,
-            )
+            ),
+            ctx=ctx,
+        )
 
         if ex_param := ctx.env.script_params.get(param_name):
             # N.B. Accessing the schema_type from the param is unreliable

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -691,6 +691,8 @@ class ParamTransType:
 
 @dataclasses.dataclass(eq=False)
 class ParamScalar(ParamTransType):
+    cast_to: typing.Optional[TypeRef] = None
+
     def flatten(self) -> tuple[typing.Any, ...]:
         return (int(qltypes.TypeTag.SCALAR), self.idx)
 

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -3303,7 +3303,6 @@ def _extract_params(
         )
 
         if param.sub_params:
-            assert not ctx.json_parameters
             array_tids: list[Optional[uuid.UUID]] = []
             for p in param.sub_params.params:
                 if isinstance(p.schema_type, s_types.Array):

--- a/tests/test_http_edgeql.py
+++ b/tests/test_http_edgeql.py
@@ -405,15 +405,10 @@ class TestHttpEdgeQL(tb.EdgeQLTestCase):
         )
 
     def test_http_edgeql_query_func_04(self):
-        # JSON parameter can be null, so <str>$x is AT_MOST_ONE in this case
-        with self.assertRaisesRegex(
-                edgedb.QueryError,
-                r'possibly an empty set passed as non-optional argument '
-                r'into modifying function'):
-            self.edgeql_query(
-                r'''select modifying_noop(<str>$x)''',
-                variables=dict(x='foo'),
-            )
+        self.edgeql_query(
+            r'''select modifying_noop(<str>$x)''',
+            variables=dict(x='foo'),
+        )
 
     def test_http_edgeql_query_duration_01(self):
         Q = r"""select <duration>'15m' < <duration>'1h'"""


### PR DESCRIPTION
This uses the "tuple_args" mechanism for transforming and caching
parameter inputs to do it.
Maybe that should get a rename in a follow-up.

This also fixes cardinality inference of params in JSON mode,
apparently.

Cousin to #8753.