### PR TITLE
Fix some new simple_scoping + inline functions regressions

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -89,7 +89,15 @@ def compile_Path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         # Mark the nodes as having been protected from factoring. At
         # the end of compilation, we see if we can eliminate the
         # scopes without inducing factoring.
-        res.is_factoring_protected = True
+        #
+        # Don't do this if the head of the path is an expression
+        # (instead of an ObjectRef), though, because that interacts
+        # badly with function inlining in some cases??
+        # (test_edgeql_functions_inline_object_06).
+        # My hope is to just destroy all this machinery instead of tracking
+        # that interaction down, though.
+        if expr.partial or not isinstance(expr.steps[0], qlast.Expr):
+            res.is_factoring_protected = True
         return res
 
     if ctx.warn_factoring and not expr.allow_factoring:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -653,6 +653,11 @@ def _collapse_factoring_protected(
         if not (parent := node.parent):
             continue
 
+        # If the underlying thing has already been factored fully, we
+        # skip it, because it might be no-factor fenced?
+        if parent.find_visible(ir_set.expr.result.path_id):
+            continue
+
         # If collapsing this node would lead to any factoring, we
         # obviously can't do it.
         # We check by seeing if there are some factorable nodes

--- a/tests/test_edgeql_functions_inline.py
+++ b/tests/test_edgeql_functions_inline.py
@@ -23,7 +23,10 @@ import edgedb
 from edb.testbase import server as tb
 
 
-class TestEdgeQLFunctionsInline(tb.QueryTestCase):
+class TestEdgeQLFunctionsInline(tb.DDLTestCase):
+    SETUP = '''
+        create future simple_scoping;
+    '''
 
     async def test_edgeql_functions_inline_basic_01(self):
         await self.con.execute('''
@@ -1411,7 +1414,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
             insert Bar{a := 3};
             create function foo() -> set of tuple<int64, int64> {
                 set is_inlined := true;
-                using ((Bar.a, count(Bar)));
+                using (for Bar in Bar union (Bar.a, count(Bar)));
             };
         ''')
         await self.assert_query_result(
@@ -2002,7 +2005,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
             insert Bar{a := 3};
             create function foo() -> set of tuple<int64, int64> {
                 set is_inlined := true;
-                using ((Bar.a, count(Bar)));
+                using (for Bar in Bar union (Bar.a, count(Bar)));
             };
         ''')
         await self.assert_query_result(
@@ -4185,7 +4188,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
             insert Bar{a := 3};
             create function inner() -> set of tuple<int64, int64> {
                 set is_inlined := true;
-                using ((Bar.a, count(Bar)));
+                using (for Bar in Bar select (Bar.a, count(Bar)));
             };
             create function foo() -> set of tuple<int64, int64> {
                 set is_inlined := true;
@@ -4677,6 +4680,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
                 set is_inlined := true;
                 using (
                     with y := (select Bar{a, b := inner(x)})
+                    for y in y
                     select (y.a, y.b)
                 );
             };


### PR DESCRIPTION
Another bug introduced just now in #8985 and caught by my in-progress
PR to rip out old scoping.