### PR TITLE
Refactor auth_ext to go through a helper for parse_execute_json

### DIFF
--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -72,7 +72,7 @@ class Client(local.Client):
 
     async def register(self, email: str) -> data.EmailFactor:
         try:
-            result = await execute.parse_execute_json(
+            result = await util.json_query(
                 self.db,
                 """
 with
@@ -89,8 +89,6 @@ select email_factor { ** };""",
                 variables={
                     "email": email,
                 },
-                cached_globally=True,
-                query_tag='gel/auth',
             )
 
         except Exception as e:

--- a/edb/server/protocol/auth_ext/oauth.py
+++ b/edb/server/protocol/auth_ext/oauth.py
@@ -20,7 +20,6 @@
 import json
 
 from typing import cast, Any, Callable
-from edb.server.protocol import execute
 from edb.server.http import HttpClient
 
 from . import github, google, azure, apple, discord, slack
@@ -123,7 +122,7 @@ class Client:
     ) -> tuple[data.Identity, bool]:
         """Update or create an identity"""
 
-        r = await execute.parse_execute_json(
+        r = await util.json_query(
             db=self.db,
             query="""\
 with
@@ -144,8 +143,6 @@ select {
                 "issuer_url": self.provider.issuer_url,
                 "subject": user_info.sub,
             },
-            cached_globally=True,
-            query_tag='gel/auth',
         )
         result_json = json.loads(r.decode())
         assert len(result_json) == 1

--- a/edb/server/protocol/auth_ext/webhook.py
+++ b/edb/server/protocol/auth_ext/webhook.py
@@ -28,7 +28,8 @@ import hmac
 import hashlib
 import uuid
 
-from edb.server.protocol import execute
+
+from . import util
 
 if typing.TYPE_CHECKING:
     from edb.server import tenant as edbtenant
@@ -253,7 +254,7 @@ async def send(
         ).hexdigest()
         headers.append(("x-ext-auth-signature-sha256", signature))
 
-    result_json = await execute.parse_execute_json(
+    result_json = await util.json_query(
         db,
         """
 with
@@ -280,8 +281,6 @@ select REQUEST;
             "body": body,
             "headers": headers,
         },
-        cached_globally=True,
-        query_tag='gel/auth',
     )
     result = json.loads(result_json)
 


### PR DESCRIPTION
I may end up putting retries there, though I now think I might put it
directly in parse_execute_json.

Saves adding some boilerplate arguments to every call.