### PR TITLE
Add sys::current_permissions.

### DIFF
--- a/edb/buildmeta.py
+++ b/edb/buildmeta.py
@@ -57,7 +57,7 @@ from edb.common import verutils
 # The merge conflict there is a nice reminder that you probably need
 # to write a patch in edb/pgsql/patches.py, and then you should preserve
 # the old value.
-EDGEDB_CATALOG_VERSION = 2025_09_29_00_00
+EDGEDB_CATALOG_VERSION = 2025_09_29_00_01
 EDGEDB_MAJOR_VERSION = 8
 
 

--- a/edb/lib/sys.edgeql
+++ b/edb/lib/sys.edgeql
@@ -474,6 +474,10 @@ CREATE REQUIRED GLOBAL sys::current_role -> str {
     SET default := '';
 };
 
+CREATE REQUIRED GLOBAL sys::current_permissions -> array<str> {
+    SET default := <array<str>>[];
+};
+
 # Add permissions to schema and std.
 
 # These modules are populated before sys permissions so we need to

--- a/edb/server/pgcon/pgcon.pyx
+++ b/edb/server/pgcon/pgcon.pyx
@@ -84,8 +84,6 @@ DEF PREP_STMTS_CACHE = 100
 
 DEF COPY_SIGNATURE = b"PGCOPY\n\377\r\n\0"
 
-DEF TEXT_OID = 25
-
 cdef object CARD_NO_RESULT = compiler.Cardinality.NO_RESULT
 cdef object FMT_NONE = compiler.OutputFormat.NONE
 cdef dict POSTGRES_SHUTDOWN_ERR_CODES = {

--- a/tests/test_edgeql_globals.py
+++ b/tests/test_edgeql_globals.py
@@ -447,6 +447,17 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.ConfigurationError,
+            "system global 'sys::current_permissions' may not be explicitly"
+            "specified"
+        ):
+            await self.con.execute(
+                '''
+                set global sys::current_permissions := ['yay!']
+                ''',
+            )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.ConfigurationError,
             "global 'def_cur_user_excited' is computed from an expression "
             "and cannot be modified",
         ):
@@ -610,6 +621,24 @@ class TestEdgeQLGlobals(tb.QueryTestCase):
                 r"extra {'sys::current_role'}",
             ):
                 await scon.query_single('select global sys::current_role')
+        finally:
+            await con.aclose()
+
+    async def test_edgeql_globals_client_06(self):
+        con = edgedb.create_async_client(
+            **self.get_connect_args()
+        )
+        try:
+            globs = {
+                'sys::current_permissions': ['lol']
+            }
+            scon = con.with_globals(**globs)
+            with self.assertRaisesRegex(
+                edgedb.QueryArgumentError,
+                r"got {'sys::current_permissions'}, "
+                r"extra {'sys::current_permissions'}",
+            ):
+                await scon.query_single('select global sys::current_permissions')
         finally:
             await con.aclose()
 


### PR DESCRIPTION
This provides a simple way for a user to check all of their permissions.

Previously, the only way for a non-superuser to do this was to select all permission names, then check each one. This would have to be done per branch, since they may have different permissions, but would also miss any permissions which were not yet created.