### PR TITLE
Better error message for invalid property reference on primitives

### DIFF
--- a/tests/test_edgeql_enums.py
+++ b/tests/test_edgeql_enums.py
@@ -120,16 +120,20 @@ class TestEdgeQLEnums(tb.QueryTestCase):
                 )
 
         with self.assertRaisesRegex(
-                edgedb.QueryError,
-                "invalid property reference on a primitive type expression"):
+            edgedb.QueryError,
+            "invalid property reference on an expression of primitive type "
+            "'default::color_enum_t'"
+        ):
             async with self._run_and_rollback():
                 await self.con.execute(
                     'SELECT color_enum_t.RED.GREEN'
                 )
 
         with self.assertRaisesRegex(
-                edgedb.QueryError,
-                "invalid property reference on a primitive type expression"):
+            edgedb.QueryError,
+            "invalid property reference on an expression of primitive type "
+            "'default::color_enum_t'"
+        ):
             async with self._run_and_rollback():
                 await self.con.execute(
                     'WITH x := color_enum_t.RED SELECT x.GREEN'

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -6622,9 +6622,11 @@ class TestEdgeQLSelect(tb.QueryTestCase):
         ])
 
     async def test_edgeql_partial_06(self):
-        with self.assertRaisesRegex(edgedb.QueryError,
-                                    'invalid property reference on a '
-                                    'primitive type expression'):
+        with self.assertRaisesRegex(
+            edgedb.QueryError,
+            "invalid property reference on an expression of primitive type "
+            "'default::issue_num_t'"
+        ):
             await self.con.execute('''
                 SELECT Issue.number FILTER .number > '1';
             ''')


### PR DESCRIPTION
Include the primitive type name in the message.