### PR TITLE
rbac: Fix doing POPULATE MIGRATION for functions with required_permissions

### DIFF
--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -6123,6 +6123,28 @@ class TestEdgeQLDataMigration(EdgeQLDataMigrationTestCase):
           permission bar;
        """)
 
+    async def test_edgeql_migration_permissions_03c(self):
+        # Check tracing dependency works
+        await self.migrate(r"""
+          permission foo;
+          permission bar;
+          function test(x: int64) -> int64 {
+              using (1);
+              required_permissions := {foo, bar};
+          };
+       """)
+
+    async def test_edgeql_migration_permissions_03d(self):
+        # Sigh... test using POPULATE MIGRATION also...
+        # Check tracing dependency works
+        await tb.DDLTestCase.migrate(self, r"""
+          permission foo;
+          function test(x: int64) -> int64 {
+              using (x);
+              required_permissions := foo;
+          };
+       """)
+
     async def test_edgeql_migration_index_01(self):
         await self.migrate('''
             type Message {


### PR DESCRIPTION
The problem was that we were generating ASTs that had the permissions as
`TypeName`s, which then errored because the permissions weren't types.
Change `shell_to_ast` to return a regular AST for non type shells.

Follow up to #8812, progress on #8177.