### PR TITLE
Avoid duplicating a cached computed global in some unnecessary cases

### DIFF
--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -60,6 +60,7 @@ def should_ignore_rewrite(
     #
     # (Eventually will might do a generalization of this based on
     # RBAC ownership of schema objects.)
+    # XXX: extension modules???
     schema = ctx.env.schema
     if (
         isinstance(stype, s_objtypes.ObjectType)

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -121,6 +121,12 @@ def new_set(
         from . import policies
         policies.try_type_rewrite(stype, skip_subtypes=skip_subtypes, ctx=ctx)
 
+    if (
+        not ignore_rewrites
+        and ctx.env.type_rewrites.get(rw_key)
+    ):
+        ctx.env.policy_use_count += 1
+
     typeref = typegen.type_to_typeref(stype, env=ctx.env)
     ir_set = ircls(typeref=typeref, expr=expr, **kwargs)
     ctx.env.set_types[ir_set] = stype

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -560,3 +560,18 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             count,
             1,
             f"ScheduledRequest selected from and not just inserted: {sql}")
+
+    SCHEMA_gcache = r'''
+        global b := true;
+        type T {
+            access policy ok allow all using (global b);
+        };
+    '''
+
+    def test_codegen_global_cache_01(self):
+        tree = self._compile_to_tree('''
+            select gcache::T filter global gcache::b
+        ''')
+        assert isinstance(tree, pgast.SelectStmt)
+        # One CTE for the global, one for the policy
+        self.assertEqual(len(tree.ctes), 2)


### PR DESCRIPTION
Currently we always produce two CTEs for a computed global that is
referenced in both an access policy and outside of an access policy
(since it may produce different results in those contexts).

Add a check for whether any access policies are actually referenced,
and merge the CTEs if they are not.

This is important since #8953 would otherwise cause duplication of
auth JWT validation. This may also remove duplication in some existing
user queries.