### PR TITLE
Add more grammar type annotations

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -101,7 +101,7 @@ class Base(ast.AST):
 
 class GrammarEntryPoint(Base):
     """Mixin denoting nodes that are entry points for EdgeQL grammar"""
-    __mixin_node__ = True
+    __abstract_node__ = True
 
 
 class OptionValue(Base):
@@ -449,8 +449,7 @@ class Set(Expr):
 # Statements
 #
 
-
-class Command(GrammarEntryPoint, Base):
+class Command(Base):
     """
     A top-level node that is evaluated by our server and
     cannot be a part of a sub expression.
@@ -458,6 +457,10 @@ class Command(GrammarEntryPoint, Base):
 
     __abstract_node__ = True
     aliases: typing.Optional[list[Alias]] = None
+
+
+class Commands(GrammarEntryPoint, Base):
+    commands: list[Command]
 
 
 class SessionSetAliasDecl(Command):
@@ -526,7 +529,7 @@ class Shape(Expr):
     allow_factoring: bool = False
 
 
-class Query(Expr, GrammarEntryPoint):
+class Query(Expr, GrammarEntryPoint, Command):
     __abstract_node__ = True
 
     aliases: typing.Optional[list[Alias]] = None
@@ -683,7 +686,7 @@ class ReleaseSavepoint(Transaction):
 
 class DDL(Base):
     '''A mixin denoting DDL nodes.'''
-    __mixin_node__ = True
+    __abstract_node__ = True
 
 
 class Position(DDL):
@@ -1584,7 +1587,7 @@ class AdministerStmt(Command):
 class SDL(Base):
     '''A mixin denoting SDL nodes.'''
 
-    __mixin_node__ = True
+    __abstract_node__ = True
 
 
 class ModuleDeclaration(SDL):

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -135,7 +135,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         parent: Optional[qlast.Base] = node._parent
         return (
             parent is not None
-            and not isinstance(parent, qlast.DDL)
+            and not isinstance(parent, (qlast.Commands, qlast.DDL))
             # Non-union FOR bodies can't have parens
             and not (
                 isinstance(parent, qlast.ForQuery)
@@ -209,7 +209,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self._block_ws(-1, newlines)
 
     def visit_Commands(self, node: qlast.Commands) -> None:
-        self.visit_list(node.commands)
+        self.visit_list(node.commands, separator=';', terminator=';')
 
     def visit_AliasedExpr(self, node: qlast.AliasedExpr) -> None:
         self.write(ident_to_str(node.alias))

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -208,6 +208,9 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
             self.visit(node.limit)
             self._block_ws(-1, newlines)
 
+    def visit_Commands(self, node: qlast.Commands) -> None:
+        self.visit_list(node.commands)
+
     def visit_AliasedExpr(self, node: qlast.AliasedExpr) -> None:
         self.write(ident_to_str(node.alias))
         self.write(' := ')

--- a/edb/edgeql/codegen.py
+++ b/edb/edgeql/codegen.py
@@ -497,7 +497,7 @@ class EdgeQLSourceGenerator(codegen.SourceGenerator):
         parenthesize = not (
             isinstance(parent, qlast.SelectQuery)
             and parent.implicit
-            and parent._parent is None  # type: ignore
+            and isinstance(parent._parent, qlast.Commands)  # type: ignore
         )
         if parenthesize:
             self.write('(')

--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -133,6 +133,7 @@ from typing import (
     TypeVar,
     AbstractSet,
     Mapping,
+    Sequence,
     cast,
     overload,
     TYPE_CHECKING,
@@ -373,7 +374,7 @@ def compile_ast_fragment_to_ir(
 
 @compiler_entrypoint
 def preprocess_script(
-    stmts: list[qlast.Base],
+    stmts: Sequence[qlast.Base],
     schema: s_schema.Schema,
     *,
     options: CompilerOptions,

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -980,7 +980,7 @@ def throw_on_loose_param(
 
 
 def preprocess_script(
-    stmts: list[qlast.Base], *, ctx: context.ContextLevel
+    stmts: Sequence[qlast.Base], *, ctx: context.ContextLevel
 ) -> irast.ScriptInfo:
     """Extract parameters from all statements in a script.
 

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -34,18 +34,18 @@ from .. import tokenizer as qltokenizer
 SPEC_LOADED = False
 
 
-def append_module_aliases(tree, aliases):
-    modaliases = []
+def append_module_aliases(
+    command: qlast.Command, aliases: Mapping[Optional[str], str]
+):
+    modaliases: list[qlast.Alias] = []
     for alias, module in aliases.items():
         decl = qlast.ModuleAliasDecl(module=module, alias=alias)
         modaliases.append(decl)
 
-    if not tree.aliases:
-        tree.aliases = modaliases
+    if not command.aliases:
+        command.aliases = modaliases
     else:
-        tree.aliases = modaliases + tree.aliases
-
-    return tree
+        command.aliases = modaliases + command.aliases
 
 
 def parse_fragment(
@@ -80,12 +80,13 @@ def parse_query(
 def parse_block(
     source: qltokenizer.Source | str,
     module_aliases: Optional[Mapping[Optional[str], str]] = None,
-) -> list[qlast.Base]:
-    trees = parse(tokens.T_STARTBLOCK, source)
+) -> list[qlast.Command]:
+    node = parse(tokens.T_STARTBLOCK, source)
+    assert isinstance(node, qlast.Commands)
     if module_aliases:
-        for tree in trees:
-            append_module_aliases(tree, module_aliases)
-    return trees
+        for command in node.commands:
+            append_module_aliases(command, module_aliases)
+    return node.commands
 
 
 def parse_migration_body_block(
@@ -138,9 +139,8 @@ def parse(
         # - original order.
         errs = result.errors
         unexpected = [e for e in errs if e[0].startswith('Unexpected')]
-        if (
-            len(unexpected) == 1
-            and unexpected[0][0].startswith('Unexpected keyword')
+        if len(unexpected) == 1 and unexpected[0][0].startswith(
+            'Unexpected keyword'
         ):
             error = unexpected[0]
         else:
@@ -162,7 +162,7 @@ def parse(
             position=position,
             hint=hint,
             details=details,
-            span=parsing_span
+            span=parsing_span,
         )
 
     assert isinstance(result.out, rust_parser.CSTNode)
@@ -209,9 +209,7 @@ def _cst_to_ast(
                     end=terminal.end,
                 )
                 result.append(
-                    parsing.Token(
-                        terminal.text, terminal.value, span
-                    )
+                    parsing.Token(terminal.text, terminal.value, span)
                 )
 
             elif production := node.production:

--- a/edb/edgeql/parser/__init__.py
+++ b/edb/edgeql/parser/__init__.py
@@ -82,7 +82,7 @@ def parse_block(
     module_aliases: Optional[Mapping[Optional[str], str]] = None,
 ) -> list[qlast.Command]:
     node = parse(tokens.T_STARTBLOCK, source)
-    assert isinstance(node, qlast.Commands)
+    assert isinstance(node, qlast.Commands), node
     if module_aliases:
         for command in node.commands:
             append_module_aliases(command, module_aliases)

--- a/edb/edgeql/parser/grammar/commondl.py
+++ b/edb/edgeql/parser/grammar/commondl.py
@@ -550,6 +550,7 @@ class OptUsingBlock(Nonterm):
 
 
 class AccessKind(Nonterm):
+    val: list[qltypes.AccessKind]
 
     def reduce_ALL(self, _):
         self.val = list(qltypes.AccessKind)
@@ -576,7 +577,7 @@ class AccessKind(Nonterm):
 
 class AccessKindList(parsing.ListNonterm, element=AccessKind,
                      separator=tokens.T_COMMA):
-    pass
+    val: list[list[qltypes.AccessKind]]
 
 
 class AccessPolicyAction(Nonterm):

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -143,6 +143,8 @@ class ExprStmtAnnoyingCore(Nonterm):
 # instead need to spell it out more explicitly because it doesn't
 # exactly fit.)
 class GenExpr(Nonterm):
+    val: qlast.Expr
+
     @parsing.inline(0)
     def reduce_Expr(self, *kids):
         pass
@@ -1176,12 +1178,16 @@ class OptUnlessConflictClause(Nonterm):
 
 
 class FilterClause(Nonterm):
+    val: qlast.Expr
+
     @parsing.inline(1)
     def reduce_FILTER_Expr(self, *kids):
         pass
 
 
 class OptFilterClause(Nonterm):
+    val: typing.Optional[qlast.Expr]
+
     @parsing.inline(0)
     def reduce_FilterClause(self, *kids):
         pass
@@ -1191,12 +1197,16 @@ class OptFilterClause(Nonterm):
 
 
 class SortClause(Nonterm):
+    val: list[qlast.SortExpr]
+
     @parsing.inline(1)
     def reduce_ORDERBY_OrderbyList(self, *kids):
         pass
 
 
 class OptSortClause(Nonterm):
+    val: list[qlast.SortExpr]
+
     @parsing.inline(0)
     def reduce_SortClause(self, *kids):
         pass
@@ -1206,6 +1216,8 @@ class OptSortClause(Nonterm):
 
 
 class OrderbyExpr(Nonterm):
+    val: qlast.SortExpr
+
     def reduce_Expr_OptDirection_OptNonesOrder(self, *kids):
         self.val = qlast.SortExpr(path=kids[0].val,
                                   direction=kids[1].val,
@@ -1214,10 +1226,12 @@ class OrderbyExpr(Nonterm):
 
 class OrderbyList(ListNonterm, element=OrderbyExpr,
                   separator=tokens.T_THEN):
-    pass
+    val: list[qlast.SortExpr]
 
 
 class OptSelectLimit(Nonterm):
+    val: tuple[typing.Optional[qlast.Expr], typing.Optional[qlast.Expr]]
+
     @parsing.inline(0)
     def reduce_SelectLimit(self, *kids):
         pass
@@ -1227,6 +1241,8 @@ class OptSelectLimit(Nonterm):
 
 
 class SelectLimit(Nonterm):
+    val: tuple[typing.Optional[qlast.Expr], typing.Optional[qlast.Expr]]
+
     def reduce_OffsetClause_LimitClause(self, *kids):
         self.val = (kids[0].val, kids[1].val)
 
@@ -1238,12 +1254,16 @@ class SelectLimit(Nonterm):
 
 
 class OffsetClause(Nonterm):
+    val: qlast.Expr
+
     @parsing.inline(1)
     def reduce_OFFSET_Expr(self, *kids):
         pass
 
 
 class LimitClause(Nonterm):
+    val: qlast.Expr
+
     @parsing.inline(1)
     def reduce_LIMIT_Expr(self, *kids):
         pass
@@ -1296,6 +1316,7 @@ class ParenExpr(Nonterm):
 
 
 class BaseAtomicExpr(Nonterm):
+    val: qlast.Expr
     # { ... } | Constant | '(' Expr ')' | FuncExpr
     # | Tuple | NamedTuple | Collection | Set
     # | '__source__' | '__subject__'
@@ -1399,6 +1420,7 @@ class BaseAtomicExpr(Nonterm):
 
 
 class Expr(Nonterm):
+    val: qlast.Expr
     # BaseAtomicExpr
     # Path | Expr { ... }
 
@@ -1722,10 +1744,12 @@ class OptExprList(Nonterm):
 
 class ExprList(ListNonterm, element=GenExpr, separator=tokens.T_COMMA,
                allow_trailing_separator=True):
-    pass
+    val: list[qlast.Expr]
 
 
 class Constant(Nonterm):
+    val: qlast.Expr
+
     # PARAMETER
     # | BaseNumberConstant
     # | BaseStringConstant
@@ -1804,6 +1828,8 @@ class StringInterpolation(Nonterm):
 
 
 class BaseNumberConstant(Nonterm):
+    val: qlast.Constant
+
     def reduce_ICONST(self, *kids):
         self.val = qlast.Constant(
             value=kids[0].val, kind=qlast.ConstantKind.INTEGER
@@ -1826,18 +1852,22 @@ class BaseNumberConstant(Nonterm):
 
 
 class BaseStringConstant(Nonterm):
+    val: qlast.Constant
 
     def reduce_SCONST(self, token):
         self.val = qlast.Constant.string(value=token.clean_value)
 
 
 class BaseBytesConstant(Nonterm):
+    val: qlast.BaseConstant
 
     def reduce_BCONST(self, bytes_tok):
         self.val = qlast.BytesConstant(value=bytes_tok.clean_value)
 
 
 class BaseBooleanConstant(Nonterm):
+    val: qlast.Constant
+
     def reduce_TRUE(self, *kids):
         self.val = qlast.Constant.boolean(True)
 

--- a/edb/edgeql/parser/grammar/start.py
+++ b/edb/edgeql/parser/grammar/start.py
@@ -43,6 +43,7 @@ from .config import *  # NOQA
 #   in parser.rs `fn get_token_kind`
 class EdgeQLGrammar(Nonterm):
     "%start"
+
     val: qlast.GrammarEntryPoint
 
     def reduce_STARTBLOCK_EdgeQLBlock_EOI(self, *kids):
@@ -65,14 +66,14 @@ class EdgeQLGrammar(Nonterm):
 
 
 class EdgeQLBlock(Nonterm):
-    val: list[qlast.Command]
+    val: qlast.Commands
 
     @parsing.inline(0)
-    def reduce_StatementBlock_OptSemicolons(self, _, _semicolon):
-        pass
+    def reduce_StatementBlock_OptSemicolons(self, s, _semicolon):
+        self.val = qlast.Commands(commands=s.val)
 
     def reduce_OptSemicolons(self, _semicolon):
-        self.val = []
+        self.val = qlast.Commands(commands=[])
 
 
 class SingleStatement(Nonterm):
@@ -105,7 +106,7 @@ class SingleStatement(Nonterm):
 class StatementBlock(
     parsing.ListNonterm, element=SingleStatement, separator=commondl.Semicolons
 ):
-    pass
+    val: list[qlast.Command]
 
 
 class SDLDocument(Nonterm):

--- a/edb/edgeql/parser/grammar/start.py
+++ b/edb/edgeql/parser/grammar/start.py
@@ -68,7 +68,6 @@ class EdgeQLGrammar(Nonterm):
 class EdgeQLBlock(Nonterm):
     val: qlast.Commands
 
-    @parsing.inline(0)
     def reduce_StatementBlock_OptSemicolons(self, s, _semicolon):
         self.val = qlast.Commands(commands=s.val)
 

--- a/edb/language_server/completion.py
+++ b/edb/language_server/completion.py
@@ -58,7 +58,7 @@ def get_completion(
     if can_be_ident:
         ql_ast = ls_parsing.parse_and_recover(document)
         ls.show_message_log(f'ql_ast = {ql_ast}')
-        if isinstance(ql_ast, list):
+        if isinstance(ql_ast, qlast.Commands):
             items = (
                 _get_completion_in_ql(ls, document, ql_ast, target.offset)
             ) + items
@@ -73,13 +73,13 @@ def get_completion(
 def _get_completion_in_ql(
     ls: ls_server.GelLanguageServer,
     document: pygls.workspace.TextDocument,
-    ql_stmts: list[qlast.Base],
+    ql_stmts: qlast.Commands,
     target: int,
 ) -> list[lsp_types.CompletionItem]:
     # replace the expr under the cursor with qlast.Cursor
-    if not ql_stmts:
+    if not ql_stmts.commands:
         return []
-    for ql_stmt in ql_stmts:
+    for ql_stmt in ql_stmts.commands:
         replaced = replace_by_source_position(ql_stmt, qlast.Cursor(), target)
         if replaced:
             break

--- a/edb/language_server/definition.py
+++ b/edb/language_server/definition.py
@@ -60,7 +60,7 @@ def get_definition(
                 return []
             ql_ast = ql_ast_res.ok
 
-            if isinstance(ql_ast, list):
+            if isinstance(ql_ast, qlast.Commands):
                 return (
                     _get_definition_in_ql(ls, document, ql_ast, position) or []
                 )
@@ -79,12 +79,12 @@ def get_definition(
 def _get_definition_in_ql(
     ls: ls_server.GelLanguageServer,
     document: pygls.workspace.TextDocument,
-    ql_ast: list[qlast.Base],
+    ql_ast: qlast.Commands,
     position: int,
 ) -> lsp_types.Location | None:
     # compile the whole doc
     # TODO: search ql ast before compiling all stmts
-    _, ir_stmts = ls_server.compile_ql(ls, document, ql_ast)
+    _, ir_stmts = ls_server.compile_ql(ls, document, ql_ast.commands)
 
     # find the ir node at the position
     node_path = None

--- a/edb/language_server/parsing.py
+++ b/edb/language_server/parsing.py
@@ -35,7 +35,7 @@ from . import utils as ls_utils
 
 def parse(
     doc: TextDocument,
-) -> Result[list[qlast.Base] | qlast.Schema, list[lsp_types.Diagnostic]]:
+) -> Result[qlast.Commands | qlast.Schema, list[lsp_types.Diagnostic]]:
     sdl = is_schema_file(doc.filename) if doc.filename else False
 
     start_t = qltokens.T_STARTSDLDOCUMENT if sdl else qltokens.T_STARTBLOCK
@@ -81,13 +81,13 @@ def parse(
     if sdl:
         assert isinstance(ast, qlast.Schema), ast
     else:
-        assert isinstance(ast, list), ast
+        assert isinstance(ast, qlast.Commands), ast
     return Result(ok=ast)
 
 
 def parse_and_recover(
     doc: TextDocument,
-) -> Optional[list[qlast.Base] | qlast.Schema]:
+) -> Optional[qlast.Commands | qlast.Schema]:
     sdl = is_schema_file(doc.filename) if doc.filename else False
 
     start_t = qltokens.T_STARTSDLDOCUMENT if sdl else qltokens.T_STARTBLOCK

--- a/edb/language_server/parsing.py
+++ b/edb/language_server/parsing.py
@@ -113,7 +113,7 @@ def parse_and_recover(
     if sdl:
         assert isinstance(ast, qlast.Schema), ast
     else:
-        assert isinstance(ast, list), ast
+        assert isinstance(ast, qlast.Commands), ast
 
     return ast
 

--- a/edb/language_server/schema.py
+++ b/edb/language_server/schema.py
@@ -209,7 +209,7 @@ def _parse_schema(
             if isinstance(res.ok, qlast.Schema):
                 sdl.declarations.extend(res.ok.declarations)
             else:
-                # TODO: complain that .esdl contains non-SDL syntax
+                # TODO: complain that .gel contains non-SDL syntax
                 pass
     ls.state.schema_sdl = sdl
     return diagnostics

--- a/edb/language_server/server.py
+++ b/edb/language_server/server.py
@@ -114,8 +114,8 @@ def document_updated(ls: GelLanguageServer, doc_uri: str, *, compile: bool):
                 diagnostic_set.extend(document, ast_res.err)
 
             # compile
-            if compile and isinstance(ast_res.ok, list):
-                diag, _ = compile_ql(ls, document, ast_res.ok)
+            if compile and isinstance(ast_res.ok, qlast.Commands):
+                diag, _ = compile_ql(ls, document, ast_res.ok.commands)
                 diagnostic_set.merge(diag)
         else:
             ls.show_message_log(f'Unknown file type: {doc_uri}')
@@ -130,7 +130,7 @@ def document_updated(ls: GelLanguageServer, doc_uri: str, *, compile: bool):
 def compile_ql(
     ls: GelLanguageServer,
     doc: pygls.workspace.TextDocument,
-    stmts: list[qlast.Base],
+    stmts: list[qlast.Command],
 ) -> tuple[ls_utils.DiagnosticsSet, list[irast.Statement]]:
     from . import schema as ls_schema
 

--- a/edb/schema/unknown_pointers.py
+++ b/edb/schema/unknown_pointers.py
@@ -181,6 +181,7 @@ class AlterUnknownPointer(
             else qlast.CreateConcreteLink
         )
         astnode = astnode.replace(__class__=astcls)
+        assert isinstance(astnode, qlast.DDLCommand)
         qlparser.append_module_aliases(astnode, context.modaliases)
         res = sd.compile_ddl(schema, astnode, context=context)
         assert isinstance(res, pointers.AlterPointer)

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1050,7 +1050,7 @@ class Compiler:
 
     def _reprocess_restore_config(
         self,
-        stmts: list[qlast.Base],
+        stmts: Iterable[qlast.Base],
     ) -> list[qlast.Base]:
         '''Do any rewrites to the restore script needed.
 
@@ -1183,8 +1183,8 @@ class Compiler:
 
         # The state serializer generated below is somehow inappropriate,
         # so it's simply ignored here and the I/O process will do it on its own
-        statements = edgeql.parse_block(ddl_source)
-        statements = self._reprocess_restore_config(statements)
+        commands = edgeql.parse_block(ddl_source)
+        statements = self._reprocess_restore_config(commands)
         units = _try_compile_ast(
             ctx=ctx, source=ddl_source, statements=statements
         ).units
@@ -2852,7 +2852,7 @@ def _try_compile(
 def _try_compile_ast(
     *,
     ctx: CompileContext,
-    statements: list[qlast.Base],
+    statements: Sequence[qlast.Base],
     source: edgeql.Source,
 ) -> dbstate.QueryUnitGroup:
     if ctx.is_testmode():

--- a/edb/tools/docs/eql.py
+++ b/edb/tools/docs/eql.py
@@ -765,15 +765,14 @@ class EQLFunctionDirective(BaseEQLDirective):
             return fullname
 
         from edb.edgeql import parser as edgeql_parser
-        from edb.edgeql.parser import grammar as edgeql_grammar
         from edb.edgeql import ast as ql_ast
         from edb.edgeql import codegen as ql_gen
         from edb.edgeql import qltypes
 
         try:
-            astnode = edgeql_parser.parse(
-                edgeql_grammar.tokens.T_STARTBLOCK,
-                f'create function {sig} using SQL function "xxx";')[0]
+            astnode = edgeql_parser.parse_block(
+                f'create function {sig} using SQL function "xxx";'
+            )[0]
         except Exception as ex:
             raise self.error(
                 f'could not parse function signature {sig!r}: '
@@ -842,13 +841,11 @@ class EQLConstraintDirective(BaseEQLDirective):
             return fullname
 
         from edb.edgeql import parser as edgeql_parser
-        from edb.edgeql.parser import grammar as edgeql_grammar
         from edb.edgeql import ast as ql_ast
         from edb.edgeql import codegen as ql_gen
 
         try:
-            astnode = edgeql_parser.parse(
-                edgeql_grammar.tokens.T_STARTBLOCK,
+            astnode = edgeql_parser.parse_block(
                 f'create abstract constraint {sig};'
             )[0]
         except Exception as ex:

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -871,7 +871,7 @@ aa';
         SELECT a = b = c;
         """
 
-    def test_edgeql_toplevel_if(self):
+    def test_edgeql_syntax_toplevel_if(self):
         """
         IF true THEN (SELECT Foo) ELSE (INSERT Foo);
         """


### PR DESCRIPTION
This PR is split off from the work to translate grammar from Python to Rust.

It:
- adds a few `val: qlast.X` annotations to grammar rules,
- creates a `qlast.Commands(commands: list[qlast.Command])`, which is returned by `parse_block(str) -> qlast.Commands` (before it was a `list[qlast.Command]`)