### PR TITLE
auth: add email header and fix alt content bug

### DIFF
--- a/edb/server/protocol/auth_ext/ui/__init__.py
+++ b/edb/server/protocol/auth_ext/ui/__init__.py
@@ -1040,6 +1040,7 @@ email address:
 </tr>
     """  # noqa: E501
 
+    msg["X-gel-password-reset-url"] = reset_url
     msg.set_content(plain_text_content, subtype="plain")
     msg.add_alternative(
         render.base_default_email(
@@ -1204,6 +1205,7 @@ email address:
   </td>
 </tr>
     """
+    msg["X-gel-email-verify-url"] = verify_url
     msg.set_content(plain_text_content, subtype="plain")
     msg.add_alternative(
         render.base_default_email(
@@ -1345,6 +1347,7 @@ your account:
 </tr>
     """  # noqa: E501
 
+    msg["X-gel-magic-link"] = link
     msg.set_content(plain_text_content, subtype="plain")
     msg.add_alternative(
         render.base_default_email(
@@ -1460,6 +1463,7 @@ This code will expire in 10 minutes.
 </tr>
     """  # noqa: E501
 
+    msg["X-gel-email-verify-code"] = code
     msg.set_content(plain_text_content, subtype="plain")
     msg.add_alternative(
         render.base_default_email(
@@ -1575,6 +1579,7 @@ This code will expire in 10 minutes. If you didn't request a password reset, you
 </tr>
     """  # noqa: E501
 
+    msg["X-gel-password-reset-code"] = code
     msg.set_content(plain_text_content, subtype="plain")
     msg.add_alternative(
         render.base_default_email(

--- a/edb/server/protocol/auth_ext/ui/__init__.py
+++ b/edb/server/protocol/auth_ext/ui/__init__.py
@@ -1205,7 +1205,7 @@ email address:
 </tr>
     """
     msg.set_content(plain_text_content, subtype="plain")
-    msg.set_content(
+    msg.add_alternative(
         render.base_default_email(
             content=html_content,
             app_name=app_name,


### PR DESCRIPTION
Added the following email headers for the tools to parse:

* `X-gel-password-reset-url`
* `X-gel-email-verify-url`
* `X-gel-magic-link`
* `X-gel-email-verify-code`
* `X-gel-password-reset-code`

Also fixed a bug in the verification email that plain-text alternative content was mistakenly overwritten.