### PR TITLE
Drop required_permissions on all ext::auth::_jwt_* functions

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_08_18_00_00
+EDGEDB_CATALOG_VERSION = 2025_08_19_00_00
 EDGEDB_MAJOR_VERSION = 8
 
 

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -583,7 +583,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
                     message := "JWT signature mismatch",
                 )
         );
-        SET required_permissions := ext::auth::perm::auth_read;
     };
 
     create function ext::auth::_jwt_parse(
@@ -592,8 +591,7 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
     {
         set volatility := 'Stable';
         using (
-            with
-                parts := std::str_split(token, "."),
+            for parts in std::str_split(token, ".")
             select
                 (
                     header := parts[0],
@@ -603,7 +601,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
             order by
                 assert(len(parts) = 3, message := "JWT is malformed")
         );
-        SET required_permissions := ext::auth::perm::auth_read;
     };
 
     create function ext::auth::_jwt_verify(
@@ -637,7 +634,6 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
                     message := "JWT is expired or is not yet valid",
                 )
         );
-        SET required_permissions := ext::auth::perm::auth_read_user;
     };
 
     create global ext::auth::client_token: std::str;


### PR DESCRIPTION
They don't access the database at all, they just do computation
using non-restricted functions.

Also tweak one function to use FOR instead of WITH.