### PR TITLE
Add `std::identifier` annotations to abstract operators

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_07_09_00_01
+EDGEDB_CATALOG_VERSION = 2025_07_23_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/std/17-abstractops.edgeql
+++ b/edb/lib/std/17-abstractops.edgeql
@@ -22,25 +22,41 @@
 # for the benefit of generic expressions (e.g. in abstract constraints).
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`>=` (l: anytype, r: anytype) -> std::bool;
+std::`>=` (l: anytype, r: anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'ge';
+};
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`>` (l: anytype, r: anytype) -> std::bool;
+std::`>` (l: anytype, r: anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'gt';
+};
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`<=` (l: anytype, r: anytype) -> std::bool;
+std::`<=` (l: anytype, r: anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'le';
+};
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`<` (l: anytype, r: anytype) -> std::bool;
+std::`<` (l: anytype, r: anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'lt';
+};
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`=` (l: anytype, r: anytype) -> std::bool;
+std::`=` (l: anytype, r: anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'eq';
+};
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`?=` (l: OPTIONAL anytype, r: OPTIONAL anytype) -> std::bool;
+std::`?=` (l: OPTIONAL anytype, r: OPTIONAL anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_eq';
+};
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`!=` (l: anytype, r: anytype) -> std::bool;
+std::`!=` (l: anytype, r: anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'ne';
+};
 
 CREATE ABSTRACT INFIX OPERATOR
-std::`?!=` (l: OPTIONAL anytype, r: OPTIONAL anytype) -> std::bool;
+std::`?!=` (l: OPTIONAL anytype, r: OPTIONAL anytype) -> std::bool {
+    CREATE ANNOTATION std::identifier := 'coal_neq';
+};


### PR DESCRIPTION
These were overlooked and `std::identifier` is needed on all operqtors
for reflection purposes.
