### PR TITLE
Downgrade tiktoken, mistral_common

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dependencies = [
     'webauthn~=2.0.0',
     'argon2-cffi~=23.1.0',
     'aiosmtplib~=3.0',
-    'tiktoken~=0.9.0',
-    'mistral_common~=1.8.1',
+    'tiktoken~=0.7.0',
+    'mistral_common~=1.3.0',
 
     # pin because newer versions are either broken or require
     # us to update setuptools (in gel-pkg)


### PR DESCRIPTION
Followup for #8875

mistral_common adds dependency on numpy and pillow, which require
compiling C modules and are really unnecessary. tiktoken of this version
is needed because mistral_common depends on in.
