### PR TITLE
Fix params with union types producing ISEs 

### DIFF
--- a/edb/edgeql/tracer.py
+++ b/edb/edgeql/tracer.py
@@ -811,7 +811,20 @@ def trace_Path(
                 tip = ctx.objects[aname]
 
             elif not step.module and step.name in ctx.params:
-                tip = _resolve_type_expr(ctx.params[step.name], ctx=ctx)
+                param_type = ctx.params[step.name]
+                if (
+                    isinstance(param_type, qlast.TypeName)
+                    and isinstance(param_type.maintype, qlast.PseudoObjectRef)
+                ):
+                    # Pretend pseudotypes (eg. `anytype`) have a fully
+                    # qualified name.
+                    refname = sn.QualName('std', param_type.maintype.name)
+                    ctx.refs.add(refname)
+
+                    tip = ctx.objects[refname]
+
+                else:
+                    tip = _resolve_type_expr(param_type, ctx=ctx)
 
             else:
                 refname = ctx.get_ref_name(step)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2150,6 +2150,13 @@ class TestSchema(tb.BaseSchemaLoadTest):
         self.assertIsNone(A_tf_d.maybe_get_ptr(schema, 'd_prop2'))
         A_tf_df.getptr(schema, s_name.UnqualName('df_prop'))
 
+    def test_schema_advanced_function_params(self):
+        """
+            type Foo { required value: int64 };
+            type Bar { required value: int64 };
+            function get_value(x: Foo | Bar) -> int64 using (x.value);
+        """
+
     def test_schema_ancestor_propagation_on_sdl_migration(self):
         schema = self.load_schema("""
             type A;


### PR DESCRIPTION
Related #8786

Previously, this schema would produce an error:
```
type Foo {
  required name: str;
}
type Bar {
  name: str;
}

function name(x: Foo | Bar) -> optional str using (x.name);
```