### PR TITLE
sql: Fix COLLATE clauses that require quotation

### DIFF
--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -1019,7 +1019,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
 
     def visit_CollateClause(self, node: pgast.CollateClause) -> None:
         self.visit(node.arg)
-        self.write(f' COLLATE {node.collname}')
+        self.write(f' COLLATE {common.quote_col(node.collname)}')
 
     def visit_CoalesceExpr(self, node: pgast.CoalesceExpr) -> None:
         self.write('COALESCE(')

--- a/tests/test_sql_query.py
+++ b/tests/test_sql_query.py
@@ -1433,6 +1433,13 @@ class TestSQLQuery(tb.SQLQueryTestCase):
         )
         self.assertEqual(res, 'UPDATE 1')
 
+    async def test_sql_query_59(self):
+        await self.squery_values(
+            '''
+            SELECT 'lol' COLLATE "C";
+            '''
+        )
+
     async def test_sql_query_introspection_00(self):
         dbname = self.con.dbname
         res = await self.squery_values(


### PR DESCRIPTION
We were failing to quote the name of the collation.