### PR TITLE
Directly use generate_series for array of tuple decoding

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_06_17_00_03
+EDGEDB_CATALOG_VERSION = 2025_06_19_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/edgeql/compiler/tuple_args.py
+++ b/edb/edgeql/compiler/tuple_args.py
@@ -334,30 +334,11 @@ def make_decoder(
 
             sub_expr = mk(typ.typ, idx=inner_idx)
 
-            # For some reason, this is much faster if force the range to
-            # be over int64 instead of int32.
-            lo = qlast.TypeCast(
-                expr=lo,
-                type=qlast.TypeName(
-                    maintype=qlast.ObjectRef(module='__std__', name='int64')
-                ),
-            )
-
             loop = qlast.ForQuery(
                 iterator_alias=inner_idx_alias,
-                # TODO: Using _gen_series would be marginally faster,
-                # but it isn't actually available in distributions
-                # iterator=qlast.FunctionCall(
-                #     func=('__std__', '_gen_series'),
-                #     args=[lo, _plus_const(hi, -1)],
-                # ),
                 iterator=qlast.FunctionCall(
-                    func=('__std__', 'range_unpack'), args=[
-                        qlast.FunctionCall(
-                            func=('__std__', 'range'),
-                            args=[lo, hi],
-                        )
-                    ]
+                    func=('__std__', '__pg_generate_series'),
+                    args=[lo, _plus_const(hi, -1)],
                 ),
                 result=sub_expr,
             )

--- a/edb/lib/std/31-rangefuncs.edgeql
+++ b/edb/lib/std/31-rangefuncs.edgeql
@@ -913,3 +913,18 @@ CREATE CAST FROM range<anypoint> TO multirange<anypoint> {
     # Any range can be implicitly cast into a multirange.
     ALLOW IMPLICIT;
 };
+
+
+## For annoying performance reasons, we want to be able to internally
+## directly call generate_series.
+## Hopefully I'll fix this better later.
+
+CREATE FUNCTION
+std::__pg_generate_series(
+    `start`: std::int64,
+    stop: std::int64
+) -> SET OF std::int64
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'generate_series';
+};


### PR DESCRIPTION
We want to just use _gen_series, but that is testmode only, so add a
__pg_generate_series to expose it more easily.
In the future I'll try to properly optimize `range_unpack(range(lo, hi))`

Fixes #8813.