### PR TITLE
Fix a bad assert

### DIFF
--- a/edb/pgsql/metaschema.py
+++ b/edb/pgsql/metaschema.py
@@ -9661,9 +9661,9 @@ async def execute_sql_script(
         elif pl_func_line:
             point = ql_parser.offset_of_line(sql_text, pl_func_line)
             text = sql_text
-        assert text
 
         if point is not None:
+            assert text
             span = qlast.Span(
                 None, text, start=point, end=point, context_lines=30
             )


### PR DESCRIPTION
I was asserting a original source text was found,
but that is the case only when a span has been
found too.

Introduced in #7071
