### PR TITLE
Fix UPDATING a link table field with reference to non-link field in some cases

### DIFF
--- a/edb/pgsql/compiler/dml.py
+++ b/edb/pgsql/compiler/dml.py
@@ -570,6 +570,7 @@ def get_dml_range(
         merge_iterator(ctx.enclosing_cte_iterator, range_stmt, ctx=subctx)
 
         dispatch.visit(target_ir_set, ctx=subctx)
+        relgen.ensure_source_rvar(target_ir_set, range_stmt, ctx=subctx)
 
         pathctx.get_path_identity_output(
             range_stmt, target_ir_set.path_id, env=subctx.env)

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -2853,6 +2853,29 @@ class TestUpdate(tb.QueryTestCase):
                 ) FILTER false;
             """)
 
+    async def test_edgeql_update_no_source_multi_01(self):
+        await self.con.execute("""
+            with x := assert_exists(
+                select UpdateTest filter .name = 'update-test3')
+            update x
+            set {
+                str_tags := x.comment
+            };
+        """)
+
+        await self.assert_query_result(
+            r"""
+                SELECT UpdateTest {
+                    str_tags
+                } filter .name = 'update-test3'
+            """,
+            [
+                {
+                    'str_tags': ['third'],
+                },
+            ]
+        )
+
     async def test_edgeql_update_insert_multi_required_01(self):
         await self.con.execute("""
             insert MultiRequiredTest {


### PR DESCRIPTION
In particular, if the source aspect of the UPDATE target is not
visible (because of assert_exists or a cast-from-uuid), then we can't
access the base object in the link-table parts of updates.

Easy fix is making sure we have the source.

Fixes #8903.