### PR TITLE
Refactor schema abstract base classess away

### DIFF
--- a/edb/edgeql/compiler/expr.py
+++ b/edb/edgeql/compiler/expr.py
@@ -33,7 +33,6 @@ from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 from edb.ir import utils as irutils
 
-from edb.schema import abc as s_abc
 from edb.schema import constraints as s_constr
 from edb.schema import functions as s_func
 from edb.schema import globals as s_globals
@@ -1075,7 +1074,7 @@ def _infer_slice_type(
         base_name = 'JSON array'
     elif node_type.issubclass(env.schema, bytes_t):
         base_name = 'bytes'
-    elif isinstance(node_type, s_abc.Array):
+    elif isinstance(node_type, s_types.Array):
         base_name = 'array'
     elif node_type.is_any(env.schema):
         base_name = 'anytype'

--- a/edb/edgeql/compiler/typegen.py
+++ b/edb/edgeql/compiler/typegen.py
@@ -30,7 +30,6 @@ from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 from edb.ir import utils as irutils
 
-from edb.schema import abc as s_abc
 from edb.schema import name as s_name
 from edb.schema import objtypes as s_objtypes
 from edb.schema import pointers as s_pointers
@@ -84,7 +83,7 @@ def infer_common_type(
             continue
 
         t = env.set_types[arg]
-        if isinstance(t, s_abc.Collection):
+        if isinstance(t, s_types.Collection):
             seen_coll = True
         elif isinstance(t, s_scalars.ScalarType):
             seen_scalar = True
@@ -263,7 +262,7 @@ def _ql_typename_to_type(
         coll = s_types.Collection.get_class(ql_t.maintype.name)
         ct: s_types.Type
 
-        if issubclass(coll, s_abc.Tuple):
+        if issubclass(coll, s_types.Tuple):
             t_subtypes = {}
             named = False
             for si, st in enumerate(ql_t.subtypes):

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -29,7 +29,6 @@ from edb.common import lru
 from edb.ir import ast as irast
 from edb.ir import typeutils as irtyputils
 
-from edb.schema import abc as s_abc
 from edb.schema import scalars as s_scalars
 from edb.schema import objtypes as s_objtypes
 from edb.schema import name as sn
@@ -324,7 +323,7 @@ def pg_type_from_object(
     elif isinstance(obj, s_types.Type) and obj.is_anytuple(schema):
         return ('record',)
 
-    elif isinstance(obj, s_abc.Tuple):
+    elif isinstance(obj, s_types.Tuple):
         if persistent_tuples:
             return cast(
                 tuple[str, ...],

--- a/edb/schema/abc.py
+++ b/edb/schema/abc.py
@@ -21,10 +21,6 @@ from __future__ import annotations
 import typing
 
 
-class Schema:
-    pass
-
-
 class Reducible:
     """An interface implemented by all non-builtin objects stored in schema."""
 
@@ -42,87 +38,3 @@ class Reducible:
     ) -> Reducible:
         """Restore object from data returned by *schema_reduce*."""
         raise NotImplementedError
-
-
-class Object:
-    pass
-
-
-class Branch(Object):
-    pass
-
-
-class Migration(Object):
-    pass
-
-
-class Constraint(Object):
-    pass
-
-
-class Callable(Object):
-    pass
-
-
-class Function(Callable):
-    pass
-
-
-class Operator(Callable):
-    pass
-
-
-class Cast(Callable):
-    pass
-
-
-class Parameter(Object):
-    pass
-
-
-class Type(Object):
-    pass
-
-
-class ScalarType(Type):
-    pass
-
-
-class ObjectType(Type):
-    pass
-
-
-class Collection(Type):
-    pass
-
-
-class Tuple(Collection):
-    pass
-
-
-class Array(Collection):
-    pass
-
-
-class Range(Collection):
-    pass
-
-
-class MultiRange(Collection):
-    pass
-
-
-class Pointer(Object):
-    pass
-
-
-class Property(Pointer):
-    pass
-
-
-class Link(Pointer):
-    pass
-
-
-class Expression:
-    pass

--- a/edb/schema/casts.py
+++ b/edb/schema/casts.py
@@ -26,7 +26,6 @@ from edb.common import lru
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import delta as sd
 from . import functions as s_func
@@ -208,7 +207,6 @@ class Cast(
     so.QualifiedObject,
     s_anno.AnnotationSubject,
     s_func.VolatilitySubject,
-    s_abc.Cast,
     qlkind=qltypes.SchemaObjectClass.CAST,
     data_safe=True,
 ):

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -39,7 +39,6 @@ from edb.edgeql import parser as qlparser
 from edb.edgeql import utils as qlutils
 from edb.edgeql import qltypes
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import delta as sd
 from . import expr as s_expr
@@ -114,7 +113,7 @@ class ObjectIndexByConstraintName(
 
 class Constraint(
     referencing.ReferencedInheritingObject,
-    s_func.CallableObject, s_abc.Constraint,
+    s_func.CallableObject,
     qlkind=ft.SchemaObjectClass.CONSTRAINT,
     data_safe=True,
 ):

--- a/edb/schema/database.py
+++ b/edb/schema/database.py
@@ -27,7 +27,6 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 from edb.schema import defines as s_def
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import delta as sd
 from . import objects as so
@@ -39,7 +38,6 @@ from typing import cast
 class Branch(
     so.ExternalObject,
     s_anno.AnnotationSubject,
-    s_abc.Branch,
     qlkind=qltypes.SchemaObjectClass.DATABASE,
     data_safe=False,
 ):

--- a/edb/schema/expr.py
+++ b/edb/schema/expr.py
@@ -41,7 +41,6 @@ from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import parser as qlparser
 from edb.edgeql import qltypes
 
-from . import abc as s_abc
 from . import objects as so
 from . import name as sn
 from . import delta as sd
@@ -54,7 +53,7 @@ if TYPE_CHECKING:
     from edb.ir import ast as irast_
 
 
-class Expression(struct.MixedRTStruct, so.ObjectContainer, s_abc.Expression):
+class Expression(struct.MixedRTStruct, so.ObjectContainer):
 
     text = struct.Field(str, frozen=True)
     # mypy wants an argument to the ObjectSet generic, but

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -147,7 +147,7 @@ def param_is_inherited(
     return qualname != param_name.name
 
 
-class ParameterLike(s_abc.Parameter):
+class ParameterLike:
 
     def get_parameter_name(self, schema: s_schema.Schema) -> str:
         raise NotImplementedError
@@ -361,6 +361,7 @@ def make_func_param(
 class Parameter(
     so.ObjectFragment,
     so.Object,  # Help reflection figure out the right db MRO
+    s_abc.Parameter,
     ParameterLike,
     qlkind=ft.SchemaObjectClass.PARAMETER,
     data_safe=True,

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -48,7 +48,6 @@ from edb.edgeql import parser as qlparser
 from edb.edgeql import qltypes
 from edb.common import uuidgen
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import delta as sd
 from . import expr as s_expr
@@ -361,7 +360,6 @@ def make_func_param(
 class Parameter(
     so.ObjectFragment,
     so.Object,  # Help reflection figure out the right db MRO
-    s_abc.Parameter,
     ParameterLike,
     qlkind=ft.SchemaObjectClass.PARAMETER,
     data_safe=True,
@@ -1247,7 +1245,6 @@ class DeleteCallableObject(
 class Function(
     CallableObject,
     VolatilitySubject,
-    s_abc.Function,
     qlkind=ft.SchemaObjectClass.FUNCTION,
     data_safe=True,
 ):

--- a/edb/schema/links.py
+++ b/edb/schema/links.py
@@ -26,7 +26,6 @@ from edb.edgeql import qltypes
 
 from edb import errors
 
-from . import abc as s_abc
 from . import constraints
 from . import delta as sd
 from . import inheriting
@@ -107,7 +106,6 @@ def merge_actions(
 class Link(
     s_sources.Source,
     pointers.Pointer,
-    s_abc.Link,
     qlkind=qltypes.SchemaObjectClass.LINK,
     data_safe=False,
 ):

--- a/edb/schema/migrations.py
+++ b/edb/schema/migrations.py
@@ -31,7 +31,6 @@ from edb.edgeql import qltypes
 from edb.edgeql import parser as qlparser
 import edb._edgeql_parser as ql_parser
 
-from . import abc as s_abc
 from . import delta as sd
 from . import name as sn
 from . import objects as so
@@ -43,7 +42,6 @@ if TYPE_CHECKING:
 
 class Migration(
     so.Object,
-    s_abc.Migration,
     qlkind=qltypes.SchemaObjectClass.MIGRATION,
     data_safe=False,
 ):

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1043,7 +1043,7 @@ class FieldValueNotFoundError(Exception):
     pass
 
 
-class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
+class Object(ObjectContainer, metaclass=ObjectMeta):
     """Base schema item class."""
 
     __slots__ = ('id',)

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -28,7 +28,6 @@ from edb import errors
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import constraints
 from . import delta as sd
@@ -86,7 +85,6 @@ class ObjectType(
     s_types.Type,  # Help reflection figure out the right db MRO
     s_anno.AnnotationSubject,  # Help reflection figure out the right db MRO
     ObjectTypeRefMixin,
-    s_abc.ObjectType,
     qlkind=qltypes.SchemaObjectClass.TYPE,
     data_safe=False,
 ):

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -26,7 +26,6 @@ from edb.common import checked
 from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes as ft
 
-from . import abc as s_abc
 from . import delta as sd
 from . import functions as s_func
 from . import name as sn
@@ -40,7 +39,6 @@ if TYPE_CHECKING:
 class Operator(
     s_func.CallableObject,
     s_func.VolatilitySubject,
-    s_abc.Operator,
     qlkind=ft.SchemaObjectClass.OPERATOR,
     data_safe=True,
 ):

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -27,6 +27,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import abc
 import collections.abc
 import enum
 import json
@@ -300,15 +301,15 @@ def _merge_types(
 
     # When two pointers are merged, check target compatibility
     # and return a target that satisfies both specified targets.
-    elif (isinstance(t1, s_abc.ScalarType) !=
-            isinstance(t2, s_abc.ScalarType)):
+    elif (isinstance(t1, s_types.ScalarType) !=
+            isinstance(t2, s_types.ScalarType)):
         # Mixing a property with a link.
         vnp = ptr.get_verbosename(schema, with_parent=True)
         vn = ptr.get_verbosename(schema)
         t1_vn = t1.get_verbosename(schema)
         t2_vn = t2.get_verbosename(schema)
-        t1_cls = 'property' if isinstance(t1, s_abc.ScalarType) else 'link'
-        t2_cls = 'property' if isinstance(t2, s_abc.ScalarType) else 'link'
+        t1_cls = 'property' if isinstance(t1, s_types.ScalarType) else 'link'
+        t2_cls = 'property' if isinstance(t2, s_types.ScalarType) else 'link'
 
         t1_source_vn = t1_source.get_verbosename(schema, with_parent=True)
         if t2_source is None:
@@ -1013,7 +1014,7 @@ class Pointer(referencing.NamedReferencedInheritingObject,
         return None
 
 
-class PseudoPointer(s_abc.Pointer):
+class PseudoPointer(abc.ABC):
     # An abstract base class for pointer-like objects, i.e.
     # pseudo-links used by the compiler to represent things like
     # tuple and type intersection.
@@ -1029,6 +1030,7 @@ class PseudoPointer(s_abc.Pointer):
     def get_ancestors(self, schema: s_schema.Schema) -> so.ObjectList[Pointer]:
         return so.ObjectList.create(schema, [])
 
+    @abc.abstractmethod
     def get_name(self, schema: s_schema.Schema) -> sn.QualName:
         raise NotImplementedError
 
@@ -1044,6 +1046,7 @@ class PseudoPointer(s_abc.Pointer):
     def get_required(self, schema: s_schema.Schema) -> bool:
         return True
 
+    @abc.abstractmethod
     def get_cardinality(
         self, schema: s_schema.Schema
     ) -> qltypes.SchemaCardinality:
@@ -1079,9 +1082,11 @@ class PseudoPointer(s_abc.Pointer):
     def get_expr(self, schema: s_schema.Schema) -> Optional[s_expr.Expression]:
         return None
 
+    @abc.abstractmethod
     def get_source(self, schema: s_schema.Schema) -> so.Object:
         raise NotImplementedError
 
+    @abc.abstractmethod
     def get_target(self, schema: s_schema.Schema) -> s_types.Type:
         raise NotImplementedError
 
@@ -1115,6 +1120,7 @@ class PseudoPointer(s_abc.Pointer):
     def is_non_concrete(self, schema: s_schema.Schema) -> bool:
         return False
 
+    @abc.abstractmethod
     def singular(
         self,
         schema: s_schema.Schema,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -47,7 +47,6 @@ from edb.edgeql import compiler as qlcompiler
 from edb.edgeql import qltypes
 from edb.edgeql import quote as qlquote
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import constraints
 from . import delta as sd
@@ -418,10 +417,11 @@ def _get_target_name_in_diff(
         return not_none(target).get_name(schema)
 
 
-class Pointer(referencing.NamedReferencedInheritingObject,
-              constraints.ConsistencySubject,
-              s_anno.AnnotationSubject,
-              s_abc.Pointer):
+class Pointer(
+    referencing.NamedReferencedInheritingObject,
+    constraints.ConsistencySubject,
+    s_anno.AnnotationSubject,
+):
 
     source = so.SchemaField(
         so.InheritingObject,

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -60,6 +60,7 @@ from . import referencing
 from . import rewrites as s_rewrites
 from . import schema as s_schema
 from . import types as s_types
+from . import scalars as s_scalars
 from . import utils
 
 
@@ -300,15 +301,15 @@ def _merge_types(
 
     # When two pointers are merged, check target compatibility
     # and return a target that satisfies both specified targets.
-    elif (isinstance(t1, s_types.ScalarType) !=
-            isinstance(t2, s_types.ScalarType)):
+    elif (isinstance(t1, s_scalars.ScalarType) !=
+            isinstance(t2, s_scalars.ScalarType)):
         # Mixing a property with a link.
         vnp = ptr.get_verbosename(schema, with_parent=True)
         vn = ptr.get_verbosename(schema)
         t1_vn = t1.get_verbosename(schema)
         t2_vn = t2.get_verbosename(schema)
-        t1_cls = 'property' if isinstance(t1, s_types.ScalarType) else 'link'
-        t2_cls = 'property' if isinstance(t2, s_types.ScalarType) else 'link'
+        t1_cls = 'property' if isinstance(t1, s_scalars.ScalarType) else 'link'
+        t2_cls = 'property' if isinstance(t2, s_scalars.ScalarType) else 'link'
 
         t1_source_vn = t1_source.get_verbosename(schema, with_parent=True)
         if t2_source is None:

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -301,8 +301,9 @@ def _merge_types(
 
     # When two pointers are merged, check target compatibility
     # and return a target that satisfies both specified targets.
-    elif (isinstance(t1, s_scalars.ScalarType) !=
-            isinstance(t2, s_scalars.ScalarType)):
+    elif isinstance(t1, s_scalars.ScalarType) != isinstance(
+        t2, s_scalars.ScalarType
+    ):
         # Mixing a property with a link.
         vnp = ptr.get_verbosename(schema, with_parent=True)
         vn = ptr.get_verbosename(schema)

--- a/edb/schema/properties.py
+++ b/edb/schema/properties.py
@@ -26,7 +26,6 @@ from edb.edgeql import qltypes
 
 from edb import errors
 
-from . import abc as s_abc
 from . import constraints
 from . import delta as sd
 from . import inheriting
@@ -46,7 +45,6 @@ if TYPE_CHECKING:
 
 class Property(
     pointers.Pointer,
-    s_abc.Property,
     qlkind=qltypes.SchemaObjectClass.PROPERTY,
     data_safe=False,
 ):

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -29,7 +29,6 @@ from edb.edgeql import qltypes
 
 from edb.common.typeutils import downcast
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import casts as s_casts
 from . import constraints
@@ -46,7 +45,6 @@ from . import utils as s_utils
 class ScalarType(
     s_types.InheritingType,
     constraints.ConsistencySubject,
-    s_abc.ScalarType,
     qlkind=qltypes.SchemaObjectClass.SCALAR_TYPE,
     data_safe=True,
 ):

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -34,7 +34,6 @@ from edb.edgeql import ast as qlast
 from edb.edgeql import qltypes
 from edb.edgeql import compiler as qlcompiler
 
-from . import abc as s_abc
 from . import annos as s_anno
 from . import casts as s_casts
 from . import delta as sd
@@ -85,7 +84,6 @@ CollectionExprAliasT = typing.TypeVar(
 class Type(
     so.SubclassableObject,
     s_anno.AnnotationSubject,
-    s_abc.Type,
 ):
     """A schema item that is a valid *type*."""
 
@@ -1050,7 +1048,7 @@ class IntersectionTypeShell(TypeExprShell[TypeT_co]):
 _collection_impls: dict[str, type[Collection]] = {}
 
 
-class Collection(Type, s_abc.Collection):
+class Collection(Type):
 
     _schema_name: typing.ClassVar[typing.Optional[str]] = None
 
@@ -1323,7 +1321,6 @@ class CollectionExprAlias(QualifiedType, Collection):
 
 class Array(
     Collection,
-    s_abc.Array,
     qlkind=qltypes.SchemaObjectClass.ARRAY_TYPE,
     schema_name='array',
 ):
@@ -1711,7 +1708,6 @@ Tuple_T_co = typing.TypeVar('Tuple_T_co', bound='Tuple', covariant=True)
 
 class Tuple(
     Collection,
-    s_abc.Tuple,
     qlkind=qltypes.SchemaObjectClass.TUPLE_TYPE,
     schema_name='tuple',
 ):
@@ -2281,7 +2277,6 @@ Range_T_co = typing.TypeVar('Range_T_co', bound='Range', covariant=True)
 
 class Range(
     Collection,
-    s_abc.Range,
     qlkind=qltypes.SchemaObjectClass.RANGE_TYPE,
     schema_name='range',
 ):
@@ -2644,7 +2639,6 @@ MultiRange_T_co = typing.TypeVar(
 
 class MultiRange(
     Collection,
-    s_abc.MultiRange,
     qlkind=qltypes.SchemaObjectClass.MULTIRANGE_TYPE,
     schema_name='multirange',
 ):


### PR DESCRIPTION
Most ABCs in `edb.schema.abc` had exactly one implementer. Such usage is not really beneficial.

There were two exceptions: `PseudoPointer` and `ParameterLike`. Their base classes were never used, so they can be defined as extending `abc.ABC` directly.

Most ABSs were also not even used. The only usage was subtype checking via `isinstance`. This can be replaced by checking for main type instead.