### PR TITLE
Remove all_objects from the issues schema

### DIFF
--- a/tests/schemas/issues.esdl
+++ b/tests/schemas/issues.esdl
@@ -170,7 +170,3 @@ function opt_test(tag: bool, x: optional int64) -> int64 using (x ?? -1);
 
 function opt_test(tag: int64, x: int64, y: optional int64) -> int64 using (y ?? -1);
 function opt_test(tag: bool, x: optional int64, y: optional int64) -> int64 using (y ?? -1);
-
-function all_objects() -> SET OF BaseObject {
-    USING (BaseObject)
-}

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -33,9 +33,6 @@ class TestEdgeQLPolicies(tb.DDLTestCase):
 
     SETUP = [
         '''
-            # Dropping all_objects() is no longer required for correctness,
-            # but it does still speed things up a lot.
-            drop function all_objects();
             create future warn_old_scoping;
         ''',
         os.path.join(os.path.dirname(__file__), 'schemas',

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -31,8 +31,17 @@ class TestEdgeQLSelect(tb.QueryTestCase):
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
-    SETUP = os.path.join(os.path.dirname(__file__), 'schemas',
-                         'issues_setup.edgeql')
+    SETUP = [
+        os.path.join(os.path.dirname(__file__), 'schemas',
+                     'issues_setup.edgeql'),
+        # Used by patch/upgrade testing
+        # We create it here to avoid some terrible slowdowns
+        '''
+        create function all_objects() -> SET OF BaseObject {
+            USING (BaseObject)
+        };
+        ''',
+    ]
 
     async def test_edgeql_select_unique_01(self):
         await self.assert_query_result(


### PR DESCRIPTION
It causes perf problems, and we just made it worse.
(There are some follow-ups to investigate here)