### PR TITLE
Work around for bug #8974 when updating extension globals using secrets

### DIFF
--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1070,6 +1070,20 @@ def _check_secret_ptr(
 ) -> None:
     module = ptrcls.get_name(ctx.env.schema).module
 
+    # HACK: Workaround for #8974. Aliases/globals have expr duplicated
+    # in their associated Type, and sometimes recompilation of the
+    # Type is triggered.
+    # Skip producing secret errors there, since we don't have the
+    # result_view_name available.
+    #
+    # The errors will get produced when actually compiling the
+    # Global/Alias itself.
+    if (
+        ctx.env.options.schema_object_context
+        and issubclass(ctx.env.options.schema_object_context, s_types.Type)
+    ):
+        return
+
     func_name = ctx.env.options.func_name
     if func_name and func_name.module == module:
         return

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -3082,10 +3082,14 @@ class TypeCommand[TypeT: Type](sd.ObjectCommand[TypeT]):
         value: s_expr.Expression,
         track_schema_ref_exprs: bool=False,
     ) -> s_expr.CompiledExpression:
+        # XXX: This seems like pointless duplication of work from
+        # globals/aliases... why is expr even here?
+        # (... because we export it in the introspection schema)
         assert field.name == 'expr'
         return value.compiled(
             schema=schema,
             options=qlcompiler.CompilerOptions(
+                schema_object_context=self.get_schema_metaclass(),
                 modaliases=context.modaliases,
                 in_ddl_context_name='type definition',
                 track_schema_ref_exprs=track_schema_ref_exprs,


### PR DESCRIPTION
This is needed to backport #8953 and #8964, but I don't feel great
about it.