### PR TITLE
Fix some issues with overloading AI indexes

### DIFF
--- a/edb/pgsql/dbops/ddl.py
+++ b/edb/pgsql/dbops/ddl.py
@@ -366,6 +366,23 @@ class CreateObject(SchemaObjectOperation):
             block.add_command(mdata.code_with_block(block))
 
 
+class RenameObject(SchemaObjectOperation):
+    def __init__(self, object, *, new_name, **kwargs):
+        super().__init__(name=object.name, **kwargs)
+        self.object = object
+        self.altered_object = object.copy()
+        self.altered_object.rename(new_name)
+        self.new_name = new_name
+
+    def generate_extra(self, block: base.PLBlock) -> None:
+        super().generate_extra(block)
+        # if self.object.metadata:
+        #     breakpoint()
+        #     mdata = UpdateMetadata(
+        #         self.altered_object, self.altered_object.metadata)
+        #     block.add_command(mdata.code_with_block(block))
+
+
 class AlterObject(SchemaObjectOperation):
     def __init__(self, object, **kwargs):
         super().__init__(object.get_id(), **kwargs)

--- a/edb/schema/indexes.py
+++ b/edb/schema/indexes.py
@@ -1854,8 +1854,7 @@ def get_effective_object_index(
             )
         effective = object_indexes_defined_here[0]
         overridden = [
-            i.get_implicit_bases(schema)[0]
-            for i in object_indexes if i != effective
+            i for i in object_indexes if i != effective
         ]
 
     else:

--- a/tests/test_ext_ai.py
+++ b/tests/test_ext_ai.py
@@ -522,6 +522,25 @@ class TestExtAI(tb.BaseHttpExtensionTest):
             json.dumps(qv),
         )
 
+    async def test_ext_ai_indexing_05f(self):
+        async with self._run_and_rollback():
+            await self.con.execute('''
+                alter type Astronomy
+                drop index
+                  ext::ai::index(embedding_model := 'text-embedding-test')
+                on (.content);
+            ''')
+
+            qv = [1.0, -2.0, 3.0, -4.0, 5.0, -6.0, 7.0, -8.0, 9.0, -10.0]
+
+            await self._assert_index_use(
+                f'''
+                with vector := <array<float32>>$0
+                select ext::ai::search(OnExpression, vector) limit 5;
+                ''',
+                qv,
+            )
+
     async def test_ext_ai_indexing_06(self):
         # Index on mixed inherited types
         try:


### PR DESCRIPTION
When the "effective" index changes, we need to rename the pg index, so
ANALYZE won't get confused.

We also need to do a `refresh` when the effective index changes due to
a delete index, like we do for creates, since that will invalidate the
vectors.

Fix this by adding the new refresh call and making refresh rename the
index.

In PR #2474, I yanked out all the rename dbops, and remarked:
> If something changes in the future and we need to generate a pgsql
> rename, we can pull the old dbops code out of git.

Fixes #9048.