### PR TITLE
Fix handling of SQL syntax error over gel proto

### DIFF
--- a/edb/pgsql/parser/__init__.py
+++ b/edb/pgsql/parser/__init__.py
@@ -42,7 +42,7 @@ __all__ = (
 def parse(
     sql_query: str, propagate_spans: bool = False
 ) -> list[pgast.Query | pgast.Statement]:
-    ast_json = parser.pg_parse(bytes(sql_query, encoding="UTF8"))
+    ast_json = parser.pg_parse(sql_query)
 
     return ast_builder.build_stmts(
         json.loads(ast_json),

--- a/edb/pgsql/parser/parser.pyx
+++ b/edb/pgsql/parser/parser.pyx
@@ -83,10 +83,14 @@ cdef extern from "protobuf/pg_query.pb-c.h":
         const ProtobufCEnumDescriptor *desc, int value)
 
 
-def pg_parse(query) -> str:
-    cdef PgQueryParseResult result
+def pg_parse(query: str) -> str:
+    cdef:
+        PgQueryParseResult result
+        bytes queryb
 
-    result = pg_query_parse(query)
+    queryb = query.encode("utf-8")
+    result = pg_query_parse(queryb)
+
     if result.error:
         error = PSqlSyntaxError(
             result.error.message.decode('utf8'),

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -783,11 +783,7 @@ def static_interpret_psql_parse_error(
     if isinstance(exc, parser_errors.PSqlSyntaxError):
         res = errors.EdgeQLSyntaxError(str(exc))
         res.set_position(exc.cursor_pos - 1, None)
-
-        source: bytes | str = exc.query_source
-        if isinstance(source, bytes):
-            source = str(source, 'utf-8')
-        res.compute_line_col(source)
+        res.compute_line_col(exc.query_source)
     elif isinstance(exc, parser_errors.PSqlUnsupportedError):
         res = errors.UnsupportedFeatureError(str(exc))
         if exc.location is not None:

--- a/edb/server/compiler/errormech.py
+++ b/edb/server/compiler/errormech.py
@@ -783,7 +783,11 @@ def static_interpret_psql_parse_error(
     if isinstance(exc, parser_errors.PSqlSyntaxError):
         res = errors.EdgeQLSyntaxError(str(exc))
         res.set_position(exc.cursor_pos - 1, None)
-        res.compute_line_col(exc.query_source)
+
+        source: bytes | str = exc.query_source
+        if isinstance(source, bytes):
+            source = str(source, 'utf-8')
+        res.compute_line_col(source)
     elif isinstance(exc, parser_errors.PSqlUnsupportedError):
         res = errors.UnsupportedFeatureError(str(exc))
         if exc.location is not None:


### PR DESCRIPTION
When string normalization was disabled, handling crashed.
