### PR TITLE
Minor refactor of qlast

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -913,11 +913,6 @@ class GlobalObjectCommand(UnqualifiedObjectCommand):
     __abstract_node__ = True
 
 
-class ExternalObjectCommand(GlobalObjectCommand):
-
-    __abstract_node__ = True
-
-
 class BranchType(s_enum.StrEnum):
     EMPTY = 'EMPTY'
     SCHEMA = 'SCHEMA'
@@ -925,7 +920,7 @@ class BranchType(s_enum.StrEnum):
     TEMPLATE = 'TEMPLATE'
 
 
-class DatabaseCommand(ExternalObjectCommand, NonTransactionalDDLCommand):
+class DatabaseCommand(GlobalObjectCommand, NonTransactionalDDLCommand):
 
     __abstract_node__ = True
     flavor: qltypes.SchemaObjectClass = qltypes.SchemaObjectClass.BRANCH

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -2604,9 +2604,7 @@ def _compile_dispatch_ql(
     elif isinstance(ql, qlast.DDLCommand):
         query = ddl.compile_and_apply_ddl_stmt(ctx, ql, source=source)
         capability = enums.Capability.DDL
-        if isinstance(
-            ql, (qlast.GlobalObjectCommand, qlast.PermissionCommand)
-        ):
+        if isinstance(ql, (qlast.GlobalObjectCommand)):
             capability |= enums.Capability.GLOBAL_DDL
 
         return (query, capability)

--- a/tests/test_server_permissions.py
+++ b/tests/test_server_permissions.py
@@ -975,6 +975,7 @@ class TestServerPermissions(tb.EdgeQLTestCase, server_tb.CLITestCaseMixin):
             await self.con.query('''
                 DROP TYPE Widget;
                 DROP ROLE foo;
+                DROP PERMISSION data_export;
             ''')
 
     async def test_server_permissions_admin_01(self):

--- a/tests/test_server_permissions.py
+++ b/tests/test_server_permissions.py
@@ -966,6 +966,10 @@ class TestServerPermissions(tb.EdgeQLTestCase, server_tb.CLITestCaseMixin):
                     CREATE EMPTY BRANCH bar
                 """)
 
+            await conn.execute("""
+                CREATE PERMISSION data_export;
+            """)
+
         finally:
             await conn.aclose()
             await self.con.query('''


### PR DESCRIPTION
Removes `qlast.ExternalObjectCommand`, because it was only extended by
`GlobalObjectCommand`, which I believe was wrong anyway.