### PR TITLE
Make SET REQUIRED USING (...) work on link properties

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -1108,7 +1108,10 @@ def _get_rel_path_output(
     ptr_info = None
     if ptrref and not isinstance(ptrref, irast.TypeIntersectionPointerRef):
         ptr_info = pg_types.get_ptrref_storage_info(
-            ptrref, resolve_type=False, link_bias=False)
+            ptrref,
+            resolve_type=False,
+            link_bias=bool(rel.path_id and rel.path_id.is_ptr_path()),
+        )
 
     if (rptr_dir is not None and
             rptr_dir != s_pointers.PointerDirection.Outbound):

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -2936,6 +2936,8 @@ class AlterPointerLowerCardinality[Pointer_T: Pointer](
         schema: s_schema.Schema,
         context: sd.CommandContext,
     ) -> s_schema.Schema:
+        from edb.ir import utils as irutils
+
         orig_schema = schema
         schema = super()._alter_begin(schema, context)
         scls = self.scls
@@ -2985,6 +2987,17 @@ class AlterPointerLowerCardinality[Pointer_T: Pointer](
                     raise errors.SchemaError(
                         f'result of USING clause for the alteration of '
                         f'{vn} may not include a shape',
+                        span=self.span,
+                    )
+
+                if (
+                    self.scls.is_link_property(schema)
+                    and irutils.contains_dml(self.fill_expr.ir_statement)
+                ):
+                    raise errors.UnsupportedFeatureError(
+                        f'USING clause for the alteration of optionality of '
+                        f'{vn} cannot include mutating statements, '
+                        'because it is a link property',
                         span=self.span,
                     )
 


### PR DESCRIPTION
The SET REQUIRED USING path always used the `produce_ctes=True` mode
of `_compile_conversion_expression`, which depends on using `id` as
the key. That doesn't work for us here, since there's no `id` for a
link property.

If we supported using ctid or source, target as the key (see #5050) we
could make it work, but until then, use the `produce_ctes=False` mode
for link properties.

This means DML won't work there, but whatever.