### PR TITLE
Fix updating of two single links with linkprops at once

### DIFF
--- a/tests/schemas/updates.esdl
+++ b/tests/schemas/updates.esdl
@@ -44,6 +44,9 @@ type UpdateTest {
     link annotated_status -> Status {
         property note -> str;
     }
+    link annotated_status2 -> Status {
+        property note -> str;
+    }
 
     # for testing links to sets
     multi link tags -> Tag;

--- a/tests/test_edgeql_policies.py
+++ b/tests/test_edgeql_policies.py
@@ -789,6 +789,18 @@ class TestEdgeQLPolicies(tb.DDLTestCase):
             };
             ''')
 
+        async with self.assertRaisesRegexTx(
+                edgedb.InvalidValueError,
+                r"access policy violation on insert of default::Issue"):
+            await self.con.query('''
+            insert Issue {
+                name := '', body := '',
+                watchers := {},
+                status := (select Status filter .name = 'Open'), number := '',
+                owner := (insert User { name := "???" }),
+            };
+            ''')
+
     async def test_edgeql_policies_12(self):
         await self.con.query('''
             create global cur_user_obj := (

--- a/tests/test_edgeql_update.py
+++ b/tests/test_edgeql_update.py
@@ -1795,6 +1795,32 @@ class TestUpdate(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_update_props_11(self):
+        # Check that we can update a link property on a specific link.
+
+        # Setup some multi links
+        await self.con.execute(
+            r"""
+                UPDATE UpdateTest
+                FILTER .name = 'update-test1'
+                SET {
+                    annotated_status := (select Status limit 1),
+                    annotated_status2 := (select Status limit 1),
+                };
+            """,
+        )
+
+        await self.con.execute(
+            r"""
+                UPDATE UpdateTest
+                FILTER .name = 'update-test1'
+                SET {
+                    annotated_status := (select Status limit 1),
+                    annotated_status2 := (select Status limit 1),
+                };
+            """,
+        )
+
     async def test_edgeql_update_for_01(self):
         await self.assert_query_result(
             r"""


### PR DESCRIPTION
Mutating a single link with link properties works by compiling the
actual expression that defines the value into the link table update,
and then copying that value into the table itself by (ab/re)using the
rewrite machinery.

The rewrite machinery uses a "policy_ctx", which uses one of the input
tables as part of the overlay instead of an output table. The
"policy_ctx" has its overlay tables copied before being updated, but
it does the copy "just in time", which means that you can sometimes
get away with depending on things added to the context *after* the
policy_ctx was created.

Of course, this only worked *once*, after which the copy had been
made. As a result there was a bug where an 'except' overlay wasn't
being applied when populating a single link.

Be more explicit about all this by populating *both* overlay tables.

Also, it turns out that we do depend on incorporating unrelated
changes made to the overlay tables during compilation (like if an
INSERT is happening nested inside other DML), so we need to explicitly
reapply the policy overlays to the main one. (There was an existing bug
caused by this that this change made appear more easily.)

Possibly also fix some other policy related issues, since the code is
shared, but I haven't tracked it down too much.