### PR TITLE
Fix permission tests when asyncpg is not installed

### DIFF
--- a/tests/test_server_permissions.py
+++ b/tests/test_server_permissions.py
@@ -988,11 +988,6 @@ class TestServerPermissionsSQL(server_tb.SQLQueryTestCase):
     PARALLELISM_GRANULARITY = 'system'
     TRANSACTION_ISOLATION = False
 
-    try:
-        import asyncpg
-    except ImportError:
-        pass
-
     @staticmethod
     async def query_sql_values(
         conn: tconn.Connection, query: str, *args, **kwargs
@@ -1001,7 +996,7 @@ class TestServerPermissionsSQL(server_tb.SQLQueryTestCase):
         return [r.as_dict() for r in res]
 
     @staticmethod
-    async def sql_con_query_values(conn: asyncpg.Connection, query, *args):
+    async def sql_con_query_values(conn, query, *args):
         res = await conn.fetch(query, *args)
         return [list(r.values()) for r in res]
 


### PR DESCRIPTION
Followup for #8843

I've ended up just removing the type annotation. I don't know why it requires asyncpg to be installed just for the type annotation.

I did test that it works without asyncpg installed.