### PR TITLE
Fix rewrites making UPDATE infer as ONE

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -1238,11 +1238,6 @@ def _compile_rewrites_for_stype(
                 scopectx.iterator_path_ids |= {anchor.path_id}
                 scopectx.anchors[key] = anchor
 
-            # XXX: I am pretty sure this must be wrong, but we get
-            # a failure without due to volatility issues in
-            # test_edgeql_rewrites_16
-            scopectx.env.singletons.append(anchors.subject_set.path_id)
-
             ctx.path_scope.factoring_allowlist.add(anchors.subject_set.path_id)
 
             # prepare expression

--- a/tests/test_edgeql_rewrites.py
+++ b/tests/test_edgeql_rewrites.py
@@ -1179,6 +1179,15 @@ class TestRewrites(tb.DDLTestCase):
             [{'title': 'updated'}] * 2,
         )
 
+    async def test_edgeql_rewrites_33(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InterfaceError,
+            r"more than one element"
+        ):
+            await self.con.query_single('''
+                update Asdf set {}
+            ''')
+
     async def test_edgeql_rewrites_triggers_01(self):
         await self.con.execute('''
             create type Pidgeon {


### PR DESCRIPTION
This was caused by some code doing something nonsensical, with a
comment above it that I wrote saying that it must be wrong but made a
particular test pass. That test still passes if I remove it, so all
right.

Fixes #8791.