### PR TITLE
Fix referencing a computed pointer in a conversion USING expression

### DIFF
--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -4825,12 +4825,16 @@ class PointerMetaCommand[Pointer_T: s_pointers.Pointer](
         for child in list(ir.scope_tree.children):
             scope_body.attach_child(child)
 
-        scope_root = irast.ScopeTreeNode(
+        scope_node = irast.ScopeTreeNode(
             unique_id=root_uid,
             path_id=outer_path,
         )
-        scope_root.attach_child(scope_iter)
-        scope_root.attach_child(scope_body)
+        scope_node.attach_child(scope_iter)
+        scope_node.attach_child(scope_body)
+
+        # The top-level node must be a fence.
+        scope_root = irast.ScopeTreeNode(fenced=True)
+        scope_root.attach_child(scope_node)
         ir.scope_tree = scope_root
 
         # IR ast wrapping

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -3596,6 +3596,26 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
         await self.assert_query_result("select X { foo }", [{"foo": "test"}])
 
+    async def test_edgeql_ddl_ptr_set_required_03(self):
+        await self.con.execute("""
+            CREATE TYPE Agent;
+            CREATE TYPE AgentVersion {
+                CREATE SINGLE LINK agent2 -> Agent;
+                CREATE SINGLE LINK agent := .agent2;
+            };
+            CREATE TYPE Obj {
+                CREATE REQUIRED SINGLE LINK agentVersion: AgentVersion;
+            };
+        """)
+
+        await self.con.execute("""
+            ALTER TYPE Obj {
+                CREATE REQUIRED SINGLE LINK agent: Agent {
+                    SET REQUIRED USING (.agentVersion.agent);
+                };
+            };
+        """)
+
     async def test_edgeql_ddl_link_property_01(self):
         await self.con.execute("""
             CREATE TYPE Tgt;


### PR DESCRIPTION
The scope tree we were setting up was different from real scope trees
in ways that caused problems, since the top-level node was not a
FENCE.

Fixes #8980.