### PR TITLE
Fix ISE when computed global is introspected using GraphQL.

### DIFF
--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -245,3 +245,6 @@ function modifying_noop(x: str) -> str {
     using (x);
     volatility := 'Modifying';
 }
+
+global current_user_id: uuid;
+global current_user := (select User filter .id = global current_user_id);

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -4601,6 +4601,17 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                     },
                 )
 
+    def test_graphql_introspect_01(self):
+        # Issue 8814
+        # Check that schema introspection works with computed globals
+        self.graphql_query(r"""
+            query {
+                __schema {
+                    types { name }
+                }
+            }
+        """)
+
     def test_graphql_func_01(self):
         Q = r'''query { FuncTest { fstr } }'''
 


### PR DESCRIPTION
close #8814

Given the schema:
```
using extension graphql;

module default {
    global current_user_id: uuid;
    global current_user := (select User filter .id = global current_user_id);
    type User;
}
```

The graphql query `query { __schema { types { name } } }` would produce an ISE.