### PR TITLE
Fix casting to multi-ranges accidentally aggregating

### DIFF
--- a/edb/edgeql/compiler/casts.py
+++ b/edb/edgeql/compiler/casts.py
@@ -970,6 +970,7 @@ def _cast_multirange(
     with ctx.new() as subctx:
         subctx.allow_factoring()
         subctx.anchors = subctx.anchors.copy()
+        pathctx.register_set_in_scope(ir_set, ctx=subctx)
         source_path = subctx.create_anchor(ir_set, 'a')
 
         # multirange(

--- a/tests/test_edgeql_casts.py
+++ b/tests/test_edgeql_casts.py
@@ -3019,6 +3019,16 @@ class TestEdgeQLCasts(tb.QueryTestCase):
                 SELECT <multirange<int64>>to_json('{"a": 1}');
             """)
 
+    async def test_edgeql_casts_multirange_set_01(self):
+        await self.assert_query_result(
+            r"""
+                select count(
+                  <multirange<int32>>{range(0, 10), range(12, 15)}
+                 );
+            """,
+            [2],
+        )
+
     async def test_edgeql_casts_assignment_01(self):
         async with self._run_and_rollback():
             await self.con.execute(r"""


### PR DESCRIPTION
Casting a set to a multirange would aggregate the ranges, because we
didn't properly bind the RHS when generating code for casts.