### PR TITLE
Exclude inherited cfg views from access policies.

### DIFF
--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -87,6 +87,20 @@ def is_cfg_view(
     )
 
 
+def is_excluded_cfg_view(
+    child: s_obj.Object,
+    *,
+    ancestor: s_obj.Object,
+    schema: s_schema.Schema,
+) -> bool:
+    """Used to exclude sys/cfg tables from non sys/cfg views for performance.
+
+    Also used by access policies to prevent including cfg views in
+    when expanding a non-cfg type's descendants (#8865).
+    """
+    return is_cfg_view(child, schema) and not is_cfg_view(ancestor, schema)
+
+
 def is_scalar(typeref: irast.TypeRef) -> bool:
     """Return True if *typeref* describes a scalar type."""
     return typeref.is_scalar

--- a/edb/pgsql/inheritance.py
+++ b/edb/pgsql/inheritance.py
@@ -74,9 +74,8 @@ def get_inheritance_view(
         # figure that out, do *something* so that DDL isn't
         # excruciatingly slow because of the cost of explicit id
         # checks. See #5168.
-        and (
-            not irtyputils.is_cfg_view(child, schema)
-            or irtyputils.is_cfg_view(obj, schema)
+        and not irtyputils.is_excluded_cfg_view(
+            child, ancestor=obj, schema=schema
         )
     ]
 


### PR DESCRIPTION
This prevents sys/cfg objects from showing up in schema object rewrites.

related #8177
