### PR TITLE
Add apply_access_policies_pg_default flag to Role

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_07_29_00_00
+EDGEDB_CATALOG_VERSION = 2025_08_04_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -127,6 +127,7 @@ CREATE TYPE sys::Role EXTENDING
     CREATE PROPERTY password -> std::str;
     CREATE MULTI PROPERTY permissions -> std::str;
     CREATE MULTI PROPERTY branches -> std::str;
+    CREATE PROPERTY apply_access_policies_pg_default -> std::bool;
 
     CREATE ACCESS POLICY ap_read allow select using (
         global sys::perm::superuser

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -7004,6 +7004,9 @@ class CreateRole(MetaCommand, RoleMixin, adapts=s_roles.CreateRole):
         branches: list[str] = list(sorted(
             role.get_branches(schema)
         ))
+        apply_access_policies_pg_default = (
+            role.get_apply_access_policies_pg_default(schema)
+        )
 
         instance_params = backend_params.instance_params
         tenant_id = instance_params.tenant_id
@@ -7039,6 +7042,9 @@ class CreateRole(MetaCommand, RoleMixin, adapts=s_roles.CreateRole):
                 builtin=role.get_builtin(schema),
                 permissions=permissions,
                 branches=branches,
+                apply_access_policies_pg_default=(
+                    apply_access_policies_pg_default
+                ),
             ),
         )
         self.pgops.add(dbops.CreateRole(db_role))
@@ -7068,6 +7074,9 @@ class AlterRole(MetaCommand, RoleMixin, adapts=s_roles.AlterRole):
             builtin=role.get_builtin(schema),
             permissions=list(sorted(role.get_permissions(schema) or ())),
             branches=list(sorted(role.get_branches(schema) or ())),
+            apply_access_policies_pg_default=(
+                role.get_apply_access_policies_pg_default(schema)
+            ),
         )
 
         if self.has_attribute_value('password'):
@@ -7087,6 +7096,7 @@ class AlterRole(MetaCommand, RoleMixin, adapts=s_roles.AlterRole):
         if (
             self.has_attribute_value('permissions')
             or self.has_attribute_value('branches')
+            or self.has_attribute_value('apply_access_policies_pg_default')
         ):
             update_metadata = True
 

--- a/edb/schema/roles.py
+++ b/edb/schema/roles.py
@@ -82,6 +82,13 @@ class Role(
         inheritable=False,
     )
 
+    apply_access_policies_pg_default = so.SchemaField(
+        bool,
+        default=None,
+        allow_ddl_set=True,
+        inheritable=True,
+    )
+
 
 class RoleCommandContext(
         sd.ObjectCommandContext[Role],

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -2129,6 +2129,7 @@ def compile_sys_queries(
             password,
             branches,
             all_permissions,
+            apply_access_policies_pg_default,
         };
     '''
     _, sql = compile_bootstrap_script(

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -3811,6 +3811,9 @@ def _extract_roles(
             superuser=role.get_superuser(global_schema),
             password=role.get_password(global_schema),
             branches=list(sorted(role.get_branches(global_schema))),
+            apply_access_policies_pg_default=(
+                role.get_apply_access_policies_pg_default(global_schema)
+            ),
         )
 
     # To populate all_permissions, combine the permissions of each role

--- a/edb/server/protocol/pg_ext.pxd
+++ b/edb/server/protocol/pg_ext.pxd
@@ -32,6 +32,7 @@ cdef class PreparedStmt:
 cdef class ConnectionView:
 
     cdef:
+        object _local_fe_defaults
         object _settings
         object _fe_settings
 
@@ -47,6 +48,7 @@ cdef class ConnectionView:
 
         tuple _session_state_db_cache
 
+    cdef _init_user_configs(self, username, tenant)
     cpdef inline current_fe_settings(self)
     cdef inline fe_transaction_state(self)
     cpdef inline bint in_tx(self)

--- a/edb/server/tenant.py
+++ b/edb/server/tenant.py
@@ -100,6 +100,7 @@ class RoleDescriptor(TypedDict):
     password: str | None
     all_permissions: list[str] | None
     branches: list[str]
+    apply_access_policies_pg_default: bool | None
 
 
 class Tenant(ha_base.ClusterProtocol):


### PR DESCRIPTION
This allows an individual Role to override the per-branch
configuration of apply_access_policies_pg. The point of this is so
that we can make apply_access_policies_pg the *default*, but still
make it possible to create a role where the policies aren't applied.

This is mainly for the purpose of integration with external tools that
don't provide some sort of way to inject arbitrary config commands to
the connection estabalishment.