### PR TITLE
Enable FOR OPTIONAL

### DIFF
--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -206,16 +206,6 @@ def compile_ForQuery(
 
         view_scope_info = sctx.env.path_scope_map[iterator_view]
 
-        if (
-            qlstmt.optional
-            and not qlstmt.from_desugaring
-            and not ctx.env.options.testmode
-        ):
-            raise errors.UnsupportedFeatureError(
-                "'FOR OPTIONAL' is an internal testing feature",
-                span=qlstmt.span,
-            )
-
         pathctx.register_set_in_scope(
             iterator_stmt,
             path_scope=sctx.path_scope,

--- a/tests/test_edgeql_for.py
+++ b/tests/test_edgeql_for.py
@@ -1141,8 +1141,8 @@ class TestEdgeQLFor(tb.QueryTestCase):
         )
 
     async def test_edgeql_for_optional_01(self):
-        # Lol FOR OPTIONAL doesn't work for object-type iterators
-        # but it does work for 1-ary tuples
+        # Lol *originally* FOR OPTIONAL didn't work for object-type
+        # iterators but it did work for 1-ary tuples...
         await self.assert_query_result(
             r'''
                 for optional x in


### PR DESCRIPTION
I think it's likely to be in decent shape, actually.
A big part of the original disabling was that the first
implementation didn't work on object types, but that
has been fixed.