### PR TITLE
Make system-wide DDL require SUPERUSER

### DIFF
--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2579,10 +2579,12 @@ def _compile_dispatch_ql(
             return query, enums.Capability(0)
 
     elif isinstance(ql, qlast.DDLCommand):
-        return (
-            ddl.compile_and_apply_ddl_stmt(ctx, ql, source=source),
-            enums.Capability.DDL,
-        )
+        query = ddl.compile_and_apply_ddl_stmt(ctx, ql, source=source)
+        capability = enums.Capability.DDL
+        if isinstance(ql, qlast.GlobalObjectCommand):
+            capability |= enums.Capability.GLOBAL_DDL
+
+        return (query, capability)
 
     elif isinstance(ql, qlast.Transaction):
         return (

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -36,12 +36,15 @@ TypeTag = ir.TypeTag
 
 class Capability(enum.IntFlag):
 
+    # Capability flags that are part of the protocol.
+    # Can be picked up with the PROTO_CAPS mask.
     MODIFICATIONS     = 1 << 0    # noqa
     SESSION_CONFIG    = 1 << 1    # noqa
     TRANSACTION       = 1 << 2    # noqa
     DDL               = 1 << 3    # noqa
     PERSISTENT_CONFIG = 1 << 4    # noqa
 
+    # Internal only capability flags.
     GLOBAL_DDL        = 1 << 58   # noqa
     BRANCH_CONFIG     = 1 << 59   # noqa
     INSTANCE_CONFIG   = 1 << 60   # noqa

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -42,6 +42,7 @@ class Capability(enum.IntFlag):
     DDL               = 1 << 3    # noqa
     PERSISTENT_CONFIG = 1 << 4    # noqa
 
+    GLOBAL_DDL        = 1 << 58   # noqa
     BRANCH_CONFIG     = 1 << 59   # noqa
     INSTANCE_CONFIG   = 1 << 60   # noqa
     DESCRIBE          = 1 << 61   # noqa
@@ -82,6 +83,7 @@ CAPABILITY_TITLES = {
     Capability.ANALYZE: 'ANALYZE commands',
     Capability.INSTANCE_CONFIG: 'instance configuration commands',
     Capability.BRANCH_CONFIG: 'database branch configuration commands',
+    Capability.GLOBAL_DDL: 'instance-wide DDL commands',
 }
 
 

--- a/tests/test_server_permissions.py
+++ b/tests/test_server_permissions.py
@@ -858,6 +858,26 @@ class TestServerPermissions(tb.EdgeQLTestCase, server_tb.CLITestCaseMixin):
                 CREATE TYPE Widget;
             """)
 
+            # But *not* system wide DDL!
+            with self.assertRaisesRegex(
+                edgedb.DisabledCapabilityError,
+                'cannot execute instance-wide DDL commands: '
+                'role foo does not have permission'
+            ):
+                await conn.execute("""
+                    CREATE SUPERUSER ROLE bar {
+                        SET password := 'secret';
+                    };
+                """)
+            with self.assertRaisesRegex(
+                edgedb.DisabledCapabilityError,
+                'cannot execute instance-wide DDL commands: '
+                'role foo does not have permission'
+            ):
+                await conn.execute("""
+                    CREATE EMPTY BRANCH bar
+                """)
+
         finally:
             await conn.aclose()
             await self.con.query('''


### PR DESCRIPTION
Importantly, this includes creating new users.