### PR TITLE
Expose 'protected' on schema::Property

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_08_05_00_00
+EDGEDB_CATALOG_VERSION = 2025_08_07_00_00
 EDGEDB_MAJOR_VERSION = 7
 
 

--- a/edb/lib/schema.edgeql
+++ b/edb/lib/schema.edgeql
@@ -305,6 +305,7 @@ CREATE ABSTRACT TYPE schema::Pointer
     CREATE PROPERTY secret -> std::bool;
     CREATE PROPERTY splat_strategy -> schema::SplatStrategy;
     CREATE PROPERTY linkful -> std::bool;
+    CREATE PROPERTY protected -> std::bool;
 };
 
 


### PR DESCRIPTION
For full schema introspection to support automatic configuration, we need to know which properties are protected.