### PR TITLE
Return identity_id when registering new Magic Link

### DIFF
--- a/edb/server/protocol/auth_ext/http.py
+++ b/edb/server/protocol/auth_ext/http.py
@@ -1357,6 +1357,7 @@ class Router:
                 return_data = {
                     "code": "true",
                     "signup": "true",
+                    "identity_id": str(email_factor.identity.id),
                     "email": email,
                 }
 
@@ -1555,6 +1556,7 @@ class Router:
                         "email": email,
                     }
                     if is_signup:
+                        return_data["identity_id"] = str(identity_id)
                         return_data["signup"] = "true"
                 else:
                     _check_keyset(

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -4674,7 +4674,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 self.assertEqual(data.get("email"), email)
                 self.assertEqual(
                     data.get("identity_id"),
-                    expected_identity_id
+                    str(expected_identity_id)
                 )
         finally:
             await self.con.query(
@@ -6463,7 +6463,7 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
                 self.assertEqual(
                     response_data.get("identity_id"),
-                    expected_identity_id
+                    str(expected_identity_id)
                 )
 
                 # Verify that a 6-digit code email was sent

--- a/tests/test_http_ext_auth.py
+++ b/tests/test_http_ext_auth.py
@@ -4659,9 +4659,23 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 )
                 self.assertEqual(status, 200, body)
                 data = json.loads(body)
+                expected_identity_id = await self.con.query_single(
+                    """
+                    with IDENTITY := (
+                      select ext::auth::MagicLinkFactor
+                      filter .email = <str>$email
+                    ).identity
+                    select IDENTITY.id;
+                    """,
+                    email=email,
+                )
                 self.assertEqual(data.get("code"), "true")
                 self.assertEqual(data.get("signup"), "true")
                 self.assertEqual(data.get("email"), email)
+                self.assertEqual(
+                    data.get("identity_id"),
+                    expected_identity_id
+                )
         finally:
             await self.con.query(
                 """
@@ -6437,6 +6451,20 @@ class TestHttpExtAuth(tb.ExtAuthTestCase):
                 self.assertEqual(response_data.get("code"), "true")
                 self.assertEqual(response_data.get("signup"), "true")
                 self.assertEqual(response_data.get("email"), email)
+                expected_identity_id = await self.con.query_single(
+                    """
+                    with IDENTITY := (
+                      select ext::auth::MagicLinkFactor
+                      filter .email = <str>$email
+                    ).identity
+                    select IDENTITY.id;
+                    """,
+                    email=email,
+                )
+                self.assertEqual(
+                    response_data.get("identity_id"),
+                    expected_identity_id
+                )
 
                 # Verify that a 6-digit code email was sent
                 file_name_hash = hashlib.sha256(


### PR DESCRIPTION
It's easy to get the identity from the actual Link-based token, but for the Code-based flows, you have to look it up in order to get to the identity in order to link your app's User type to it. This returns it in the success payload.