### PR TITLE
Support graphql over the binary protocol

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -303,6 +303,23 @@ class Constant(BaseConstant):
     def integer(cls, i: int) -> Constant:
         return Constant(kind=ConstantKind.INTEGER, value=str(i))
 
+    @classmethod
+    def float(cls, f: float) -> Constant:
+        return Constant(kind=ConstantKind.FLOAT, value=str(f))
+
+    @classmethod
+    def make(cls, n: object) -> Constant:
+        if isinstance(n, str):
+            return cls.string(n)
+        elif isinstance(n, bool):
+            return cls.boolean(n)
+        elif isinstance(n, int):
+            return cls.integer(n)
+        elif isinstance(n, float):
+            return cls.float(n)
+        else:
+            raise AssertionError('unsupported constant type')
+
 
 class ConstantKind(s_enum.StrEnum):
     STRING = 'STRING'

--- a/edb/graphql/compiler.py
+++ b/edb/graphql/compiler.py
@@ -54,6 +54,7 @@ def compile_graphql(
     substitutions: Optional[dict[str, tuple[str, int, int]]],
     operation_name: Optional[str] = None,
     variables: Optional[Mapping[str, object]] = None,
+    native_input: bool = False,
 ) -> graphql.TranspiledOperation:
     if tokens is None:
         ast = graphql.parse_text(gql)
@@ -68,4 +69,5 @@ def compile_graphql(
         variables=variables,
         substitutions=substitutions,
         operation_name=operation_name,
+        native_input=native_input,
     )

--- a/edb/graphql/extension.pyx
+++ b/edb/graphql/extension.pyx
@@ -60,6 +60,12 @@ _USER_ERRORS = (
     _graphql_rewrite.NotFoundError,
 )
 
+# key_vars tracks which variables are actually needed for evaluation,
+# since the compiler depends on some
+
+# redirect accounts for the fact that we actually don't always know
+# which the relevant variables are until after compiling
+
 @cython.final
 cdef class CacheRedirect:
     cdef public list key_vars  # List[str],  must be sorted

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -2017,8 +2017,6 @@ def translate_ast(
     if variables is None:
         variables = {}
 
-    # variables = {}
-
     validation_errors = convert_errors(
         graphql.validate(gqlcore.graphql_schema, document_ast),
         substitutions=substitutions)

--- a/edb/graphql/translator.py
+++ b/edb/graphql/translator.py
@@ -98,6 +98,8 @@ class GraphQLTranslatorContext:
         query,
         document_ast,
         operation_name,
+        native_input,
+        parse_only_mode,
     ):
         self.variables = variables
         self.fragments = {}
@@ -111,6 +113,8 @@ class GraphQLTranslatorContext:
         self.query = query
         self.document_ast = document_ast
         self.operation_name = operation_name
+        self.native_input = native_input
+        self.parse_only_mode = parse_only_mode
 
         # only used inside ObjectFieldNode
         self.base_expr = None
@@ -170,9 +174,22 @@ class BookkeepDict(dict):
         self.update(values)
         self.touched = set()
 
+    def __bool__(self):
+        # HACK! And kind of wrong!
+        # But this keeps this from getting replaced by code in graphql-core
+        # that does "raw_variable_values or {}"...
+        return True
+
     def __getitem__(self, key):
         self.touched.add(key)
         return super().__getitem__(key)
+
+    def __contains__(self, key):
+        self.touched.add(key)
+        return super().__contains__(key)
+
+    def keys(self):
+        raise NotImplementedError()
 
     def values(self):
         raise NotImplementedError()
@@ -285,11 +302,25 @@ class GraphQLTranslator:
                     variable_values=vars)
                 for var_name in vars.touched:
                     var = self._context.vars.get(var_name)
+                    # TODO: Why do we track this twice?
                     self._context.vars[var_name] = var._replace(critical=True)
+                    operation.critvars[var_name] = (
+                        self._context.vars[var_name].val
+                    )
 
                 if result.errors:
                     err = result.errors[0]
-                    if isinstance(err, graphql.GraphQLError):
+
+                    if (
+                        self._context.parse_only_mode
+                        and all(
+                            'was not provided' in str(e) for e in result.errors
+                        )
+                    ):
+                        # Don't worry about it.
+                        # And explain why!
+                        assert vars.touched
+                    elif isinstance(err, graphql.GraphQLError):
                         err_loc = (err.locations[0].line,
                                    err.locations[0].column)
                         raise g_errors.GraphQLCoreError(
@@ -298,11 +329,26 @@ class GraphQLTranslator:
                     else:
                         raise err
 
-                name = el.expr.steps[0].name
-                el.compexpr.args[0] = qlast.Constant.string(
-                    json.dumps(result.data[name]))
-                for var in vars.touched:
-                    operation.critvars[var] = self._context.vars[var].val
+                    expr = qlast.FunctionCall(
+                        func='assert_exists',
+                        args=[
+                            qlast.TypeCast(
+                                type=qlast.TypeName(
+                                    maintype=qlast.ObjectRef(name='str')
+                                ),
+                                expr=qlast.Set(elements=[]),
+                            ),
+                        ],
+                        kwargs=dict(message=qlast.Constant.string(
+                            "SERVER BUG: error with graphql introspection"
+                        )),
+                    )
+
+                else:
+                    name = el.expr.steps[0].name
+                    expr = qlast.Constant.string(json.dumps(result.data[name]))
+
+                el.compexpr.args[0] = expr
 
         return translated
 
@@ -408,7 +454,13 @@ class GraphQLTranslator:
 
                 if isinstance(cond, gql_ast.VariableNode):
                     varname = cond.name.value
-                    value = self._context.vars[varname].val
+                    var = self._context.vars[varname]
+                    self._context.vars[varname] = var._replace(critical=True)
+
+                    if self._context.parse_only_mode:
+                        return True
+
+                    value = var.val
 
                     if value is None:
                         raise g_errors.GraphQLValidationError(
@@ -496,6 +548,13 @@ class GraphQLTranslator:
                 loc=self.get_loc(node))
 
         return top
+
+    def _maybe_get_current_type(self):
+        if self._context.path:
+            path = self._context.path[-1]
+            return path[-1].type
+        else:
+            return None
 
     def _get_parent_and_current_type(self):
         path = self._context.path[-1]
@@ -1663,7 +1722,9 @@ class GraphQLTranslator:
         return [Ordering(names=[], direction=direction, nulls=nulls)]
 
     def visit_VariableNode(self, node):
-        varname = node.name.value
+        return self._get_variable(node.name.value)
+
+    def _get_variable(self, varname):
         var = self._context.vars[varname]
         err_msg = (f"Only scalar input variables are allowed. "
                    f"Variable {varname!r} has non-scalar value.")
@@ -1671,17 +1732,16 @@ class GraphQLTranslator:
         vartype = var.defn.type
         optional = True
         # get the type of the value being inserted
-        _, target = self._get_parent_and_current_type()
+        target = self._maybe_get_current_type()
 
         if isinstance(vartype, gql_ast.NonNullTypeNode):
             vartype = vartype.type
             optional = False
 
         if self.is_list_type(vartype):
-            if target.is_multirange:
-                subtype = target.edb_base.get_subtypes(target.edb_schema)[0]
-                st_name = subtype.get_name(target.edb_schema)
-                castname = qlast.ObjectRef(name=str(st_name))
+            if target and target.is_multirange:
+                castname = qlast.ObjectRef(name='json')
+
             else:
                 # So far the only list allowed is a multirange
                 # representation.
@@ -1708,28 +1768,43 @@ class GraphQLTranslator:
 
         casttype = qlast.TypeName(maintype=castname)
 
-        # potentially this is an array
-        if self.is_list_type(vartype):
-            if target.is_multirange:
-                # Wrap the base type into range, the next step will wrap it into
-                # an array.
-                casttype = qlast.TypeName(
-                    maintype=qlast.ObjectRef(name='range'),
-                    subtypes=[casttype],
-                )
+        needs_coalesce = self._context.native_input and var.val is not None
+        optional = optional or needs_coalesce
 
-            casttype = qlast.TypeName(
-                maintype=qlast.ObjectRef(name='array'),
-                subtypes=[casttype]
-            )
-
-        return qlast.TypeCast(
+        val = qlast.TypeCast(
             type=casttype,
             expr=qlast.QueryParameter(name=varname),
             cardinality_mod=(
                 qlast.CardinalityModifier.Optional if optional else None
             ),
         )
+
+        # In HTTP mode, we rely on merging the dict of defaults with
+        # the dict of actual arguments. That would be a pain on the
+        # native protocol, so we inject coalesces instead.
+        #
+        # FIXME: This is actually a little dodgy, since the gel proto
+        # will require passing an explicit None, but in graphql that
+        # should result in null being passed and the default not
+        # used... But in our implementation, that fails, because
+        # the rewriter (I think?) is marking it required?
+        #
+        # Alright, actually for now we are rejecting it.
+        if needs_coalesce:
+            # val = qlast.BinOp(
+            #     left=val,
+            #     op='??',
+            #     # We have to cast because of enums
+            #     right=qlast.TypeCast(
+            #         type=casttype,
+            #         expr=qlast.Constant.make(var.val),
+            #     ),
+            # )
+            raise errors.UnsupportedFeatureError(
+                'Default variables are not supported on the gel protocol'
+            )
+
+        return val
 
     def visit_StringValueNode(self, node):
         return qlast.Constant.string(node.value)
@@ -1930,10 +2005,19 @@ def translate_ast(
     operation_name: Optional[str]=None,
     variables: Optional[Mapping[str, Any]]=None,
     substitutions: Optional[dict[str, tuple[str, int, int]]],
+    native_input: bool = False,
 ) -> TranspiledOperation:
+
+    # If no variables have been provided, and we are in native
+    # protocol mode, that means we need to be tolerant of critical
+    # variables not having values. We'll report out which ones
+    # existed, and then recompile with the variables present.
+    parse_only_mode = native_input and variables is None
 
     if variables is None:
         variables = {}
+
+    # variables = {}
 
     validation_errors = convert_errors(
         graphql.validate(gqlcore.graphql_schema, document_ast),
@@ -1952,11 +2036,17 @@ def translate_ast(
             raise err
 
     context = GraphQLTranslatorContext(
-        gqlcore=gqlcore, query=None,
-        variables=variables, document_ast=document_ast,
-        operation_name=operation_name)
+        gqlcore=gqlcore,
+        query=None,
+        variables=variables,
+        document_ast=document_ast,
+        operation_name=operation_name,
+        native_input=native_input,
+        parse_only_mode=parse_only_mode,
+    )
 
-    edge_forest_map = GraphQLTranslator(context=context).visit(document_ast)
+    translator = GraphQLTranslator(context=context)
+    edge_forest_map = translator.visit(document_ast)
 
     if debug.flags.graphql_compile:
         for opname, op in sorted(edge_forest_map.items()):
@@ -1964,6 +2054,21 @@ def translate_ast(
             print(ql_codegen.generate_source(op.stmt))
 
     op = next(iter(edge_forest_map.values()))
+
+    if native_input and op.critvars:
+        op.stmt.orderby = [
+            qlast.SortExpr(
+                path=qlast.UnaryOp(
+                    op='EXISTS',
+                    operand=qlast.Set(
+                        elements=[
+                            translator._get_variable(vn)
+                            for vn in op.critvars
+                        ]
+                    )
+                )
+            )
+        ]
 
     # generate the specific result
     return TranspiledOperation(

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -220,6 +220,7 @@ class Param:
     array_type_id: Optional[uuid.UUID]
     outer_idx: Optional[int]
     sub_params: Optional[tuple[list[Optional[uuid.UUID]], tuple[Any, ...]]]
+    typename: str
 
 
 #############################
@@ -466,6 +467,8 @@ class QueryUnitGroup:
     tx_seq_id: int = 0
 
     force_non_normalized: bool = False
+
+    graphql_key_variables: Optional[list[str]] = None
 
     @property
     def units(self) -> list[QueryUnit]:

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -108,6 +108,7 @@ class InputLanguage(strenum.StrEnum):
     EDGEQL = 'EDGEQL'
     SQL = 'SQL'
     SQL_PARAMS = 'SQL_PARAMS'
+    GRAPHQL = 'GRAPHQL'
 
 
 def cardinality_from_ir_value(card: ir.Cardinality) -> Cardinality:

--- a/edb/server/compiler/rpc.pxd
+++ b/edb/server/compiler/rpc.pxd
@@ -55,6 +55,7 @@ cdef class CompilationRequest:
         object database_config
         object system_config
         object schema_version
+        readonly object key_params
 
         bytes serialized_cache
         object cache_key

--- a/edb/server/compiler/rpc.pyi
+++ b/edb/server/compiler/rpc.pyi
@@ -57,6 +57,7 @@ class CompilationRequest:
 
     modaliases: immutables.Map[str | None, str] | None
     session_config: immutables.Map[str, config.SettingValue] | None
+    key_params: typing.Mapping[str, object] | None = None
 
     def __init__(
         self,
@@ -79,22 +80,8 @@ class CompilationRequest:
         system_config: typing.Mapping[str, config.SettingValue] | None = None,
         role_name: str = defines.EDGEDB_SUPERUSER,
         branch_name: str = defines.EDGEDB_SUPERUSER_DB,
+        key_params: typing.Mapping[str, object] | None = None,
     ):
-        ...
-
-    def update(
-        self,
-        source: edgeql.Source,
-        protocol_version: defines.ProtocolVersion,
-        *,
-        output_format: enums.OutputFormat = enums.OutputFormat.BINARY,
-        input_format: enums.InputFormat = enums.InputFormat.BINARY,
-        expect_one: bool = False,
-        implicit_limit: int = 0,
-        inline_typeids: bool = False,
-        inline_typenames: bool = False,
-        inline_objectids: bool = True,
-    ) -> CompilationRequest:
         ...
 
     def set_modaliases(

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -418,8 +418,8 @@ class RollbackException(Exception):
 
 
 class RollbackChanges:
-    def __init__(self, test):
-        self._conn = test.con
+    def __init__(self, con):
+        self._conn = con
 
     async def __aenter__(self):
         self._tx = self._conn.transaction()
@@ -1134,7 +1134,7 @@ class ConnectedTestCase(ClusterTestCase):
                 pass
 
     def _run_and_rollback(self):
-        return RollbackChanges(self)
+        return RollbackChanges(self.con)
 
     async def _run_and_rollback_retrying(self):
         @contextlib.asynccontextmanager

--- a/tests/test_http_graphql_query.py
+++ b/tests/test_http_graphql_query.py
@@ -531,6 +531,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
 
     def test_graphql_functional_query_17(self):
         # Test unused & null variables
+        # (native proto doesn't allow these...)
         self.assert_graphql_query_result(
             r"""
                 query Person {
@@ -546,6 +547,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                 }],
             },
             variables={'name': None},
+            native_variables={},
         )
 
         self.assert_graphql_query_result(
@@ -2112,6 +2114,9 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
                     ... on User {
                         age
                     }
+                    ... on Setting {
+                        value
+                    }
                 }
             }
         """, {
@@ -3146,7 +3151,19 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             }
         """, {
             'User': [],
-        })
+            # HMMMM: Should we allow omiting?
+        }, native_variables=dict(val=None))
+
+        self.assert_graphql_query_result(r"""
+            query($val: Int = 5) {
+                User(filter: {score: {eq: $val}}) {
+                    id,
+                }
+            }
+        """, {
+            'User': [{}],
+            # HMMMM: Should we allow omiting?
+        }, native_variables=dict(val=None))
 
     def test_graphql_functional_variables_04(self):
         self.assert_graphql_query_result(r"""
@@ -3776,6 +3793,7 @@ class TestGraphQLFunctional(tb.GraphQLTestCase):
             },
             # JSON can only be passed as a variable.
             variables={"val": {"foo": [1, None, "bar"]}},
+            native_variables={"val": json.dumps({"foo": [1, None, "bar"]})},
         )
 
     def test_graphql_functional_variables_47(self):

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -332,6 +332,22 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             }
         })
 
+        self.assert_graphql_query_result(r"""
+            query {
+                __type(name: "Profile") {
+                    __typename
+                    name
+                    kind
+                }
+            }
+        """, {
+            "__type": {
+                "kind": "INTERFACE",
+                "name": "Profile",
+                "__typename": "__Type"
+            }
+        })
+
     def test_graphql_schema_type_02(self):
         self.assert_graphql_query_result(r"""
             query {
@@ -2278,6 +2294,39 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
             }
         })
 
+        self.assert_graphql_query_result(r"""
+            query($name: String!) {
+                __type(name: $name) {
+                    __typename
+                    name
+                    kind
+                    description
+                    enumValues {
+                        name
+                    }
+                }
+            }
+        """, {
+
+            "__type": {
+                "kind": "ENUM",
+                "name": "other__ColorEnum",
+                "__typename": "__Type",
+                "description": "RGB color enum",
+                "enumValues": [
+                    {
+                        "name": "RED"
+                    },
+                    {
+                        "name": "GREEN"
+                    },
+                    {
+                        "name": "BLUE"
+                    },
+                ]
+            }
+        }, variables={'name': 'other__ColorEnum'})
+
     def test_graphql_schema_type_15(self):
         self.assert_graphql_query_result(r"""
             query {
@@ -2907,7 +2956,7 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
         # Make sure that FreeObject is not reflected.
         result = self.graphql_query(r"""
             query {
-                __type(name: "FeeObject") {
+                __type(name: "FreeObject") {
                     name
                 }
                 __schema {


### PR DESCRIPTION
This is implemented by adding another language enum field, and then
using the same flow as edgeql and SQL.

We'll only expose the JSON output mode in clients for now, because the
binary one doesn't work right for queries that do things like
introspection or @include.

Handling things like introspection and @include is the only reason
that this PR isn't trivial: graphql introspection queries are
implemented by having the compiler call out to the graphql-core
implementation to execute the query, and then including the json
response in the output. Making this work when the query might depend
on a variable requires tracking "key variables" and including them in
the cache keys, and recompiling when they don't match.

We already did this in the graphql HTTP endpoint but now need to
support it in the main flow.

Two main caveats to follow-up on:
 * This first take doesn't support doing the query normalization to
   extract constants. I'll do that in a follow-up.
 * We don't support queries that have default values for parameters.
   This is because the gel bindings don't have a way to *not pass*
   a parameter. (They can pass None, but that's not the same thing!)
   Not sure the best thing to do here.

Mostly finishes #8831.
(I'll close that when we land this and open follow-ups.)