### PR TITLE
Allow Magic Link sign in to register new user

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_08_20_00_00
+EDGEDB_CATALOG_VERSION = 2025_09_09_00_00
 EDGEDB_MAJOR_VERSION = 8
 
 

--- a/edb/lib/ext/auth.edgeql
+++ b/edb/lib/ext/auth.edgeql
@@ -378,6 +378,10 @@ CREATE EXTENSION PACKAGE auth VERSION '1.0' {
         create required property verification_method: ext::auth::VerificationMethod {
             set default := ext::auth::VerificationMethod.Link;
         };
+
+        create required property auto_signup: std::bool {
+            set default := false;
+        };
     };
 
     create scalar type ext::auth::FlowType extending std::enum<PKCE, Implicit>;

--- a/edb/server/protocol/auth_ext/config.py
+++ b/edb/server/protocol/auth_ext/config.py
@@ -104,6 +104,7 @@ class MagicLinkProviderConfig(ProviderConfig):
     name: Literal["builtin::local_magic_link"]
     token_time_to_live: statypes.Duration
     verification_method: VerificationMethod
+    auto_signup: bool
 
 
 @dataclass

--- a/edb/server/protocol/auth_ext/magic_link.py
+++ b/edb/server/protocol/auth_ext/magic_link.py
@@ -63,6 +63,7 @@ class Client(local.Client):
                     name=cfg.name,
                     token_time_to_live=cfg.token_time_to_live,
                     verification_method=cfg.verification_method,
+                    auto_signup=cfg.auto_signup,
                 )
 
         raise errors.MissingConfiguration(


### PR DESCRIPTION
Adds a configuration property to the provider config that will have the
sign-in flow act as a sign-up flow if set to true.