### PR TITLE
Fix bad HTTP cache response when cache expires and upstream is not modified

### DIFF
--- a/rust/gel-http/Cargo.toml
+++ b/rust/gel-http/Cargo.toml
@@ -22,7 +22,8 @@ eventsource-stream = "0.2.3"
 http-cache-semantics = { version = "2", features = [] }
 http = "1"
 http-body-util = "0.1.2"
-lru = "0.13"
+lru = "0.16"
+bytes = "1"
 
 # We want to use rustls to avoid setenv issues w/ OpenSSL and the system certs. As long
 # as we don't call `openssl_probe::*init*env*()` functions (functions that call setenv
@@ -37,10 +38,10 @@ lru = "0.13"
 # - stream: to support streaming responses
 # - rustls-tls-native-roots: to use the native root certificates (rather than WebPKI)
 reqwest = { version = "0.12", default-features = false, features = ["http2", "charset", "gzip", "deflate", "brotli", "stream", "rustls-tls-native-roots"] }
-futures = "0"
+futures = "0.3"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-rstest = "0.23"
+rstest = "0.26"
 
 [lib]

--- a/rust/gel-http/src/cache.rs
+++ b/rust/gel-http/src/cache.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use http::{HeaderMap, Method, Request, Response, Uri};
 use http_cache_semantics::{AfterResponse, BeforeRequest, CacheOptions, CachePolicy};
 use lru::LruCache;
@@ -7,14 +8,34 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum CacheBefore {
-    Request(http::Request<Vec<u8>>),
-    Response(http::Response<Vec<u8>>),
+    /// The cache is stale or missing, so we need to make a request. Note that CachedItem
+    /// may contain a stale cache item and must be returned in `after_request`.
+    Request(http::Request<Vec<u8>>, Cacheditem),
+    /// The cache is fresh, so we can return the response
+    Response(http::Response<Bytes>),
+}
+
+#[derive(Debug)]
+pub struct Cacheditem {
+    maybe_item: Option<(Arc<CachePolicy>, Bytes)>,
+}
+
+impl Cacheditem {
+    fn none() -> Self {
+        Self { maybe_item: None }
+    }
+
+    fn some(policy: Arc<CachePolicy>, body: Bytes) -> Self {
+        Self {
+            maybe_item: Some((policy, body)),
+        }
+    }
 }
 
 struct CacheItems<T> {
-    items: LruCache<Uri, (T, Vec<u8>)>,
+    items: LruCache<Uri, (T, Bytes)>,
     byte_size: usize,
     max_byte_size: usize,
 }
@@ -28,7 +49,7 @@ impl<T> CacheItems<T> {
         }
     }
 
-    fn insert(&mut self, uri: Uri, policy: T, body: Vec<u8>) {
+    fn insert(&mut self, uri: Uri, policy: T, body: Bytes) {
         let body_len = body.len();
         if let Some((_, old_body)) = self.items.push(uri, (policy, body)) {
             self.byte_size = self.byte_size.saturating_sub(old_body.1.len());
@@ -43,7 +64,7 @@ impl<T> CacheItems<T> {
         }
     }
 
-    fn get_mut(&mut self, uri: &Uri) -> Option<&mut (T, Vec<u8>)> {
+    fn get_mut(&mut self, uri: &Uri) -> Option<&mut (T, Bytes)> {
         self.items.get_mut(uri)
     }
 }
@@ -51,7 +72,7 @@ impl<T> CacheItems<T> {
 #[derive(Clone)]
 pub struct Cache {
     cache_options: CacheOptions,
-    cache: Arc<Mutex<CacheItems<CachePolicy>>>,
+    cache: Arc<Mutex<CacheItems<Arc<CachePolicy>>>>,
 }
 
 impl Cache {
@@ -76,9 +97,15 @@ impl Cache {
         let entry = cache.get_mut(url);
         if let Some((policy, body)) = entry {
             let state = policy.is_stale(SystemTime::now());
-            return Some((state, body.clone()));
+            // NOTE: inefficient, for testing only
+            return Some((state, body.to_vec()));
         }
         None
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.cache.lock().unwrap().items.clear();
     }
 
     pub fn before_request(
@@ -96,7 +123,7 @@ impl Cache {
 
         // Only cache GET requests
         if !allow_cache || method != Method::GET {
-            return CacheBefore::Request(req);
+            return CacheBefore::Request(req, Cacheditem::none());
         }
 
         let now = SystemTime::now();
@@ -108,14 +135,15 @@ impl Cache {
                     CacheBefore::Response(Response::from_parts(parts, body.clone()))
                 }
                 BeforeRequest::Stale { request, .. } => {
+                    // Stale response, return the cached item that we need to revalidate
                     *req.uri_mut() = request.uri;
                     *req.headers_mut() = request.headers;
                     *req.method_mut() = request.method;
-                    CacheBefore::Request(req)
+                    CacheBefore::Request(req, Cacheditem::some(policy.clone(), body.clone()))
                 }
             }
         } else {
-            CacheBefore::Request(req)
+            CacheBefore::Request(req, Cacheditem::none())
         }
     }
 
@@ -125,7 +153,8 @@ impl Cache {
         method: Method,
         uri: Uri,
         headers: HeaderMap,
-        res: &mut http::Response<Vec<u8>>,
+        res: &mut http::Response<Bytes>,
+        cached_item: Cacheditem,
     ) {
         // Only cache GET requests
         if !allow_cache || method != Method::GET {
@@ -134,39 +163,50 @@ impl Cache {
 
         let now = SystemTime::now();
         let mut cache = self.cache.lock().unwrap();
-        let entry = cache.get_mut(&uri);
 
         let mut req = Request::new(());
         *req.method_mut() = method;
         *req.uri_mut() = uri.clone();
         *req.headers_mut() = headers;
 
-        let mut resp = Response::new(vec![]);
-        *resp.status_mut() = res.status();
-        *resp.headers_mut() = res.headers().clone();
-
-        if let Some((policy, body)) = entry {
-            let parts = match policy.after_response(&req, &resp, now) {
+        if let Some((policy, body)) = cached_item.maybe_item {
+            let entry = cache.get_mut(&uri);
+            let parts = match policy.after_response(&req, res, now) {
                 AfterResponse::NotModified(new_policy, parts) => {
-                    // Not modified, return the cached response
-                    *policy = new_policy;
-                    *resp.body_mut() = body.clone();
+                    // Not modified, return the cached response and update the
+                    // policy and response body
+                    body.clone_into(res.body_mut());
+
+                    // TODO: Can new_policy.is_storable() be false?
+                    if let Some(entry) = entry {
+                        entry.0 = Arc::new(new_policy);
+                    } else {
+                        cache.insert(uri, Arc::new(new_policy), body);
+                    }
                     parts
                 }
                 AfterResponse::Modified(new_policy, parts) => {
-                    // Modified, update the cache
-                    *policy = new_policy;
-                    *body = res.body().clone();
+                    // Modified, update the cache, but not the body
+
+                    // TODO: Can new_policy.is_storable() be false?
+                    if let Some(entry) = entry {
+                        entry.0 = Arc::new(new_policy);
+                        res.body().clone_into(&mut entry.1);
+                    } else {
+                        cache.insert(uri, Arc::new(new_policy), res.body().clone());
+                    }
                     parts
                 }
             };
-            *resp.headers_mut() = parts.headers;
-            *resp.status_mut() = parts.status;
-            *resp.version_mut() = parts.version;
+            *res.headers_mut() = parts.headers;
+            *res.status_mut() = parts.status;
+            *res.version_mut() = parts.version;
+            *res.extensions_mut() = parts.extensions;
         } else {
-            let policy = CachePolicy::new_options(&req, &resp, now, self.cache_options);
+            // We had no cached item at the start, but we might have raced another
+            let policy = CachePolicy::new_options(&req, res, now, self.cache_options);
             if policy.is_storable() {
-                cache.insert(uri, policy, res.body().clone());
+                cache.insert(uri, Arc::new(policy), res.body().clone());
             }
         }
     }
@@ -187,22 +227,22 @@ mod tests {
         (method, uri, headers, body)
     }
 
-    fn cache_control(resp: &mut Response<Vec<u8>>, value: &str) {
+    fn cache_control<T>(resp: &mut Response<T>, value: &str) {
         resp.headers_mut().insert(
             HeaderName::from_static("cache-control"),
             HeaderValue::from_str(value).unwrap(),
         );
     }
 
-    fn etag(resp: &mut Response<Vec<u8>>, value: &str) {
+    fn etag<T>(resp: &mut Response<T>, value: &str) {
         resp.headers_mut().insert(
             HeaderName::from_static("etag"),
             HeaderValue::from_str(value).unwrap(),
         );
     }
 
-    fn response(status: StatusCode, body: &str) -> Response<Vec<u8>> {
-        let mut resp = Response::new(body.as_bytes().to_vec());
+    fn response(status: StatusCode, body: &str) -> Response<Bytes> {
+        let mut resp = Response::new(body.as_bytes().to_vec().into());
         *resp.status_mut() = status;
         resp
     }
@@ -213,21 +253,21 @@ mod tests {
         cache_items.insert(
             Uri::from_str("https://www.google.com").unwrap(),
             (),
-            vec![0; 1024 * 1024],
+            vec![0; 1024 * 1024].into(),
         );
         assert_eq!(cache_items.byte_size, 1024 * 1024);
         assert_eq!(cache_items.items.len(), 1);
         cache_items.insert(
             Uri::from_str("https://www.example.com").unwrap(),
             (),
-            vec![0; 1],
+            vec![0; 1].into(),
         );
         assert_eq!(cache_items.byte_size, 1);
         assert_eq!(cache_items.items.len(), 1);
         cache_items.insert(
             Uri::from_str("https://www.google.com").unwrap(),
             (),
-            vec![0; 1024 * 1024],
+            vec![0; 1024 * 1024].into(),
         );
         assert_eq!(cache_items.byte_size, 1024 * 1024);
         assert_eq!(cache_items.items.len(), 1);
@@ -240,7 +280,7 @@ mod tests {
             cache_items.insert(
                 Uri::from_str(&format!("https://www.example.com/{}", i)).unwrap(),
                 (),
-                vec![0; 10],
+                vec![0; 10].into(),
             );
         }
         assert_eq!(cache_items.byte_size, 1000);
@@ -252,9 +292,16 @@ mod tests {
         let cache = Cache::new();
         let (method, uri, headers, body) = get_google();
         let before = cache.before_request(true, &method, &uri, &headers, body);
-        assert!(matches!(before, CacheBefore::Request(_)));
+        let CacheBefore::Request(req, cached_item) = before else {
+            panic!("Expected a request {before:?}");
+        };
 
-        let mut resp = response(StatusCode::OK, "");
+        assert_eq!(req.method(), &method);
+        assert_eq!(req.uri(), &uri);
+        assert_eq!(req.headers(), &headers);
+        assert!(cached_item.maybe_item.is_none());
+
+        let mut resp = response(StatusCode::OK, "this is a response");
         cache_control(&mut resp, "max-age=3600");
         etag(&mut resp, "\"1234567890\"");
         cache.after_request(
@@ -263,6 +310,7 @@ mod tests {
             uri.clone(),
             headers.clone(),
             &mut resp,
+            cached_item,
         );
 
         let (method, uri, headers, body) = get_google();
@@ -272,6 +320,7 @@ mod tests {
             panic!("Expected a response {after:?}");
         };
         assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.body(), "this is a response".as_bytes());
         assert_eq!(
             resp.headers().get("etag"),
             Some(&HeaderValue::from_str("\"1234567890\"").unwrap())
@@ -285,9 +334,19 @@ mod tests {
     #[test]
     fn test_cache_not_modified() {
         let cache = Cache::new();
+
+        // First request, clean cache
+
         let (method, uri, headers, body) = get_google();
         let before = cache.before_request(true, &method, &uri, &headers, body);
-        assert!(matches!(before, CacheBefore::Request(_)));
+        let CacheBefore::Request(req, cached_item) = before else {
+            panic!("Expected a request {before:?}");
+        };
+
+        assert_eq!(req.method(), &method);
+        assert_eq!(req.uri(), &uri);
+        assert_eq!(req.headers(), &headers);
+        assert!(cached_item.maybe_item.is_none());
 
         let mut resp = response(StatusCode::OK, "contents!");
         cache_control(
@@ -301,15 +360,18 @@ mod tests {
             uri.clone(),
             headers.clone(),
             &mut resp,
+            cached_item,
         );
 
         let (state, body) = cache.get_cache_body(&uri).unwrap();
         assert!(state);
         assert_eq!(body, "contents!".as_bytes());
 
+        // Must-revalidate, so we need to revalidate the cache
+
         let (method, uri, headers, body) = get_google();
         let after = cache.before_request(true, &method, &uri, &headers, body);
-        let CacheBefore::Request(req) = after else {
+        let CacheBefore::Request(req, cached_item) = after else {
             panic!("Expected a request {after:?}");
         };
         assert_eq!(req.method(), &Method::GET);
@@ -331,7 +393,45 @@ mod tests {
             uri.clone(),
             headers.clone(),
             &mut resp,
+            cached_item,
         );
+
+        let (state, body) = cache.get_cache_body(&uri).unwrap();
+        assert!(state);
+        assert_eq!(body, "contents!".as_bytes());
+
+        // Test what happens when the cache evicts during the request
+
+        let (method, uri, headers, body) = get_google();
+        let after = cache.before_request(true, &method, &uri, &headers, body);
+        let CacheBefore::Request(req, cached_item) = after else {
+            panic!("Expected a request {after:?}");
+        };
+        assert_eq!(req.method(), &Method::GET);
+        assert_eq!(req.uri(), &uri);
+        assert_eq!(
+            req.headers().get("if-none-match"),
+            Some(&HeaderValue::from_str("\"1234567890\"").unwrap())
+        );
+
+        cache.clear();
+
+        let mut resp = response(StatusCode::NOT_MODIFIED, "");
+        cache_control(
+            &mut resp,
+            "max-age=0, must-revalidate, stale-while-revalidate=86400",
+        );
+        etag(&mut resp, "\"1234567890\"");
+        cache.after_request(
+            true,
+            method.clone(),
+            uri.clone(),
+            headers.clone(),
+            &mut resp,
+            cached_item,
+        );
+
+        assert_eq!(resp.body(), "contents!".as_bytes());
 
         let (state, body) = cache.get_cache_body(&uri).unwrap();
         assert!(state);

--- a/rust/gel-http/src/cache.rs
+++ b/rust/gel-http/src/cache.rs
@@ -86,7 +86,7 @@ impl Cache {
             },
             cache: Arc::new(Mutex::new(CacheItems::new(
                 NonZero::new(100).unwrap(),
-                1024 * 1024,
+                10 * 1024 * 1024,
             ))),
         }
     }


### PR DESCRIPTION
This fixes the issue in #8876 where the Google auth page would fail once per day. There was a race condition between cache expiry and re-validation: if the LRU cache holding the request body expired after the request was made but before the response was returned, the empty body of the "not modified" response was returned.

 
