### PR TITLE
Always allow access to __edgedbsys__ to all roles

### DIFF
--- a/edb/server/protocol/frontend.pyx
+++ b/edb/server/protocol/frontend.pyx
@@ -26,6 +26,7 @@ from edgedb import scram
 
 from edb import errors
 from edb.common import debug
+from edb.server import defines
 from edb.server import args as srvargs, metrics
 from edb.server.pgcon import errors as pgerror
 
@@ -648,7 +649,11 @@ cdef class FrontendConnection(AbstractFrontendConnection):
         if not role:
             raise errors.AuthenticationError('authentication failed')
         branches = role['branches']
-        if '*' not in branches and database not in branches:
+        if (
+            '*' not in branches
+            and database not in branches
+            and database != defines.EDGEDB_SYSTEM_DB
+        ):
             raise errors.AuthenticationError(
                 f"authentication failed: user does not have permission for "
                 f"database branch '{database}'"

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -95,6 +95,14 @@ class TestServerAuth(tb.ConnectedTestCase):
                 database='auth_failure',
             )
 
+        # __edgedbsys__ on a role with a whitelist -- should still work
+        syscon = await self.connect(
+            user='foo',
+            password='foo-pass',
+            database='__edgedbsys__',
+        )
+        await syscon.aclose()
+
         body, code = await self._basic_http_request(
             None, 'foo', 'foo-pass', db='auth_failure')
         self.assertEqual(code, 401, f"Wrong result: {body}")


### PR DESCRIPTION
This ensures that roles can enumerate the branches