### PR TITLE
Defer loading cookies until needed in auth ext + return better error message

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -138,6 +138,14 @@ class Router:
         )
 
         try:
+            try:
+                request.load_cookies()
+            except http.cookies.CookieError as ex:
+                raise errors.InvalidData(
+                    f'invalid cookies header: {ex}, '
+                    f'try clearing cookies and trying again'
+                )
+
             match args:
                 # PKCE token exchange route
                 case ("token",):

--- a/edb/server/protocol/protocol.pxd
+++ b/edb/server/protocol/protocol.pxd
@@ -35,6 +35,7 @@ cdef class HttpRequest:
         public bytes authorization
         public object params
         public object forwarded
+        public bytes cookie_header
         public object cookies
 
 

--- a/edb/server/protocol/protocol.pyi
+++ b/edb/server/protocol/protocol.pyi
@@ -40,6 +40,9 @@ class HttpRequest:
     forwarded: dict[bytes, bytes]
     cookies: http.cookies.SimpleCookie
 
+    def load_cookies(self) -> None:
+        ...
+
 class HttpResponse:
     status: http.HTTPStatus
     close_connection: bool

--- a/edb/server/protocol/protocol.pyx
+++ b/edb/server/protocol/protocol.pyx
@@ -80,7 +80,11 @@ cdef class HttpRequest:
         self.authorization = b''
         self.content_type = b''
         self.forwarded = {}
+        self.cookie_header = b''
         self.cookies = http.cookies.SimpleCookie()
+
+    def load_cookies(self):
+        self.cookies.load(self.cookie_header.decode('ascii'))
 
 
 cdef class HttpResponse:
@@ -264,7 +268,7 @@ cdef class HttpProtocol:
             forwarded_key = name[len(b'x-forwarded-'):]
             self.current_request.forwarded[forwarded_key] = value
         elif name == b'cookie':
-            self.current_request.cookies.load(value.decode('ascii'))
+            self.current_request.cookie_header = value
 
     def on_body(self, body: bytes):
         self.current_request.body += body


### PR DESCRIPTION
If there are invalid cookies in the request to any of the http endpoints, the server returns a not very helpful `HttpParserCallbackError: User callback error` error message.

As only the auth ext endpoints actually read the cookies, defer parsing the cookie header until the request is being handled by the auth ext, and return a better error message in the case of a `CookieError`.