### PR TITLE
Support intersection and complex composite types in SDL parameters.

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -352,11 +352,16 @@ class TypeName(TypeExpr):
     dimensions: typing.Optional[list[int]] = None
 
 
+class TypeOpName(s_enum.StrEnum):
+    OR = '|'
+    AND = '&'
+
+
 class TypeOp(TypeExpr):
     __rust_box__ = {'left', 'right'}
 
     left: TypeExpr
-    op: str
+    op: TypeOpName
     right: TypeExpr
 
 

--- a/edb/edgeql/compiler/schemactx.py
+++ b/edb/edgeql/compiler/schemactx.py
@@ -444,7 +444,7 @@ def get_intersection_type[TypeT: s_types.Type](
 
     targets: Sequence[s_types.Type]
     targets = s_utils.simplify_intersection_types(ctx.env.schema, types)
-    ctx.env.schema, intersection = s_utils.ensure_intersection_type(
+    ctx.env.schema, intersection, _ = s_utils.ensure_intersection_type(
         ctx.env.schema, targets, transient=True
     )
 

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -216,13 +216,13 @@ def _ql_typeexpr_get_types(
             # "typeof" and is a list of object types anyway.
             if left_leaf and not left_types[0].is_object_type():
                 raise errors.UnsupportedFeatureError(
-                    f'cannot use type operator {ql_t.op!r} with non-object '
-                    f'type {left_types[0].get_displayname(ctx.env.schema)}',
+                    f"cannot use type operator '{ql_t.op}' with non-object "
+                    f"type {left_types[0].get_displayname(ctx.env.schema)}",
                     span=ql_t.left.span)
             if right_leaf and not right_types[0].is_object_type():
                 raise errors.UnsupportedFeatureError(
-                    f'cannot use type operator {ql_t.op!r} with non-object '
-                    f'type {right_types[0].get_displayname(ctx.env.schema)}',
+                    f"cannot use type operator '{ql_t.op}' with non-object "
+                    f"type {right_types[0].get_displayname(ctx.env.schema)}",
                     span=ql_t.right.span)
 
             # if an operand is either a single type or uses the same operator,

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -200,7 +200,7 @@ def _ql_typeexpr_get_types(
         return (None, True, [stype])
 
     elif isinstance(ql_t, qlast.TypeOp):
-        if ql_t.op in ['|', '&']:
+        if ql_t.op in [qlast.TypeOpName.OR, qlast.TypeOpName.AND]:
             (left_op, left_leaf, left_types) = (
                 _ql_typeexpr_get_types(ql_t.left, ctx=ctx)
             )

--- a/edb/edgeql/declarative.py
+++ b/edb/edgeql/declarative.py
@@ -1515,8 +1515,14 @@ def _resolve_type_expr(
 
     elif isinstance(texpr, qlast.TypeOp):
 
-        if texpr.op == '|':
+        if texpr.op == qlast.TypeOpName.OR:
             return qltracer.UnionType([
+                _resolve_type_expr(texpr.left, ctx=ctx),
+                _resolve_type_expr(texpr.right, ctx=ctx),
+            ])
+
+        if texpr.op == qlast.TypeOpName.AND:
+            return qltracer.IntersectionType([
                 _resolve_type_expr(texpr.left, ctx=ctx),
                 _resolve_type_expr(texpr.right, ctx=ctx),
             ])

--- a/edb/edgeql/parser/grammar/expressions.py
+++ b/edb/edgeql/parser/grammar/expressions.py
@@ -2264,12 +2264,18 @@ class NontrivialTypeExpr(Nonterm):
         pass
 
     def reduce_TypeExpr_PIPE_TypeExpr(self, *kids):
-        self.val = qlast.TypeOp(left=kids[0].val, op='|',
-                                right=kids[2].val)
+        self.val = qlast.TypeOp(
+            left=kids[0].val,
+            op=qlast.TypeOpName.OR,
+            right=kids[2].val,
+        )
 
     def reduce_TypeExpr_AMPER_TypeExpr(self, *kids):
-        self.val = qlast.TypeOp(left=kids[0].val, op='&',
-                                right=kids[2].val)
+        self.val = qlast.TypeOp(
+            left=kids[0].val,
+            op=qlast.TypeOpName.AND,
+            right=kids[2].val,
+        )
 
 
 # This is a type expression without angle brackets, so it
@@ -2308,12 +2314,18 @@ class FullTypeExpr(Nonterm):
         pass
 
     def reduce_FullTypeExpr_PIPE_FullTypeExpr(self, *kids):
-        self.val = qlast.TypeOp(left=kids[0].val, op='|',
-                                right=kids[2].val)
+        self.val = qlast.TypeOp(
+            left=kids[0].val,
+            op=qlast.TypeOpName.OR,
+            right=kids[2].val,
+        )
 
     def reduce_FullTypeExpr_AMPER_FullTypeExpr(self, *kids):
-        self.val = qlast.TypeOp(left=kids[0].val, op='&',
-                                right=kids[2].val)
+        self.val = qlast.TypeOp(
+            left=kids[0].val,
+            op=qlast.TypeOpName.AND,
+            right=kids[2].val,
+        )
 
 
 class Subtype(Nonterm):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -3700,6 +3700,14 @@ class CreateUnionType(
     pass
 
 
+class CreateIntersectionType(
+    MetaCommand,
+    adapts=s_types.CreateIntersectionType,
+    metaclass=CommandMeta,
+):
+    pass
+
+
 class ObjectTypeMetaCommand(AliasCapableMetaCommand, CompositeMetaCommand):
     def schedule_endpoint_delete_action_update(self, obj, schema, context):
         endpoint_delete_actions = context.get(

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2741,8 +2741,11 @@ class AlterScalarType(ScalarTypeMetaCommand, adapts=s_scalars.AlterScalarType):
         for prop, new_typ in props.items():
             try:
                 cmd.add(new_typ.as_create_delta(schema))
-            except errors.UnsupportedFeatureError:
-                pass
+            except NotImplementedError as e:
+                if e.args == ('unsupported typeshell',):
+                    pass
+                else:
+                    raise
 
             if prop.get_default(schema):
                 delta_alter, cmd_alter, _alter_context = prop.init_delta_branch(

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -412,7 +412,7 @@ def get_or_create_intersection_type(
     *,
     module: Optional[str] = None,
     transient: bool = False,
-) -> tuple[s_schema.Schema, ObjectType]:
+) -> tuple[s_schema.Schema, ObjectType, bool]:
 
     name = s_types.get_intersection_type_name(
         (c.get_name(schema) for c in components),
@@ -420,6 +420,7 @@ def get_or_create_intersection_type(
     )
 
     objtype = schema.get(name, default=None, type=ObjectType)
+    created = objtype is None
     if objtype is None:
         components = list(components)
 
@@ -463,7 +464,7 @@ def get_or_create_intersection_type(
                 schema = objtype.add_pointer(schema, ptr)
 
     assert isinstance(objtype, ObjectType)
-    return schema, objtype
+    return schema, objtype, created
 
 
 class ObjectTypeCommandContext(

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -1219,6 +1219,19 @@ class PointerCommandOrFragment[Pointer_T: Pointer](
             self.set_attribute_value('linkful', True)
 
         if inf_target_ref is not None:
+            if inf_target_ref.has_intersection():
+                raise errors.UnsupportedFeatureError(
+                    (
+                        f'unsupported type intersection in schema '
+                        f'{inf_target_ref.get_name(schema).name}'
+                    ),
+                    hint=(
+                        f'Type intersections are currently '
+                        f'unsupported as valid link targets.'
+                    ),
+                    span=self.span,
+                )
+
             span = self.get_attribute_span('target')
             self.set_attribute_value(
                 'target',

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3179,7 +3179,7 @@ def get_or_create_union_pointer(
             cardinality = qltypes.SchemaCardinality.Many
             break
 
-    required = all(component.get_required(schema) for component in components)
+    required = any(component.get_required(schema) for component in components)
     metacls = type(components[0])
     default_base_name = metacls.get_default_base_name()
     assert default_base_name is not None
@@ -3245,10 +3245,11 @@ def get_or_create_intersection_pointer(
     if len(components) == 1:
         return schema, components[0]
 
+    required = all(component.get_required(schema) for component in components)
     targets: Sequence[s_types.Type]
     targets = list(filter(None, [p.get_target(schema) for p in components]))
     targets = utils.simplify_intersection_types(schema, targets)
-    schema, target = utils.ensure_intersection_type(
+    schema, target, _ = utils.ensure_intersection_type(
         schema, targets, module=modname)
 
     cardinality = qltypes.SchemaCardinality.One
@@ -3270,6 +3271,7 @@ def get_or_create_intersection_pointer(
         attrs={
             'intersection_of': so.ObjectSet.create(schema, components),
             'cardinality': cardinality,
+            'required': required,
         },
         transient=transient,
     )

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -3192,7 +3192,7 @@ def get_or_create_union_pointer(
             cardinality = qltypes.SchemaCardinality.Many
             break
 
-    required = any(component.get_required(schema) for component in components)
+    required = all(component.get_required(schema) for component in components)
     metacls = type(components[0])
     default_base_name = metacls.get_default_base_name()
     assert default_base_name is not None
@@ -3258,17 +3258,17 @@ def get_or_create_intersection_pointer(
     if len(components) == 1:
         return schema, components[0]
 
-    required = all(component.get_required(schema) for component in components)
+    required = any(component.get_required(schema) for component in components)
     targets: Sequence[s_types.Type]
     targets = list(filter(None, [p.get_target(schema) for p in components]))
     targets = utils.simplify_intersection_types(schema, targets)
     schema, target, _ = utils.ensure_intersection_type(
         schema, targets, module=modname)
 
-    cardinality = qltypes.SchemaCardinality.One
+    cardinality = qltypes.SchemaCardinality.Many
     for component in components:
-        if component.get_cardinality(schema) is qltypes.SchemaCardinality.Many:
-            cardinality = qltypes.SchemaCardinality.Many
+        if component.get_cardinality(schema) is qltypes.SchemaCardinality.One:
+            cardinality = qltypes.SchemaCardinality.One
             break
 
     metacls = type(components[0])

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -636,12 +636,10 @@ class TypeShell(so.ObjectShell[TypeT_co]):
         view_name: Optional[s_name.QualName] = None,
         attrs: Optional[dict[str, Any]] = None,
     ) -> sd.Command:
-        raise errors.UnsupportedFeatureError(
-            f'unsupported type intersection in schema {str(view_name)}',
-            hint=f'Type intersections are currently '
-                 f'unsupported as valid link targets.',
-            span=self.span,
-        )
+        raise NotImplementedError('unsupported typeshell')
+
+    def has_intersection(self) -> bool:
+        return False
 
 
 class TypeExprShell(TypeShell[TypeT_co]):
@@ -674,6 +672,12 @@ class TypeExprShell(TypeShell[TypeT_co]):
         schema: s_schema.Schema,
     ) -> tuple[TypeShell[TypeT_co], ...]:
         return self.components
+
+    def has_intersection(self) -> bool:
+        return any(
+            c.has_intersection()
+            for c in self.components
+        )
 
 
 class UnionTypeShell(TypeExprShell[TypeT_co]):
@@ -1038,6 +1042,9 @@ class IntersectionTypeShell(TypeExprShell[TypeT_co]):
         cmd.set_attribute_value('components', tuple(self.components))
         cmd.set_attribute_value('span', self.span)
         return cmd
+
+    def has_intersection(self) -> bool:
+        return True
 
 
 _collection_impls: dict[str, type[Collection]] = {}

--- a/tests/schemas/cards_ir_inference.esdl
+++ b/tests/schemas/cards_ir_inference.esdl
@@ -165,3 +165,16 @@ type Named2Sub extending Named2;
 global Alice := (select User filter .name = 'Alice');
 
 permission GameAdmin;
+
+type TypeExprA {
+    val: str;
+};
+type TypeExprB {
+    required val: str;
+};
+type TypeExprC {
+    multi val: str;
+};
+type TypeExprD {
+    required multi val: str;
+};

--- a/tests/test_edgeql_ir_card_inference.py
+++ b/tests/test_edgeql_ir_card_inference.py
@@ -1349,3 +1349,103 @@ class TestEdgeQLCardinalityInference(tb.BaseEdgeQLCompilerTest):
 % OK %
         ONE
         """
+
+    def test_edgeql_ir_card_inference_158(self):
+        """
+        with TypeExpr := Object[is TypeExprA | TypeExprB]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        AT_MOST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_159(self):
+        """
+        with TypeExpr := Object[is TypeExprA | TypeExprC]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_160(self):
+        """
+        with TypeExpr := Object[is TypeExprA | TypeExprD]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_161(self):
+        """
+        with TypeExpr := Object[is TypeExprB | TypeExprC]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_162(self):
+        """
+        with TypeExpr := Object[is TypeExprB | TypeExprD]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        AT_LEAST_ONE
+        """
+
+    def test_edgeql_ir_card_inference_163(self):
+        """
+        with TypeExpr := Object[is TypeExprC | TypeExprD]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        MANY
+        """
+
+    def test_edgeql_ir_card_inference_164(self):
+        """
+        with TypeExpr := Object[is TypeExprA & TypeExprB]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        ONE
+        """
+
+    @tb.must_fail(errors.SchemaError, "different cardinality")
+    def test_edgeql_ir_card_inference_165(self):
+        """
+        with TypeExpr := Object[is TypeExprA & TypeExprC]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        AT_MOST_ONE
+        """
+
+    @tb.must_fail(errors.SchemaError, "different cardinality")
+    def test_edgeql_ir_card_inference_166(self):
+        """
+        with TypeExpr := Object[is TypeExprA & TypeExprD]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        ONE
+        """
+
+    @tb.must_fail(errors.SchemaError, "different cardinality")
+    def test_edgeql_ir_card_inference_167(self):
+        """
+        with TypeExpr := Object[is TypeExprB & TypeExprC]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        ONE
+        """
+
+    @tb.must_fail(errors.SchemaError, "different cardinality")
+    def test_edgeql_ir_card_inference_168(self):
+        """
+        with TypeExpr := Object[is TypeExprB & TypeExprD]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        ONE
+        """
+
+    def test_edgeql_ir_card_inference_169(self):
+        """
+        with TypeExpr := Object[is TypeExprC & TypeExprD]
+        select assert_exists(assert_single(TypeExpr)).val
+% OK %
+        AT_LEAST_ONE
+        """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2150,11 +2150,54 @@ class TestSchema(tb.BaseSchemaLoadTest):
         self.assertIsNone(A_tf_d.maybe_get_ptr(schema, 'd_prop2'))
         A_tf_df.getptr(schema, s_name.UnqualName('df_prop'))
 
-    def test_schema_advanced_function_params(self):
+    def test_schema_advanced_function_params_01(self):
         """
-            type Foo { required value: int64 };
-            type Bar { required value: int64 };
-            function get_value(x: Foo | Bar) -> int64 using (x.value);
+            type A { required value: int64 };
+            type B { required value: int64 };
+            function get_value(x: A | B) -> int64 using (x.value);
+        """
+
+    def test_schema_advanced_function_params_02(self):
+        """
+            type A { required value: int64 };
+            type B { required value: int64 };
+            function get_value(x: A & B) -> int64 using (x.value);
+        """
+
+    def test_schema_advanced_function_params_03(self):
+        """
+            type A { required value: int64 };
+            type B { required value: int64 };
+            type C { required value: int64 };
+            type D { required value: int64 };
+            function get_value(x: (A | B) | (C | D)) -> int64 using (x.value);
+        """
+
+    def test_schema_advanced_function_params_04(self):
+        """
+            type A { required value: int64 };
+            type B { required value: int64 };
+            type C { required value: int64 };
+            type D { required value: int64 };
+            function get_value(x: (A & B) & (C & D)) -> int64 using (x.value);
+        """
+
+    def test_schema_advanced_function_params_05(self):
+        """
+            type A { required value: int64 };
+            type B { required value: int64 };
+            type C { required value: int64 };
+            type D { required value: int64 };
+            function get_value(x: (A & B) | (C & D)) -> int64 using (x.value);
+        """
+
+    def test_schema_advanced_function_params_06(self):
+        """
+            type A { required value: int64 };
+            type B { required value: int64 };
+            type C { required value: int64 };
+            type D { required value: int64 };
+            function get_value(x: (A | B) & (C | D)) -> int64 using (x.value);
         """
 
     def test_schema_ancestor_propagation_on_sdl_migration(self):


### PR DESCRIPTION
close #8786

Allows SDL such as:
```
type A { required value: str };
type B { required value: str };
type C { required value: str };
function get_value(x: A | (B & C)) -> int64 using (x.value);
```

----

This expands on previous work to support intersection types. Previously, things such as `CreateIntersectionType` were not included, with the assumption that type intersections would not be available in the schema.

Things done in this PR:
- Add `StrEnum` for `qlast.TypeOp`
- Add `IntersectionType` for tracing
- Ensure that `required` is set correctly on intersected pointers
- For `UnionTypeShell.as_create_delta`, ensure that component type shells are created as prerequisites (same for `IntersectionTypeShell`)