### PR TITLE
Update extensions when doing an inplace upgrade

### DIFF
--- a/.github/scripts/patches/compute-ipu-versions.py
+++ b/.github/scripts/patches/compute-ipu-versions.py
@@ -46,7 +46,10 @@ if not versions:
     versions = prerelease_versions
 
 versions.sort(key=lambda x: x[0])
-if len(versions) > 1:
+if len(versions) > 3:
+    # We want to try 6.0 and 6.2
+    versions = [versions[0], versions[2], versions[-1]]
+elif len(versions) > 1:
     versions = [versions[0], versions[-1]]
 
 matrix = {

--- a/edb/pgsql/patches_6x.py
+++ b/edb/pgsql/patches_6x.py
@@ -1,0 +1,322 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2016-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""Patches copied over from 6.x.
+
+Deeply unfortunately, we need to be able to apply the user_ext patches...
+
+"""
+
+from __future__ import annotations
+
+
+"""
+The actual list of patches. The patches are (kind, script) pairs.
+
+The current kinds are:
+ * sql - simply runs a SQL script
+ * metaschema-sql - create a function from metaschema
+ * edgeql - runs an edgeql DDL command
+ * edgeql+schema - runs an edgeql DDL command and updates the std schemas
+ *                 NOTE: objects and fields added to the reflschema must
+ *                 have their patch_level set to the `get_patch_level` value
+ *                 for this patch.
+ * edgeql+user_ext|<extname> - updates extensions installed in user databases
+ *                           - should be paired with an ext-pkg patch
+ * ...+config - updates config views
+ * ext-pkg - installs an extension package given a name
+ * repair - fix up inconsistencies in *user* schemas
+ * sql-introspection - refresh all sql introspection views
+ * ...+testmode - only run the patch in testmode. Works with any patch kind.
+"""
+PATCHES: list[tuple[str, str]] = [
+    # 6.0b2
+    # One of the sql-introspection's adds a param with a default to
+    # uuid_to_oid, so we need to drop the original to avoid ambiguity.
+    ('sql', '''
+drop function if exists edgedbsql_v6_2f20b3fed0.uuid_to_oid(uuid) cascade
+'''),
+    ('sql-introspection', ''),
+    ('metaschema-sql', 'SysConfigFullFunction'),
+    # 6.0rc1
+    ('edgeql+schema+config+testmode', '''
+CREATE SCALAR TYPE cfg::TestEnabledDisabledEnum
+    EXTENDING enum<Enabled, Disabled>;
+ALTER TYPE cfg::AbstractConfig {
+    CREATE PROPERTY __check_function_bodies -> cfg::TestEnabledDisabledEnum {
+        CREATE ANNOTATION cfg::internal := 'true';
+        CREATE ANNOTATION cfg::backend_setting := '"check_function_bodies"';
+        SET default := cfg::TestEnabledDisabledEnum.Enabled;
+    };
+};
+'''),
+    ('metaschema-sql', 'PostgresConfigValueToJsonFunction'),
+    ('metaschema-sql', 'SysConfigFullFunction'),
+    ('edgeql', '''
+ALTER FUNCTION
+std::assert_single(
+    input: SET OF anytype,
+    NAMED ONLY message: OPTIONAL str = <str>{},
+) {
+    SET volatility := 'Immutable';
+};
+ALTER FUNCTION
+std::assert_exists(
+    input: SET OF anytype,
+    NAMED ONLY message: OPTIONAL str = <str>{},
+) {
+    SET volatility := 'Immutable';
+};
+ALTER FUNCTION
+std::assert_distinct(
+    input: SET OF anytype,
+    NAMED ONLY message: OPTIONAL str = <str>{},
+) {
+    SET volatility := 'Immutable';
+};
+'''),
+     ('edgeql+schema+config', '''
+CREATE SCALAR TYPE sys::TransactionAccessMode
+    EXTENDING enum<ReadOnly, ReadWrite>;
+
+
+CREATE SCALAR TYPE sys::TransactionDeferrability
+    EXTENDING enum<Deferrable, NotDeferrable>;
+
+ALTER TYPE cfg::AbstractConfig {
+    CREATE REQUIRED PROPERTY default_transaction_isolation
+        -> sys::TransactionIsolation
+    {
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION cfg::backend_setting :=
+            '"default_transaction_isolation"';
+        CREATE ANNOTATION std::description :=
+            'Controls the default isolation level of each new transaction, \
+            including implicit transactions. Defaults to `Serializable`. \
+            Note that changing this to a lower isolation level implies \
+            that the transactions are also read-only by default regardless \
+            of the value of the `default_transaction_access_mode` setting.';
+        SET default := sys::TransactionIsolation.Serializable;
+    };
+
+    CREATE REQUIRED PROPERTY default_transaction_access_mode
+        -> sys::TransactionAccessMode
+    {
+        CREATE ANNOTATION cfg::affects_compilation := 'true';
+        CREATE ANNOTATION std::description :=
+            'Controls the default read-only status of each new transaction, \
+            including implicit transactions. Defaults to `ReadWrite`. \
+            Note that if `default_transaction_isolation` is set to any value \
+            other than Serializable this parameter is implied to be \
+            `ReadOnly` regardless of the actual value.';
+        SET default := sys::TransactionAccessMode.ReadWrite;
+    };
+
+    CREATE REQUIRED PROPERTY default_transaction_deferrable
+        -> sys::TransactionDeferrability
+    {
+        CREATE ANNOTATION cfg::backend_setting :=
+            '"default_transaction_deferrable"';
+        CREATE ANNOTATION std::description :=
+            'Controls the default deferrable status of each new transaction. \
+            It currently has no effect on read-write transactions or those \
+            operating at isolation levels lower than `Serializable`. \
+            The default is `NotDeferrable`.';
+        SET default := sys::TransactionDeferrability.NotDeferrable;
+    };
+};
+'''),
+    # 6.2
+    ('ext-pkg', 'ai'),
+    ('edgeql+user_ext+config|ai', '''
+alter type ext::ai::EmbeddingModel {
+    drop annotation
+      ext::ai::embedding_model_max_batch_tokens;
+    create annotation
+      ext::ai::embedding_model_max_batch_tokens := "8191";
+}
+'''),
+    # 6.3
+    ('repair', ''),  # For #8466
+    # 6.5
+    ('sql-introspection', ''),  # For #8511
+    ('edgeql+user_ext|ai', r'''
+update ext::ai::ChatPrompt filter .name = 'builtin::rag-default' set {
+    messages += (insert ext::ai::ChatPromptMessage {
+                    participant_role := ext::ai::ChatParticipantRole.User,
+                    content := (
+                        "Query: {query}\n\
+                         Answer: "
+                    ),
+                })
+}
+'''),  # For #8553
+    # 6.6
+    ('edgeql+schema', ''),  # For #8554
+    ('ext-pkg', 'ai'),  # For #8521, #8646
+    ('edgeql+user_ext+config|ai', '''
+    create function ext::ai::search(
+        object: anyobject,
+        query: str,
+    ) -> optional tuple<object: anyobject, distance: float64>
+    {
+        create annotation std::description := '
+            Search an object using its ext::ai::index index.
+            Gets an embedding for the query from the ai provider then
+            returns objects that match the specified semantic query and the
+            similarity score.
+        ';
+        set volatility := 'Stable';
+        # Needed to pick up the indexes when used in ORDER BY.
+        set prefer_subquery_args := true;
+        set server_param_conversions :=
+            '{"query": ["ai_text_embedding", "object"]}';
+        using sql expression;
+    };
+
+    alter scalar type ext::ai::ProviderAPIStyle
+        extending enum<OpenAI, Anthropic, Ollama>;
+
+    create type ext::ai::OllamaProviderConfig
+      extending ext::ai::ProviderConfig {
+        alter property name {
+            set protected := true;
+            set default := 'builtin::ollama';
+        };
+
+        alter property display_name {
+            set protected := true;
+            set default := 'Ollama';
+        };
+
+        alter property api_url {
+            set default := 'http://localhost:11434/api'
+        };
+
+        alter property secret {
+            set default := ''
+        };
+
+        alter property api_style {
+            set protected := true;
+            set default := ext::ai::ProviderAPIStyle.Ollama;
+        };
+    };
+
+    # Ollama embedding models
+    create abstract type ext::ai::OllamaLlama_3_2_Model
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "llama3.2";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "131072";
+    };
+
+    create abstract type ext::ai::OllamaLlama_3_3_Model
+        extending ext::ai::TextGenerationModel
+    {
+        alter annotation
+            ext::ai::model_name := "llama3.3";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::text_gen_model_context_window := "131072";
+    };
+
+    create abstract type ext::ai::OllamaNomicEmbedTextModel
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "nomic-embed-text";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "768";
+    };
+
+    create abstract type ext::ai::OllamaBgeM3Model
+        extending ext::ai::EmbeddingModel
+    {
+        alter annotation
+            ext::ai::model_name := "bge-m3";
+        alter annotation
+            ext::ai::model_provider := "builtin::ollama";
+        alter annotation
+            ext::ai::embedding_model_max_input_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_batch_tokens := "8192";
+        alter annotation
+            ext::ai::embedding_model_max_output_dimensions := "1024";
+    };
+'''),
+    # 6.8
+    ('edgeql+user+remove_pointless_triggers', ''),
+    ('edgeql', '''
+CREATE FUNCTION
+std::to_bytes(j: std::json) -> std::bytes {
+    CREATE ANNOTATION std::description :=
+        'Convert a json value to a binary UTF-8 string.';
+    SET volatility := 'Immutable';
+    USING (to_bytes(to_str(j)));
+};
+'''),
+    ('metaschema-sql', 'ArrayIndexWithBoundsFunction'),
+    ('metaschema-sql', 'ArraySliceFunction'),
+    ('metaschema-sql', 'StringIndexWithBoundsFunction'),
+    ('metaschema-sql', 'BytesIndexWithBoundsFunction'),
+    ('metaschema-sql', 'StringSliceFunction'),
+    ('metaschema-sql', 'BytesSliceFunction'),
+    ('metaschema-sql', 'JSONIndexByTextFunction'),
+    ('metaschema-sql', 'JSONIndexByIntFunction'),
+    ('metaschema-sql', 'JSONSliceFunction'),
+    ('edgeql', '''
+CREATE MODULE std::lang;
+
+CREATE MODULE std::lang::go;
+CREATE ABSTRACT ANNOTATION std::lang::go::type;
+
+CREATE MODULE std::lang::js;
+CREATE ABSTRACT ANNOTATION std::lang::js::type;
+
+CREATE MODULE std::lang::py;
+CREATE ABSTRACT ANNOTATION std::lang::py::type;
+
+CREATE MODULE std::lang::rs;
+CREATE ABSTRACT ANNOTATION std::lang::rs::type;
+'''),
+    # 6.9
+    ('edgeql', '''
+CREATE FUNCTION
+std::__pg_generate_series(
+    `start`: std::int64,
+    stop: std::int64
+) -> SET OF std::int64
+{
+    SET volatility := 'Immutable';
+    USING SQL FUNCTION 'generate_series';
+};
+'''),
+]

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -2603,7 +2603,10 @@ async def _bootstrap_edgedb_super_roles(ctx: BootstrapContext) -> uuid.UUID:
 async def _bootstrap(
     ctx: BootstrapContext,
     no_template: bool=False,
-) -> edbcompiler.Compiler:
+) -> tuple[
+    StdlibBits,
+    edbcompiler.Compiler
+]:
     args = ctx.args
     cluster = ctx.cluster
     backend_params = cluster.get_runtime_params()
@@ -2822,7 +2825,7 @@ async def _bootstrap(
             args.default_database_user or edbdef.EDGEDB_SUPERUSER,
         )
 
-    return compiler
+    return stdlib, compiler
 
 
 async def ensure_bootstrapped(
@@ -2844,7 +2847,7 @@ async def ensure_bootstrapped(
         mode = await _get_cluster_mode(ctx)
         ctx = dataclasses.replace(ctx, mode=mode)
         if mode == ClusterMode.pristine:
-            compiler = await _bootstrap(ctx)
+            _, compiler = await _bootstrap(ctx)
             return True, compiler
         else:
             compiler = await _start(ctx)

--- a/edb/server/inplace_upgrade.py
+++ b/edb/server/inplace_upgrade.py
@@ -39,12 +39,14 @@ from edb.common import uuidgen
 
 from edb.schema import ddl as s_ddl
 from edb.schema import delta as sd
+from edb.schema import extensions as s_exts
 from edb.schema import functions as s_func
 from edb.schema import links as s_links
 from edb.schema import name as sn
 from edb.schema import objtypes as s_objtypes
 from edb.schema import reflection as s_refl
 from edb.schema import schema as s_schema
+from edb.schema import version as s_ver
 
 from edb.server import args as edbargs
 from edb.server import bootstrap
@@ -65,26 +67,6 @@ from edb.pgsql import trampoline
 logger = logging.getLogger('edb.server')
 
 PGCon = bootstrap.PGConnectionProxy | pgcon.PGConnection
-
-
-async def _load_schema(
-    ctx: bootstrap.BootstrapContext, state: edbcompiler.CompilerState
-) -> s_schema.ChainedSchema:
-    assert state.global_intro_query
-    json_data = await ctx.conn.sql_fetch_val(
-        state.global_intro_query.encode('utf-8'))
-    global_schema = s_refl.parse_into(
-        base_schema=state.std_schema,
-        schema=s_schema.EMPTY_SCHEMA,
-        data=json_data,
-        schema_class_layout=state.schema_class_layout,
-    )
-
-    return s_schema.ChainedSchema(
-        state.std_schema,
-        s_schema.EMPTY_SCHEMA,
-        global_schema,
-    )
 
 
 def _is_stdlib_target(
@@ -212,9 +194,117 @@ def _compile_schema_fixup(
     return current_block
 
 
+async def _collect_upgrade_patches(
+    ctx: bootstrap.BootstrapContext,
+    schema: s_schema.Schema,
+) -> list[qlast.Command]:
+    from edb.pgsql import patches_6x
+
+    cmds: list[qlast.Command] = []
+
+    # TODO: specifically look at 6.x!!
+    jnum = json.loads(await ctx.conn.sql_fetch_val(
+        f"""
+        SELECT json::json FROM edgedbinstdata.instdata
+        WHERE key = 'num_patches'
+        """.encode('utf-8'),
+    ))
+    for kind, patch in patches_6x.PATCHES[jnum:]:
+
+        if not kind.startswith('edgeql+user_ext'):
+            continue
+        # Only run a userext update if the extension we are trying to
+        # update is installed.
+        extension_name = kind.split('|')[-1]
+        extension = schema.get_global(
+            s_exts.Extension, extension_name, default=None)
+        if not extension:
+            continue
+
+        for ddl_cmd in edgeql.parse_block(patch):
+            if not isinstance(ddl_cmd, qlast.DDLCommand):
+                assert isinstance(ddl_cmd, qlast.Query)
+                ddl_cmd = qlast.DDLQuery(query=ddl_cmd)
+            cmds.append(ddl_cmd)
+
+    return cmds
+
+
+async def _apply_ddl_schema_storage(
+    ddl_cmd: qlast.Command,
+    ctx: bootstrap.BootstrapContext,
+    backend_params,
+    keys: dict[str, Any],
+    compilerctx: edbcompiler.CompileContext,
+    schema: s_schema.Schema,
+    schema_object_ids: dict[tuple[sn.Name, Any], uuidgen.UUID],
+
+) -> tuple[s_schema.ChainedSchema, str]:
+    # applies ddl schema storage but not the real ddl
+    # returns that, though
+    current_block = dbops.PLTopBlock()
+
+    if debug.flags.sdl_loading:
+        ddl_cmd.dump_edgeql()
+
+    assert isinstance(ddl_cmd, qlast.DDLCommand)
+    delta_command = s_ddl.delta_from_ddl(
+        ddl_cmd, modaliases={}, schema=schema,
+        schema_object_ids=schema_object_ids,
+        **keys,
+    )
+    # Prune any AlterSchemaVersion commands, because they won't work,
+    # since all the compile_schema_storage_in_delta commands run right
+    # away, while if we run a fixup block, it is during finalize.
+    for sub in delta_command.get_subcommands(
+        type=s_ver.AlterSchemaVersion
+    ):
+        delta_command.discard(sub)
+
+    schema, plan, tplan = bootstrap._process_delta_params(
+        delta_command,
+        schema,
+        backend_params,
+        stdmode=False,
+        **keys,
+    )
+
+    compilerctx.state.current_tx().update_schema(schema)
+
+    fixup_block = dbops.PLTopBlock()
+    plan.generate(fixup_block)
+    # # ???
+    # tplan.generate(current_block)
+    fixup_ddl = fixup_block.to_string()
+
+    context = sd.CommandContext(**keys)
+    edbcompiler.compile_schema_storage_in_delta(
+        ctx=compilerctx,
+        delta=plan,
+        block=current_block,
+        context=context,
+    )
+
+    # TODO: Should we batch them all up?
+    patch = current_block.to_string()
+
+    if debug.flags.delta_execute:
+        debug.header('Patch Script')
+        debug.dump_code(patch, lexer='sql')
+
+    try:
+        await ctx.conn.sql_execute(patch.encode('utf-8'))
+    except Exception:
+        raise
+
+    assert isinstance(schema, s_schema.ChainedSchema)
+    return schema, fixup_ddl
+
+
 async def _upgrade_one(
     ctx: bootstrap.BootstrapContext,
     state: edbcompiler.CompilerState,
+    global_schema: s_schema.Schema,
     upgrade_data: Optional[Any],
 ) -> None:
     if not upgrade_data:
@@ -233,7 +323,11 @@ async def _upgrade_one(
     }
 
     # Load the schemas
-    schema = await _load_schema(ctx, state)
+    schema = s_schema.ChainedSchema(
+        state.std_schema,
+        s_schema.EMPTY_SCHEMA,
+        global_schema,
+    )
 
     compilerctx = edbcompiler.new_compiler_context(
         compiler_state=state,
@@ -245,48 +339,27 @@ async def _upgrade_one(
         testmode=True,
     )
 
-    # Apply the DDL, but *only* execute the schema storage part!!
+    # fixup_ddl = ''
+    # cmds = [(x, False) for x in edgeql.parse_block(ddl)]
+    # cmds += await _collect_upgrade_patches(ctx)
+
+    # Apply the DDL, but usually *only* execute the schema storage part!!
+    # For the actual core DDL, only do schema storage.
+    # Sometimes we have to run extension patch code, and then we
+    # need to run the actual code.
     for ddl_cmd in edgeql.parse_block(ddl):
-        current_block = dbops.PLTopBlock()
-
-        if debug.flags.sdl_loading:
-            ddl_cmd.dump_edgeql()
-
-        assert isinstance(ddl_cmd, qlast.DDLCommand)
-        delta_command = s_ddl.delta_from_ddl(
-            ddl_cmd, modaliases={}, schema=schema,
-            schema_object_ids=schema_object_ids,
-            **keys,
-        )
-        schema, plan, _ = bootstrap._process_delta_params(
-            delta_command,
-            schema,
-            backend_params,
-            stdmode=False,
-            **keys,
+        schema, _ = await _apply_ddl_schema_storage(
+            ddl_cmd,
+            ctx, backend_params, keys, compilerctx, schema, schema_object_ids
         )
 
-        compilerctx.state.current_tx().update_schema(schema)
-
-        context = sd.CommandContext(**keys)
-        edbcompiler.compile_schema_storage_in_delta(
-            ctx=compilerctx,
-            delta=plan,
-            block=current_block,
-            context=context,
+    schema_fixup = ''
+    for ddl_cmd in await _collect_upgrade_patches(ctx, schema):
+        schema, fixup = await _apply_ddl_schema_storage(
+            ddl_cmd,
+            ctx, backend_params, keys, compilerctx, schema, schema_object_ids
         )
-
-        # TODO: Should we batch them all up?
-        patch = current_block.to_string()
-
-        if debug.flags.delta_execute:
-            debug.header('Patch Script')
-            debug.dump_code(patch, lexer='sql')
-
-        try:
-            await ctx.conn.sql_execute(patch.encode('utf-8'))
-        except Exception:
-            raise
+        schema_fixup += fixup
 
     # Refresh the pg_catalog materialized views
     current_block = dbops.PLTopBlock()
@@ -314,7 +387,7 @@ async def _upgrade_one(
     ''').encode('utf-8'))
 
     # Compile the fixup script for the schema and stash it away
-    schema_fixup = _compile_schema_fixup(ctx, schema, keys).to_string()
+    schema_fixup += _compile_schema_fixup(ctx, schema, keys).to_string()
     await bootstrap._store_static_text_cache(
         ctx,
         f'schema_fixup_query',
@@ -478,12 +551,40 @@ async def _get_databases(
     #
     # Note: We put template last, since when deleting, we need it to
     # stay around so we can query all branches.
-    EARLY: tuple[str, ...] = ()
+    EARLY: tuple[str, ...] = ('dumpv5',)
     databases.sort(
         key=lambda k: (k == edbdef.EDGEDB_TEMPLATE_DB, k not in EARLY, k)
     )
 
     return databases
+
+
+async def _get_global_schema(
+    ctx: bootstrap.BootstrapContext,
+    state: edbcompiler.CompilerState,
+) -> s_schema.FlatSchema:
+    cluster = ctx.cluster
+
+    tpl_db = cluster.get_db_name(edbdef.EDGEDB_TEMPLATE_DB)
+    conn = await cluster.connect(
+        source_description="inplace upgrade",
+        database=tpl_db
+    )
+
+    # FIXME: Use the sys query instead?
+    assert state.global_intro_query
+    try:
+        json_data = await conn.sql_fetch_val(
+            state.global_intro_query.encode('utf-8'))
+    finally:
+        conn.terminate()
+
+    return s_refl.parse_into(
+        base_schema=state.std_schema,
+        schema=s_schema.EMPTY_SCHEMA,
+        data=json_data,
+        schema_class_layout=state.schema_class_layout,
+    )
 
 
 async def _rollback_one(
@@ -540,8 +641,11 @@ async def _upgrade_all(
 ) -> None:
     cluster = ctx.cluster
 
-    state = (await bootstrap._bootstrap(ctx)).state
+    stdlib, compiler = (await bootstrap._bootstrap(ctx))
+    state = compiler.state
     databases = await _get_databases(ctx)
+
+    global_schema = await _get_global_schema(ctx, state)
 
     assert ctx.args.inplace_upgrade_prepare
     with open(ctx.args.inplace_upgrade_prepare) as f:
@@ -566,6 +670,7 @@ async def _upgrade_all(
             await _upgrade_one(
                 ctx=subctx,
                 state=state,
+                global_schema=global_schema,
                 upgrade_data=upgrade_data.get(database),
             )
         finally:
@@ -621,6 +726,8 @@ async def _finalize_all(
     # many connections.
     await go("Testing pivot of", None, b'ROLLBACK')
     await go("Pivoting", "Finished pivoting", b'COMMIT', inject_failure)
+
+    # TODO: update the global schema
 
 
 async def inplace_upgrade(

--- a/edb/server/inplace_upgrade.py
+++ b/edb/server/inplace_upgrade.py
@@ -212,7 +212,7 @@ async def _collect_6x_upgrade_patches(
             WHERE key = 'num_patches'
             """.encode('utf-8'),
         )
-    except pgcon.BackendError as e:
+    except pgcon.BackendError:
         return [], False
     jnum = json.loads(res)
     for kind, patch in patches_6x.PATCHES[jnum:]:

--- a/tests/inplace-testing/test-old.sh
+++ b/tests/inplace-testing/test-old.sh
@@ -70,6 +70,10 @@ fi
 # Prepare the upgrades
 EDGEDB_PORT=$PORT EDGEDB_CLIENT_TLS_SECURITY=insecure python3 tests/inplace-testing/prep-upgrades.py > "${DIR}/upgrade.json"
 
+if [ "$SAVE_TARBALLS" = 1 ]; then
+    tar cf "$DIR"-ready.tar "$DIR"
+fi
+
 # Get the DSN from the debug endpoint
 DSN=$(curl -s http://localhost:$PORT/server-info | jq -r '.pg_addr.dsn')
 

--- a/tests/test_dump_v5.py
+++ b/tests/test_dump_v5.py
@@ -56,6 +56,16 @@ class DumpTestCaseMixin:
             ]
         )
 
+        # This got added in 6.6. We add it in here as part of testing
+        # in place upgrades, which use dump tests as their core things.
+        await self.assert_query_result(
+            r'''
+                select schema::ObjectType { name }
+                filter .name = 'ext::ai::OllamaBgeM3Model';
+            ''',
+            [{}],
+        )
+
     async def _ensure_data_integrity(self):
         await self.assert_query_result(
             r'''


### PR DESCRIPTION
Unfortunately in 6.x we changed the ai migration using patches a bunch, so
we need to be able to replay that during inplace upgrades from non-latest 6.x branches.

Fixes #8857.