### PR TITLE
Make in-place upgrade work with recent auth changes

### DIFF
--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -550,6 +550,7 @@ def _build_object_mutation_shape(
         and not issubclass(mcls, s_types.CollectionExprAlias)
         and not cmd.get_attribute_value('abstract')
         and not cmd.get_attribute_value('transient')
+        and not cmd.has_attribute_value('backend_id')
     ):
         kind = f'"schema::{mcls.__name__}"'
 


### PR DESCRIPTION
I decided it would be most straightforward (for now) to do a patch,
like we've done with ai, to avoid the complication of the server
needing to handle multiple versions of the auth extension.

Follow-up to #8905.
Fixes #8909.