### PR TITLE
Require an existing bootstrap cache for doing inplace-upgrade-prepare

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -1704,6 +1704,10 @@ async def _init_stdlib(
     tpldbdump, tpldbdump_inplace = None, None
     if tpldbdump_package:
         tpldbdump, tpldbdump_inplace = tpldbdump_package
+    else:
+        assert not args.inplace_upgrade_prepare, (
+            "Gel must have a valid bootstrap cache to use inplace upgrade"
+        )
 
     stdlib_was_none = stdlib is None
     if stdlib is None:
@@ -1750,9 +1754,8 @@ async def _init_stdlib(
         assert bootstrap_commands is not None
         block = dbops.PLTopBlock()
 
-        if not args.inplace_upgrade_prepare:
-            fixed_bootstrap_commands = metaschema.get_fixed_bootstrap_commands()
-            fixed_bootstrap_commands.generate(block)
+        fixed_bootstrap_commands = metaschema.get_fixed_bootstrap_commands()
+        fixed_bootstrap_commands.generate(block)
 
         bootstrap_commands.generate(block)
         await _execute_block(conn, block)
@@ -1822,10 +1825,6 @@ async def _init_stdlib(
                 stdlib.inplace_upgrade_scalar_text.encode('utf-8') +
                 cleanup_tpldbdump(tpldbdump_inplace)
             )
-
-            # XXX: BE SMARTER ABOUT THIS, DON'T DO ALL THAT WORK
-            if args.inplace_upgrade_prepare:
-                tpldbdump = None
 
             buildmeta.write_data_cache(
                 (tpldbdump, tpldbdump_inplace),

--- a/tests/inplace-testing/test-old.sh
+++ b/tests/inplace-testing/test-old.sh
@@ -25,6 +25,10 @@ DIR=$(realpath "$1")
 SERVER_INSTALL=$(realpath "$2")
 shift 2
 
+# Force bootstrapping of the server
+TMPDIR=$(mktemp -d)
+edb server --bootstrap-only --data-dir $TMPDIR/bootstrap || (rm -rf $TMPDIR && false)
+
 # Setup the test database
 (cd / && GEL_SERVER_SECURITY=insecure_dev_mode $SERVER_INSTALL/bin/python3  -m edb.tools --no-devmode inittestdb --tests-dir $SERVER_INSTALL/share/tests -k test_dump --data-dir "$DIR")
 

--- a/tests/inplace-testing/test-old.sh
+++ b/tests/inplace-testing/test-old.sh
@@ -21,7 +21,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-DIR=$(realpath "$1")
+DIR="$1"
+RDIR=$(realpath "$1")
 SERVER_INSTALL=$(realpath "$2")
 shift 2
 
@@ -30,7 +31,7 @@ TMPDIR=$(mktemp -d)
 edb server --bootstrap-only --data-dir $TMPDIR/bootstrap || (rm -rf $TMPDIR && false)
 
 # Setup the test database
-(cd / && GEL_SERVER_SECURITY=insecure_dev_mode $SERVER_INSTALL/bin/python3  -m edb.tools --no-devmode inittestdb --tests-dir $SERVER_INSTALL/share/tests -k test_dump --data-dir "$DIR")
+(cd / && GEL_SERVER_SECURITY=insecure_dev_mode $SERVER_INSTALL/bin/python3  -m edb.tools --no-devmode inittestdb --tests-dir $SERVER_INSTALL/share/tests -k test_dump --data-dir "$RDIR")
 
 
 if [ "$SAVE_TARBALLS" = 1 ]; then
@@ -38,8 +39,8 @@ if [ "$SAVE_TARBALLS" = 1 ]; then
 fi
 
 
-PORT=12346
-GEL_SERVER_SECURITY=insecure_dev_mode $SERVER_INSTALL/bin/gel-server --testmode -D "$DIR" -P $PORT &
+PORT=$(( $RANDOM + 2000 ))
+GEL_SERVER_SECURITY=insecure_dev_mode $SERVER_INSTALL/bin/gel-server --testmode -D "$RDIR" -P $PORT &
 SPID=$!
 stop_server() {
     kill $SPID

--- a/tests/inplace-testing/test.sh
+++ b/tests/inplace-testing/test.sh
@@ -76,6 +76,9 @@ EDGEDB_PORT=$PORT EDGEDB_CLIENT_TLS_SECURITY=insecure python3 tests/inplace-test
 # Upgrade to the new version
 patch -f -p1 < tests/inplace-testing/upgrade.patch
 make parsers
+# Force bootstrapping of the server
+TMPDIR=$(mktemp -d)
+edb server --bootstrap-only --data-dir $TMPDIR/bootstrap || (rm -rf $TMPDIR && false)
 
 # Get the DSN from the debug endpoint
 DSN=$(curl -s http://localhost:$PORT/server-info | jq -r '.pg_addr.dsn')
@@ -102,6 +105,9 @@ if [ "$ROLLBACK" = 1 ]; then
     stop_server
     patch -R -f -p1 < tests/inplace-testing/upgrade.patch
     make parsers
+    TMPDIR=$(mktemp -d)
+    edb server --bootstrap-only --data-dir $TMPDIR/bootstrap || (rm -rf $TMPDIR && false)
+
     edb test --data-dir "$DIR" --use-data-dir-dbs -v "$@"
     exit 0
 fi

--- a/tests/inplace-testing/test.sh
+++ b/tests/inplace-testing/test.sh
@@ -42,7 +42,7 @@ if [ "$SAVE_TARBALLS" = 1 ]; then
 fi
 
 
-PORT=12346
+PORT=$(( $RANDOM + 2000 ))
 edb server -D "$DIR" -P $PORT &
 SPID=$!
 stop_server() {


### PR DESCRIPTION
This only affects development workflows, and probably affects nobody
but me, but it avoids having two distinct codepaths for
--inplace-upgrade-prepare that were having different failure modes.