### PR TITLE
Fix /rag on subtypes

### DIFF
--- a/edb/schema/reflection/writer.py
+++ b/edb/schema/reflection/writer.py
@@ -914,6 +914,9 @@ def _update_lprops(
         mcls.get_reflection_method() is so.ReflectionMethod.AS_LINK
     )
 
+    # N.B: For reflect_as_link AlterObjects, we depend on all of the
+    # relevant fields having been populated in the command, which is
+    # done by _populate_link_reflection_fields.
     if reflect_as_link:
         target_link = mcls.get_reflection_link()
         assert target_link is not None

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -12957,6 +12957,41 @@ class EdgeQLAIMigrationTestCase(EdgeQLDataMigrationTestCase):
             };
         ''', explicit_modules=True)
 
+        await self.assert_query_result(
+            r"""
+                select schema::Index {
+                    annotations: {name, @value},
+                    subject_name := .<indexes[is schema::ObjectType].name
+                }
+                filter 'ext::ai::index' IN .ancestors.name
+                and .subject_name = 'default::Sub';
+            """,
+            [
+                {
+                    "annotations": tb.bag([
+                        {"name": "ext::ai::model_name",
+                         "@value": "text-embedding-3-small"},
+                        {"name": "ext::ai::model_provider",
+                         "@value": "builtin::openai"},
+                        {"name": "ext::ai::embedding_model_max_input_tokens",
+                         "@value": "8191"},
+                        {"name": "ext::ai::embedding_model_max_batch_tokens",
+                         "@value": "8191"},
+                        {
+                            "name":
+                            "ext::ai::embedding_model_max_output_dimensions",
+                            "@value": "1536"
+                        },
+                        {"name": "ext::ai::embedding_model_supports_shortening",
+                         "@value": "true"},
+                        {"name": "ext::ai::embedding_dimensions",
+                         "@value": "1536"}
+                    ]),
+                    "subject_name": "default::Sub"
+                }
+            ]
+        )
+
         await self.migrate('''
             using extension ai;
         ''', explicit_modules=True)


### PR DESCRIPTION
When an AlterAnnotationValue is performed (this is triggered by the
annotation copying for some weird reason), we were losing the @expr
linkprop in the user-visible schema (reflected using AS_LINK).
(For actual internal use, annotations are reflected using an actual
AnnotationValue class, so this didn't cause any problems with the
internal schema.)

Fix this by making sure to populate all fields on AlterObjectFragments
of AS_LINK reflected objects. This ensures that the cruddy linkprop
based reflection can get the job done.

This is one of those classic cases that shows up a ton in our compiler
where some weird code path is being exercised in some specific case for
obscure reasons, and we are faced with the options of:
 1. Make some change to avoid the code path.
 2. Do some hacky fix in the particular code path.
 3. Try to do a general fix.

I did #3 here, though I think maybe it would have been better to do #2
and add an assert somewhere that we don't add any new uses of
AS_LINK...

We'll need to run a fixup script in the backport.
I think this will do it:
```
update schema::AnnotationSubject set {
    annotations := (
        for a in .annotations__internal
        select schema::Annotation { @value := a.value }
        filter .name = a.name
    )
};
```