### PR TITLE
Fix array-of-tuple decoding with empty arrays from some bindings

### DIFF
--- a/edb/server/protocol/args_ser.pyx
+++ b/edb/server/protocol/args_ser.pyx
@@ -471,10 +471,13 @@ cdef _decode_tuple_args_core(
             raise errors.InputDataError("unsupported array dimensions")
         frb_read(&sub_buf, 4)  # flags
         frb_read(&sub_buf, 4)  # reserved
-        cnt = <uint32_t>hton.unpack_int32(frb_read(&sub_buf, 4))
-        val = hton.unpack_int32(frb_read(&sub_buf, 4)) # bound
-        if val != 1:
-            raise errors.InputDataError("unsupported array bound")
+        if val == 0:
+            cnt = 0
+        else:
+            cnt = <uint32_t>hton.unpack_int32(frb_read(&sub_buf, 4))
+            val = hton.unpack_int32(frb_read(&sub_buf, 4)) # bound
+            if val != 1:
+                raise errors.InputDataError("unsupported array bound")
 
         # For nested arrays, we need to produce an array containing
         # the start/end indexes in the flattened array.


### PR DESCRIPTION
Some bindings (at least rust) encode empty arrays with ndims==0,
while gel-python and gel-js do ndims==1, cnt==0.

We don't properly handle the ndims==0 case when tuple parameters.
Fix that.

Testing:
```
_localdev:backup> select <array<tuple<int32, array<int32>>>>$0;
Parameter <array<tuple<int32, array<int32>>>>$0: []
{[]}
_localdev:backup> select <array<tuple<int32, array<int32>>>>$0;
Parameter <array<tuple<int32, array<int32>>>>$0: [(0, []), (1, [1])]
{[(0, []), (1, [1])]}
```

Fixes #8817