### PR TITLE
Don't lose overlays when iterating over DML with FOR

### DIFF
--- a/edb/pgsql/compiler/clauses.py
+++ b/edb/pgsql/compiler/clauses.py
@@ -190,6 +190,10 @@ def compile_iterator_expr(
 
     assert isinstance(iterator_expr.expr, (irast.GroupStmt, irast.SelectStmt))
 
+    ctx.env.binding_dml[iterator_expr.path_id] = irutils.get_dml_sources(
+        iterator_expr, ctx.env.binding_dml
+    )
+
     with ctx.new() as subctx:
         subctx.expr_exposed = False
         subctx.rel = query

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -26,6 +26,7 @@ from typing import (
     Mapping,
     ChainMap,
     Generator,
+    Sequence,
     TYPE_CHECKING,
 )
 
@@ -550,6 +551,12 @@ class Environment:
     #: query level.
     check_ctes: list[pgast.CommonTableExpr]
 
+    #: Map of binding path ids to DML used in the binding. I hope and
+    #: suspect that this will grow towards becoming a more general and
+    #: traditional symbol table as I rip out path factoring? Who knows
+    #: though.
+    binding_dml: dict[irast.PathId, Sequence[irast.MutatingLikeStmt]]
+
     def __init__(
         self,
         *,
@@ -590,6 +597,7 @@ class Environment:
         self.backend_runtime_params = backend_runtime_params
         self.versioned_stdlib = versioned_stdlib
         self.sql_dml_mode = sql_dml_mode
+        self.binding_dml = {}
 
 
 # XXX: this context hack is necessary until pathctx is converted

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -561,7 +561,7 @@ def new_primitive_rvar(
         is_global = False
 
     typeref = ir_set.typeref
-    dml_source = irutils.get_dml_sources(ir_set)
+    dml_source = irutils.get_dml_sources(ir_set, ctx.env.binding_dml)
     set_rvar = range_for_typeref(
         typeref, path_id, lateral=lateral, dml_source=dml_source,
         include_descendants=not skip_subtypes,
@@ -694,7 +694,7 @@ def _new_mapped_pointer_rvar(
     ir_ptr = ir_set.expr
 
     ptrref = ir_ptr.ptrref
-    dml_source = irutils.get_dml_sources(ir_ptr.source)
+    dml_source = irutils.get_dml_sources(ir_ptr.source, ctx.env.binding_dml)
     ptr_rvar = range_for_pointer(ir_set, dml_source=dml_source, ctx=ctx)
 
     src_col = 'source'

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -999,7 +999,7 @@ def process_set_as_path_type_intersection(
         poly_rvar = relctx.range_for_typeref(
             rptr.ptrref.out_target,
             path_id=ir_set.path_id,
-            dml_source=irutils.get_dml_sources(ir_set),
+            dml_source=irutils.get_dml_sources(ir_set, ctx.env.binding_dml),
             lateral=True,
             ctx=ctx,
         )

--- a/tests/test_edgeql_insert.py
+++ b/tests/test_edgeql_insert.py
@@ -1824,6 +1824,28 @@ class TestInsert(tb.DDLTestCase):
                                   INSERT Note {name := y ++ x.name}))))));
             """)
 
+    async def test_edgeql_insert_for_iterator_01(self):
+        await self.assert_query_result(
+            r'''
+                with noobs := {
+                  (insert InsertTest { l2 := 1 }),
+                },
+                for n in noobs select assert_exists((select n filter true));
+            ''',
+            [{}],
+        )
+
+        await self.assert_query_result(
+            r'''
+                with noobs := {
+                  ((insert InsertTest { l2 := 1 }), "bar"),
+                  ((insert InsertTest { l2 := 2 }), "eggs"),
+                },
+                for n in noobs select n.0;
+            ''',
+            [{}, {}],
+        )
+
     @tb.ignore_warnings('more than one.* in a FILTER clause')
     async def test_edgeql_insert_default_01(self):
         await self.con.execute(r'''


### PR DESCRIPTION
Since we use a VisibleBindingRef to refer to a for binding,
get_dml_sources was not finding dml sources of for variables.

Fix this by tracking the DML sources of FOR bindings in a symbol
table.

The other alternative choice here would be to make VisibleBindingRef
maintain a reference to the Set of of the iterator expression, so that
analyses can be done without needing symbol tables. (We could still
hide it from debug output.)

Fixes #8993.