### PR TITLE
Remove path factoring

### DIFF
--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -887,9 +887,6 @@ class ContextLevel(compiler.ContextLevel):
     def allow_factoring(self) -> None:
         self.no_factoring = False
 
-    def schema_factoring(self) -> None:
-        self.no_factoring = True
-
 
 class CompilerContext(compiler.CompilerContext[ContextLevel]):
     ContextLevelClass = ContextLevel

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -643,7 +643,6 @@ class ContextLevel(compiler.ContextLevel):
     """
 
     no_factoring: bool
-    warn_factoring: bool
 
     def __init__(
         self,
@@ -704,7 +703,6 @@ class ContextLevel(compiler.ContextLevel):
             self.allow_endpoint_linkprops = False
             self.disallow_dml = None
             self.no_factoring = False
-            self.warn_factoring = False
 
             self.collection_cast_info = None
 
@@ -751,7 +749,6 @@ class ContextLevel(compiler.ContextLevel):
             self.allow_endpoint_linkprops = prevlevel.allow_endpoint_linkprops
             self.disallow_dml = prevlevel.disallow_dml
             self.no_factoring = prevlevel.no_factoring
-            self.warn_factoring = prevlevel.warn_factoring
 
             self.collection_cast_info = prevlevel.collection_cast_info
 
@@ -888,16 +885,10 @@ class ContextLevel(compiler.ContextLevel):
         self.env.unsafe_isolation_dangers.append(d)
 
     def allow_factoring(self) -> None:
-        self.no_factoring = self.warn_factoring = False
+        self.no_factoring = False
 
     def schema_factoring(self) -> None:
-        self.no_factoring = s_futures.future_enabled(
-            self.env.schema, 'simple_scoping'
-        )
-        # When compiling schema things, we don't want to cause warnings
-        # The warnings will be emitted when updating the schema,
-        # and interact poorly with compilation.
-        self.warn_factoring = False
+        self.no_factoring = True
 
 
 class CompilerContext(compiler.CompilerContext[ContextLevel]):

--- a/edb/edgeql/compiler/context.py
+++ b/edb/edgeql/compiler/context.py
@@ -55,7 +55,6 @@ from edb.ir import utils as irutils
 from edb.ir import typeutils as irtyputils
 
 from edb.schema import expraliases as s_aliases
-from edb.schema import futures as s_futures
 from edb.schema import name as s_name
 from edb.schema import objects as s_obj
 from edb.schema import permissions as s_permissions

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -89,7 +89,15 @@ def compile_Path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
         # Mark the nodes as having been protected from factoring. At
         # the end of compilation, we see if we can eliminate the
         # scopes without inducing factoring.
-        res.is_factoring_protected = True
+        #
+        # Don't do this if the head of the path is an expression
+        # (instead of an ObjectRef), though, because that interacts
+        # badly with function inlining in some cases??
+        # (test_edgeql_functions_inline_object_06).
+        # My hope is to just destroy all this machinery instead of tracking
+        # that interaction down, though.
+        if expr.partial or not isinstance(expr.steps[0], qlast.Expr):
+            res.is_factoring_protected = True
         return res
 
     if ctx.warn_factoring and not expr.allow_factoring:

--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -100,13 +100,6 @@ def compile_Path(expr: qlast.Path, *, ctx: context.ContextLevel) -> irast.Set:
             res.is_factoring_protected = True
         return res
 
-    if ctx.warn_factoring and not expr.allow_factoring:
-        with ctx.newscope(fenced=False) as subctx:
-            subctx.path_scope.warn = True
-            return dispatch.compile(
-                expr.replace(allow_factoring=True), ctx=subctx
-            )
-
     return stmt.maybe_add_view(setgen.compile_path(expr, ctx=ctx), ctx=ctx)
 
 
@@ -514,10 +507,6 @@ def _compile_dml_ifelse(
             )
             els.append(else_b)
 
-        # If we are warning on factoring, double wrap it.
-        if ctx.warn_factoring:
-            cond_ir = setgen.ensure_set(
-                setgen.ensure_stmt(cond_ir, ctx=ctx), ctx=ctx)
         full = qlast.ForQuery(
             iterator_alias=alias,
             iterator=subctx.create_anchor(cond_ir, 'b'),

--- a/edb/edgeql/compiler/options.py
+++ b/edb/edgeql/compiler/options.py
@@ -154,9 +154,3 @@ class CompilerOptions(GlobalCompilerOptions):
     #: schema_object_context is set to Trigger.
     trigger_type: Optional[s_types.Type] = None
     trigger_kinds: Optional[Collection[qltypes.TriggerKind]] = None
-
-    #: These represent the *configured* values of
-    #: simple_scoping/warn_old_scoping. If they are None, we check the
-    #: presence of the futures in the schema.
-    simple_scoping: Optional[bool] = None
-    warn_old_scoping: Optional[bool] = None

--- a/edb/edgeql/compiler/policies.py
+++ b/edb/edgeql/compiler/policies.py
@@ -153,7 +153,6 @@ def compile_pol(
 
     # Compile it with all of the
     with ctx.newscope(fenced=True) as _, _.detached() as dctx:
-        dctx.schema_factoring()
         dctx.partial_path_prefix = ctx.partial_path_prefix
         dctx.expr_exposed = context.Exposure.UNEXPOSED
         dctx.suppress_rewrites = frozenset(descs)
@@ -609,4 +608,3 @@ def _prepare_dml_policy_context(
 
     ctx.anchors['__subject__'] = result
     ctx.partial_path_prefix = result
-    ctx.schema_factoring()

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -1818,8 +1818,6 @@ def _get_schema_computed_ctx(
     @contextlib.contextmanager
     def newctx() -> Iterator[context.ContextLevel]:
         with ctx.detached() as subctx:
-            subctx.schema_factoring()
-
             source_scope = pathctx.get_set_scope(rptr.source, ctx=ctx)
             if source_scope and source_scope.namespaces:
                 subctx.path_id_namespace |= source_scope.namespaces

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -88,7 +88,7 @@ def try_desugar(
 def _protect_expr(
     expr: Optional[qlast.Expr], *, ctx: context.ContextLevel
 ) -> None:
-    if ctx.no_factoring or ctx.warn_factoring:
+    if ctx.no_factoring:
         while isinstance(expr, qlast.Shape):
             expr.allow_factoring = True
             expr = expr.expr
@@ -1130,14 +1130,6 @@ def compile_Shape(
             ctx=ctx,
         )
 
-    if ctx.warn_factoring and not shape.allow_factoring:
-        with ctx.newscope(fenced=False) as subctx:
-            subctx.path_scope.warn = True
-            _protect_expr(shape, ctx=ctx)
-            return dispatch.compile(
-                shape, ctx=subctx
-            )
-
     shape_expr = shape.expr or qlutils.FREE_SHAPE_EXPR
     with ctx.new() as subctx:
         subctx.qlstmt = astutils.ensure_ql_query(shape)
@@ -1226,7 +1218,6 @@ def init_stmt(
         parent_ctx.toplevel_stmt = ctx.toplevel_stmt = irstmt
 
     ctx.path_scope = parent_ctx.path_scope.attach_fence()
-    ctx.path_scope.warn = ctx.warn_factoring
 
     pending_own_ns = parent_ctx.pending_stmt_own_path_id_namespace
     if pending_own_ns:

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -653,6 +653,11 @@ def _collapse_factoring_protected(
         if not (parent := node.parent):
             continue
 
+        # If the underlying thing has already been factored fully, we
+        # skip it, because it might be no-factor fenced?
+        if parent.find_visible(ir_set.expr.result.path_id):
+            continue
+
         # If collapsing this node would lead to any factoring, we
         # obviously can't do it.
         # We check by seeing if there are some factorable nodes

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -981,7 +981,6 @@ def _declare_view_from_schema(
     # subcontext to compile in, but it should avoid depending on the
     # context, because of the cache.
     with ctx.detached() as subctx:
-        subctx.schema_factoring()
         subctx.current_schema_views += (viewcls,)
         subctx.expr_exposed = context.Exposure.UNEXPOSED
         view_expr: s_expr.Expression | None = viewcls.get_expr(ctx.env.schema)

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -39,7 +39,6 @@ from edb.ir import utils as irutils
 from edb.ir import typeutils as irtyputils
 
 from edb.schema import constraints as s_constr
-from edb.schema import futures as s_futures
 from edb.schema import modules as s_mod
 from edb.schema import name as s_name
 from edb.schema import objects as s_obj
@@ -173,7 +172,6 @@ def init_context(
     ctx.expr_exposed = context.Exposure.EXPOSED
 
     ctx.no_factoring = True
-    ctx.warn_factoring = False
 
     return ctx
 

--- a/edb/edgeql/compiler/stmtctx.py
+++ b/edb/edgeql/compiler/stmtctx.py
@@ -172,22 +172,8 @@ def init_context(
     ctx.implicit_limit = options.implicit_limit
     ctx.expr_exposed = context.Exposure.EXPOSED
 
-    # Resolve simple_scoping/warn_old_scoping configs.
-    # options specifies the value in the configuration system;
-    # if that is None, we rely on the presence of the future.
-    simple_scoping = options.simple_scoping
-    if simple_scoping is None:
-        simple_scoping = s_futures.future_enabled(
-            ctx.env.schema, 'simple_scoping'
-        )
-    warn_old_scoping = options.warn_old_scoping
-    if warn_old_scoping is None:
-        warn_old_scoping = s_futures.future_enabled(
-            ctx.env.schema, 'warn_old_scoping'
-        )
-
-    ctx.no_factoring = simple_scoping
-    ctx.warn_factoring = warn_old_scoping
+    ctx.no_factoring = True
+    ctx.warn_factoring = False
 
     return ctx
 

--- a/edb/edgeql/compiler/triggers.py
+++ b/edb/edgeql/compiler/triggers.py
@@ -66,7 +66,6 @@ def compile_trigger(
     source = trigger.get_subject(schema)
 
     with ctx.detached() as tc, tc.newscope(fenced=True) as sctx:
-        sctx.schema_factoring()
         sctx.anchors = sctx.anchors.copy()
 
         anchors = {}

--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -908,8 +908,6 @@ def _gen_pointers_from_defaults(
         )
 
         with ctx.new() as scopectx:
-            scopectx.schema_factoring()
-
             scopectx.active_defaults |= {stype}
 
             # add __source__ to anchors
@@ -1236,7 +1234,6 @@ def _compile_rewrites_for_stype(
         assert rewrite_expr
 
         with ctx.newscope(fenced=True) as scopectx:
-            scopectx.schema_factoring()
             scopectx.active_rewrites |= {stype}
 
             # prepare context

--- a/edb/ir/scopetree.py
+++ b/edb/ir/scopetree.py
@@ -44,7 +44,6 @@ from edb import errors
 from edb.common import ordered
 from edb.common import span
 from edb.common import term
-from edb.common.typeutils import not_none
 
 from . import pathid
 from . import ast as irast
@@ -564,7 +563,6 @@ class ScopeTreeNode:
                     if desc_optional:
                         descendant.mark_as_optional()
 
-                moved = False
                 for factorable in factorable_nodes:
                     (
                         existing,
@@ -610,7 +608,6 @@ class ScopeTreeNode:
                     )
 
                     current = existing
-                    moved = True
 
                     # HACK: If we are being called from fuse_subtree,
                     # skip all but the first. This is because we don't

--- a/edb/schema/futures.py
+++ b/edb/schema/futures.py
@@ -151,6 +151,7 @@ class AlterFutureBehavior(
 
 # These are registered here because they aren't directly related to
 # any schema elements.
+# They are all dummys now, too.
 @register_handler('simple_scoping')
 @register_handler('warn_old_scoping')
 @register_handler('_scoping_noop_test')
@@ -160,73 +161,4 @@ def toggle_scoping_future(
     context: sd.CommandContext,
     on: bool,
 ) -> tuple[s_schema.Schema, sd.Command]:
-    from . import types as s_types
-    from . import pointers as s_pointers
-    from . import constraints as s_constraints
-    from . import indexes as s_indexes
-
-    # We need a subcommand to apply the _propagate_if_expr_refs on, so
-    # make an alter.
-    dummy_object = (
-        cmd.scls if isinstance(cmd, sd.CreateObject)
-        # HACK: On drops, the future doesn't exist, so grab
-        # a nonsense object we know will be there.
-        # The drops *shouldn't* ever fail, so it *shouldn't*
-        # show up in messages.
-        else schema.get_global(s_mod.Module, '__derived__')
-    )
-    alter_cmd = dummy_object.init_delta_command(
-        schema, cmdtype=sd.AlterObject)
-
-    all_expr_fields = _get_all_expr_fields()
-
-    # Indexes and constraints use simple expressions that cannot
-    # depend on path factoring!
-    del all_expr_fields[s_constraints.Constraint]
-    del all_expr_fields[s_indexes.Index]
-
-    types = tuple(all_expr_fields)
-
-    all_expr_objects: list[so.Object] = list(schema.get_objects(
-        exclude_stdlib=True,
-        exclude_extensions=True,
-        extra_filters=[lambda _, x: isinstance(x, types)],
-    ))
-    extra_refs = {
-        obj: fields
-        for obj in all_expr_objects
-        if (fields := all_expr_fields[type(obj)])
-        and any(obj.get_field_value(schema, name) for name in fields)
-        and not (
-            isinstance(obj, (s_types.Type, s_pointers.Pointer))
-            and obj.get_from_alias(schema)
-        )
-    }
-
-    schema = alter_cmd._propagate_if_expr_refs(
-        schema,
-        context,
-        action=f'toggle value of scoping future behavior',
-        extra_refs=extra_refs,
-        metadata_only=False,
-    )
-
-    return schema, alter_cmd
-
-
-def _get_all_expr_fields() -> dict[type[so.Object], list[str]]:
-    r = {}
-    from . import expr as s_expr
-
-    for schemacls in so.ObjectMeta.get_schema_metaclasses():
-        if schemacls.is_abstract():
-            continue
-        fields = [
-            name
-            for name, field in schemacls.get_schema_fields().items()
-            if issubclass(field.type, s_expr.EXPRESSION_TYPES)
-        ]
-        if fields:
-            r[schemacls] = fields
-
-    return r
+    return schema, sd.CommandGroup()

--- a/edb/schema/futures.py
+++ b/edb/schema/futures.py
@@ -26,7 +26,6 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
 from . import delta as sd
-from . import modules as s_mod
 from . import name as sn
 from . import objects as so
 from . import schema as s_schema

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1652,14 +1652,6 @@ def _get_compile_options(
             ctx.schema_reflection_mode
             or _get_config_val(ctx, '__internal_query_reflschema')
         ),
-        simple_scoping=(
-            _get_config_val(ctx, 'simple_scoping')
-        ),
-        warn_old_scoping=(
-            ctx.schema_reflection_mode or
-            ctx.bootstrap_mode or
-            _get_config_val(ctx, 'warn_old_scoping')
-        ),
     )
 
 

--- a/tests/schemas/insert.esdl
+++ b/tests/schemas/insert.esdl
@@ -113,9 +113,9 @@ type DefaultTest2 {
     required property num -> int64 {
         # XXX: circumventing sequence deficiency
         default := (
-            SELECT DefaultTest1.num + 1
-            ORDER BY DefaultTest1.num DESC
-            LIMIT 1
+          (SELECT DefaultTest1
+            ORDER BY .num DESC
+           LIMIT 1).num + 1
         );
     }
 }

--- a/tests/test_dump_v4.py
+++ b/tests/test_dump_v4.py
@@ -42,9 +42,11 @@ class DumpTestCaseMixin:
 
         await self.assert_query_result(
             r'''
-                with x := range_unpack(range(1, 1000))
                 select all(
-                    L2.vec in <v3>[x % 10, std::math::ln(x), x / 7 % 13]
+                    L2.vec in (
+                        for x in range_unpack(range(1, 1000))
+                        select <v3>[x % 10, std::math::ln(x), x / 7 % 13]
+                    )
                 )
             ''',
             [

--- a/tests/test_dump_v5.py
+++ b/tests/test_dump_v5.py
@@ -78,9 +78,11 @@ class DumpTestCaseMixin:
 
         await self.assert_query_result(
             r'''
-                with x := range_unpack(range(1, 1000))
                 select all(
-                    L2.vec in <v3>[x % 10, std::math::ln(x), x / 7 % 13]
+                    L2.vec in (
+                        for x in range_unpack(range(1, 1000))
+                        select <v3>[x % 10, std::math::ln(x), x / 7 % 13]
+                    )
                 )
             ''',
             [

--- a/tests/test_edgeql_coalesce.py
+++ b/tests/test_edgeql_coalesce.py
@@ -1995,7 +1995,3 @@ class TestEdgeQLCoalesce(tb.QueryTestCase):
                   ?? [is MultiRange].element_type.id,
             };
         ''')
-
-
-class TestEdgeQLCoalesceNoFactor(TestEdgeQLCoalesce):
-    NO_FACTOR = True

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -18836,18 +18836,15 @@ DDLStatement);
             select { func := get_whatever(), alias := X, query := all(T = T) }
         """
 
+        # It is *always* simple_scoping now
         await self.assert_query_result(
             Q,
-            [dict(func=True, alias=True, query=True)],
+            [dict(func=False, alias=False, query=False)],
         )
 
-        async with self.assertRaisesRegexTx(
-            edgedb.InvalidReferenceError,
-            "attempting to factor",
-        ):
-            await self.con.execute("""
-                create future warn_old_scoping
-            """)
+        await self.con.execute("""
+            create future warn_old_scoping
+        """)
 
         # Config flag is set but future is not: main query does not factor
         # but schema things do
@@ -18856,7 +18853,7 @@ DDLStatement);
         """)
         await self.assert_query_result(
             Q,
-            [dict(func=True, alias=True, query=False)],
+            [dict(func=False, alias=False, query=False)],
         )
 
         # Future and config flag: nothing factors
@@ -18875,7 +18872,7 @@ DDLStatement);
         """)
         await self.assert_query_result(
             Q,
-            [dict(func=False, alias=False, query=True)],
+            [dict(func=False, alias=False, query=False)],
         )
 
         # Config not set: falls back to future, nothing factors

--- a/tests/test_edgeql_functions_inline.py
+++ b/tests/test_edgeql_functions_inline.py
@@ -23,7 +23,10 @@ import edgedb
 from edb.testbase import server as tb
 
 
-class TestEdgeQLFunctionsInline(tb.QueryTestCase):
+class TestEdgeQLFunctionsInline(tb.DDLTestCase):
+    SETUP = '''
+        create future simple_scoping;
+    '''
 
     async def test_edgeql_functions_inline_basic_01(self):
         await self.con.execute('''
@@ -1411,7 +1414,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
             insert Bar{a := 3};
             create function foo() -> set of tuple<int64, int64> {
                 set is_inlined := true;
-                using ((Bar.a, count(Bar)));
+                using (for Bar in Bar union (Bar.a, count(Bar)));
             };
         ''')
         await self.assert_query_result(
@@ -2002,7 +2005,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
             insert Bar{a := 3};
             create function foo() -> set of tuple<int64, int64> {
                 set is_inlined := true;
-                using ((Bar.a, count(Bar)));
+                using (for Bar in Bar union (Bar.a, count(Bar)));
             };
         ''')
         await self.assert_query_result(
@@ -4185,7 +4188,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
             insert Bar{a := 3};
             create function inner() -> set of tuple<int64, int64> {
                 set is_inlined := true;
-                using ((Bar.a, count(Bar)));
+                using (for Bar in Bar select (Bar.a, count(Bar)));
             };
             create function foo() -> set of tuple<int64, int64> {
                 set is_inlined := true;
@@ -4677,6 +4680,7 @@ class TestEdgeQLFunctionsInline(tb.QueryTestCase):
                 set is_inlined := true;
                 using (
                     with y := (select Bar{a, b := inner(x)})
+                    for y in y
                     select (y.a, y.b)
                 );
             };

--- a/tests/test_edgeql_functions_inline.py
+++ b/tests/test_edgeql_functions_inline.py
@@ -24,9 +24,6 @@ from edb.testbase import server as tb
 
 
 class TestEdgeQLFunctionsInline(tb.DDLTestCase):
-    SETUP = '''
-        create future simple_scoping;
-    '''
 
     async def test_edgeql_functions_inline_basic_01(self):
         await self.con.execute('''

--- a/tests/test_edgeql_group.py
+++ b/tests/test_edgeql_group.py
@@ -27,7 +27,6 @@ from edb.tools import test
 class TestEdgeQLGroup(tb.QueryTestCase):
     '''These tests are focused on using the internal GROUP statement.'''
 
-    NO_FACTOR = False
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
@@ -4044,17 +4043,7 @@ class TestEdgeQLGroup(tb.QueryTestCase):
             [{"minCost": 1}, {"minCost": 1}, {"minCost": 1}, {"minCost": 2}],
         )
 
-    @test.xerror("""
-        Issue #6481
-
-        assert stype.is_view(ctx.env.schema) when in _inline_type_computable
-    """)
     async def test_edgeql_group_issue_6481(self):
-        # NO_FACTOR makes it pass but we don't want it to unexpected
-        # pass since it still fails on other modes
-        if self.NO_FACTOR:
-            raise RuntimeError('sigh')
-
         await self.assert_query_result(
             r'''
             select (
@@ -4168,12 +4157,3 @@ class TestEdgeQLGroup(tb.QueryTestCase):
                 }
             ])
         )
-
-
-class TestEdgeQLGroupNoFactor(TestEdgeQLGroup):
-    NO_FACTOR = True
-
-
-class TestEdgeQLGroupWarnFactor(TestEdgeQLGroup):
-    NO_FACTOR = False
-    WARN_FACTOR = True

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -17,7 +17,6 @@
 #
 
 
-import contextlib
 import os.path
 import uuid
 
@@ -29,8 +28,6 @@ from edb.tools import test
 
 class TestInsert(tb.DDLTestCase):
     '''The scope of the tests is testing various modes of Object creation.'''
-    NO_FACTOR = False
-    WARN_FACTOR = True
     INTERNAL_TESTMODE = False
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
@@ -38,8 +35,7 @@ class TestInsert(tb.DDLTestCase):
 
     def assertRaisesRegex(self, exc, r, **kwargs):
         if (
-            (self.NO_FACTOR or self.WARN_FACTOR)
-            and "cannot reference correlated set" in r
+            "cannot reference correlated set" in r
         ):
             r = ""
         return super().assertRaisesRegex(exc, r, **kwargs)
@@ -7514,21 +7510,13 @@ class TestInsert(tb.DDLTestCase):
         )
 
     async def test_edgeql_insert_conditional_02(self):
-        ctxmgr = (
-            contextlib.nullcontext() if self.NO_FACTOR
-            else self.assertRaisesRegexTx(
-                edgedb.errors.QueryError,
-                "cannot reference correlated set",
-            )
-        )
-        async with ctxmgr:
-            await self.con.execute('''
-                select ((if ExceptTest.deleted then (
-                    insert InsertTest { l2 := 2 }
-                ) else (
-                    insert DerivedTest { l2 := 200 }
-                )), (select ExceptTest.deleted limit 1));
-            ''')
+        await self.con.execute('''
+            select ((if ExceptTest.deleted then (
+                insert InsertTest { l2 := 2 }
+            ) else (
+                insert DerivedTest { l2 := 200 }
+            )), (select ExceptTest.deleted limit 1));
+        ''')
 
     async def test_edgeql_insert_conditional_03(self):
         await self.assert_query_result(
@@ -7993,7 +7981,6 @@ class TestInsert(tb.DDLTestCase):
 
 class TestRepeatableReadInsert(tb.QueryTestCase):
     '''The scope of the tests is testing various modes of Object creation.'''
-    NO_FACTOR = True
     INTERNAL_TESTMODE = False
 
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',

--- a/tests/test_edgeql_select.py
+++ b/tests/test_edgeql_select.py
@@ -27,7 +27,6 @@ from edb.tools import test
 
 
 class TestEdgeQLSelect(tb.QueryTestCase):
-    NO_FACTOR = False
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
@@ -8751,12 +8750,3 @@ class TestEdgeQLSelect(tb.QueryTestCase):
             ''',
             __typenames__=True
         )
-
-
-class TestEdgeQLSelectNoFactor(TestEdgeQLSelect):
-    NO_FACTOR = True
-
-
-class TestEdgeQLSelectWarnFactor(TestEdgeQLSelect):
-    NO_FACTOR = False
-    WARN_FACTOR = True

--- a/tests/test_edgeql_sql_codegen.py
+++ b/tests/test_edgeql_sql_codegen.py
@@ -38,8 +38,6 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
     Tests can be written by inspecting the AST or the generated text.
     """
 
-    SIMPLE_SCOPING = True
-
     SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas',
                           'issues.esdl')
 
@@ -65,7 +63,6 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
             self.schema,
             options=compiler.CompilerOptions(
                 modaliases={None: 'default'},
-                simple_scoping=self.SIMPLE_SCOPING,
             ),
         )
         sql_res = pg_compiler.compile_ir_to_sql_tree(
@@ -580,7 +577,3 @@ class TestEdgeQLSQLCodegen(tb.BaseEdgeQLCompilerTest):
         assert isinstance(tree, pgast.SelectStmt)
         # One CTE for the global, one for the policy
         self.assertEqual(len(tree.ctes), 2)
-
-
-class TestEdgeQLSQLCodegenOldScoping(TestEdgeQLSQLCodegen):
-    SIMPLE_SCOPING = False

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1374,9 +1374,9 @@ class TestSchema(tb.BaseSchemaLoadTest):
             type Object2 {
                 required property num -> int64 {
                     default := (
-                        SELECT Object1.num + 1
-                        ORDER BY Object1.num DESC
-                        LIMIT 1
+                       (SELECT Object1
+                         ORDER BY .num DESC
+                        LIMIT 1).num + 1
                     )
                 }
             };


### PR DESCRIPTION
This makes simple_scoping the only supported behavior.

This rips out some of the machinery for it, but most of it is still
there for now, because the scope tree is still pretty fundamental and
a bunch of internal codegen stuff actually still relies on enable path
factoring for edgeql AST that it generates.

First step is ripping that out.