### PR TITLE
Add permissions to sys types and functions.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_07_23_00_00
+EDGEDB_CATALOG_VERSION = 2025_07_24_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -465,10 +465,21 @@ sys::approximate_count(
     set required_permissions := { sys::perm::superuser };
 };
 
-# Add permissions to std.
+# Add permissions to schema and std.
 
-# The std module is populated before sys permissions so we need to
+# These modules are populated before sys permissions so we need to
 # add these restrictions here.
+
+ALTER TYPE schema::Permission {
+    CREATE ACCESS POLICY ap_read allow select using (
+        global sys::perm::superuser
+    );
+};
+ALTER TYPE schema::Migration {
+    CREATE ACCESS POLICY ap_read allow select using (
+        global sys::perm::ddl
+    );
+};
 
 ALTER FUNCTION std::sequence_reset(
     seq: schema::ScalarType,

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -20,6 +20,14 @@
 CREATE MODULE sys;
 
 
+CREATE MODULE sys::perm;
+CREATE PERMISSION sys::perm::superuser;
+CREATE PERMISSION sys::perm::data_modification;
+CREATE PERMISSION sys::perm::ddl;
+CREATE PERMISSION sys::perm::branch_config;
+CREATE PERMISSION sys::perm::sql_session_config;
+
+
 CREATE SCALAR TYPE sys::TransactionIsolation
     EXTENDING enum<RepeatableRead, Serializable>;
 
@@ -119,6 +127,10 @@ CREATE TYPE sys::Role EXTENDING
     CREATE PROPERTY password -> std::str;
     CREATE MULTI PROPERTY permissions -> std::str;
     CREATE MULTI PROPERTY branches -> std::str;
+
+    CREATE ACCESS POLICY ap_read allow select using (
+        global sys::perm::superuser
+    );
 };
 
 
@@ -239,6 +251,10 @@ CREATE TYPE sys::QueryStats EXTENDING sys::ExternalObject {
             ++ "for this query (fields `min_plan_time`, `max_plan_time`, "
             ++ "`min_exec_time` and `max_exec_time`).";
     };
+
+    CREATE ACCESS POLICY ap_read allow select using (
+        global sys::perm::superuser
+    );
 };
 
 
@@ -263,6 +279,7 @@ sys::reset_query_stats(
         ++ 'corresponding reset was actually performed.';
     SET volatility := 'Volatile';
     USING SQL FUNCTION 'edgedb.reset_query_stats';
+    set required_permissions := { sys::perm::superuser };
 };
 
 
@@ -384,6 +401,7 @@ sys::_describe_roles_as_ddl() -> str
     SET volatility := 'Stable';
     SET internal := true;
     USING SQL FUNCTION 'edgedb._describe_roles_as_ddl';
+    set required_permissions := { sys::perm::superuser };
 };
 
 
@@ -395,6 +413,7 @@ sys::_get_all_role_memberships(r: uuid) -> array<uuid>
     SET internal := true;
     USING SQL FUNCTION 'edgedb._all_role_memberships';
     set impl_is_strict := false;
+    set required_permissions := { sys::perm::superuser };
 };
 
 
@@ -443,20 +462,14 @@ sys::approximate_count(
     SET volatility := 'Stable';
     USING SQL FUNCTION 'edgedb.approximate_count';
     set impl_is_strict := false;
+    set required_permissions := { sys::perm::superuser };
 };
-
-
-CREATE MODULE sys::perm;
-CREATE PERMISSION sys::perm::superuser;
-CREATE PERMISSION sys::perm::data_modification;
-CREATE PERMISSION sys::perm::ddl;
-CREATE PERMISSION sys::perm::branch_config;
-CREATE PERMISSION sys::perm::sql_session_config;
 
 # Add permissions to std.
 
 # The std module is populated before sys permissions so we need to
 # add these restrictions here.
+
 ALTER FUNCTION std::sequence_reset(
     seq: schema::ScalarType,
     value: std::int64,

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2605,7 +2605,9 @@ def _compile_dispatch_ql(
     elif isinstance(ql, qlast.DDLCommand):
         query = ddl.compile_and_apply_ddl_stmt(ctx, ql, source=source)
         capability = enums.Capability.DDL
-        if isinstance(ql, qlast.GlobalObjectCommand):
+        if isinstance(
+            ql, (qlast.GlobalObjectCommand, qlast.PermissionCommand)
+        ):
             capability |= enums.Capability.GLOBAL_DDL
 
         return (query, capability)


### PR DESCRIPTION
related #8177


Create the following access policies and function requirements.

In `sys`
- `TYPE sys::Role`
  - `ACCESS POLICY ap_read ALLOW select USING (global sys::perm::superuser);`
- `FUNCTION sys::_describe_roles_as_ddl`
  - ` required_permissions := sys::perm::ddl`
- `FUNCTION sys::_get_all_role_memberships`
  - ` required_permissions := sys::perm::ddl`
- `TYPE sys::QueryStats`
  - `ACCESS POLICY ap_read ALLOW select USING (global sys::perm::superuser);`
- `FUNCTION sys::reset_query_stats`
  - ` required_permissions := sys::perm::ddl`

In `schema`
- `Type schema::Permission`
  - `ACCESS POLICY ap_read ALLOW select USING (global sys::perm::superuser);`
- `Type schema::Migration`
  - `ACCESS POLICY ap_read ALLOW select USING (global sys::perm::ddl);`
