### PR TITLE
Warning on order by .id without empty last

### DIFF
--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -141,14 +141,14 @@ def compile_orderby_clause(
                     ctx=exprctx)
                 if len(matched) != 1:
                     sort_type_name = schemactx.get_material_type(
-                        sort_type, ctx=ctx
-                    ).get_displayname(env.schema)
+                        sort_type, ctx=ctx).get_displayname(env.schema)
                     if len(matched) == 0:
                         raise errors.QueryError(
                             f'type {sort_type_name!r} cannot be used in '
                             f'ORDER BY clause because ordering is not '
                             f'defined for it',
                             span=sortexpr.span)
+
                     elif len(matched) > 1:
                         raise errors.QueryError(
                             f'type {sort_type_name!r} cannot be used in '

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -42,9 +42,11 @@ from edb.ir import typeutils as irtyputils
 def _is_sort_on_id(ir_sortexpr: irast.Set, sortexpr: qlast.SortExpr) -> bool:
     """Return True if the sort expression is ordering by the builtin .id.
 
-    Uses IR-level detection only:
+    Primarily uses IR-level detection:
     - direct pointer in ir_sortexpr.expr
     - path-id rptr fallback via ir_sortexpr.path_id
+    Also includes a minimal syntactic fallback: if the qlast path's terminal
+    step is literally `id`.
     """
     # Direct IR expr pointer
     rptr = getattr(ir_sortexpr, 'expr', None)

--- a/edb/edgeql/compiler/clauses.py
+++ b/edb/edgeql/compiler/clauses.py
@@ -148,15 +148,13 @@ def compile_orderby_clause(
                             f'type {sort_type_name!r} cannot be used in '
                             f'ORDER BY clause because ordering is not '
                             f'defined for it',
-                            span=sortexpr.span,
-                        )
+                            span=sortexpr.span)
                     elif len(matched) > 1:
                         raise errors.QueryError(
                             f'type {sort_type_name!r} cannot be used in '
                             f'ORDER BY clause because ordering is '
                             f'ambiguous for it',
-                            span=sortexpr.span,
-                        )
+                            span=sortexpr.span)
 
             # If ordering by the builtin id pointer without specifying
             # EMPTY FIRST/LAST, emit a performance hint.
@@ -168,8 +166,7 @@ def compile_orderby_clause(
                             "Consider adding 'empty last' to the ORDER BY, "
                             "for example: ORDER BY .id EMPTY LAST"
                         ),
-                        span=sortexpr.span,
-                    )
+                        span=sortexpr.span)
                 )
 
             result.append(

--- a/tests/test_edgeql_orderby.py
+++ b/tests/test_edgeql_orderby.py
@@ -1,0 +1,109 @@
+#
+# This source file is part of the EdgeDB open source project.
+#
+# Copyright 2017-present MagicStack Inc. and the EdgeDB authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from __future__ import annotations
+
+import os
+from edb.testbase import server as tb
+
+
+class TestEdgeQLOrderBy(tb.QueryTestCase):
+
+    # Use the standard cards test schema so `User` exists.
+    SCHEMA = os.path.join(os.path.dirname(__file__), 'schemas', 'cards.esdl')
+    SETUP = os.path.join(
+        os.path.dirname(__file__), 'schemas', 'cards_setup.edgeql'
+    )
+
+    async def test_edgeql_orderby_id_warns_without_empty(self):
+        # Ordering by .id with no EMPTY FIRST/LAST should emit a warning
+        query = r"""
+            SELECT User ORDER BY .id LIMIT 1;
+        """
+        with self.con.capture_warnings() as warnings:
+            await self.con._fetchall_json(query)
+        # Expect at least one warning message about ORDER BY .id without EMPTY
+        self.assertTrue(
+            any(
+                'ORDER BY .id without EMPTY FIRST/LAST' in str(w)
+                for w in warnings
+            ),
+            f"Expected ORDER BY .id warning, got: {[str(w) for w in warnings]}",
+        )
+
+    async def test_edgeql_orderby_id_empty_last_no_warning(self):
+        # With EMPTY LAST specified there should be no warning
+        query = r"""
+            SELECT User ORDER BY .id EMPTY LAST LIMIT 1;
+        """
+        with self.con.capture_warnings() as warnings:
+            await self.con._fetchall_json(query)
+        self.assertFalse(
+            any(
+                'ORDER BY .id without EMPTY FIRST/LAST' in str(w)
+                for w in warnings
+            ),
+            f"Did not expect a warning for ORDER BY .id EMPTY LAST, got: {[str(w) for w in warnings]}",
+        )
+
+    async def test_edgeql_orderby_non_id_no_warning(self):
+        # Ordering by a non-id property should not warn
+        query = r"""
+            SELECT User ORDER BY .name LIMIT 1;
+        """
+        with self.con.capture_warnings() as warnings:
+            await self.con._fetchall_json(query)
+        self.assertFalse(
+            any(
+                'ORDER BY .id without EMPTY FIRST/LAST' in str(w)
+                for w in warnings
+            ),
+            f"Did not expect a warning for non-id ordering, got: {[str(w) for w in warnings]}",
+        )
+
+    async def test_edgeql_orderby_user_id_warns(self):
+        # Qualified path to id should also warn
+        query = r"""
+            SELECT User ORDER BY User.id LIMIT 1;
+        """
+        with self.con.capture_warnings() as warnings:
+            await self.con._fetchall_json(query)
+        self.assertTrue(
+            any(
+                'ORDER BY .id without EMPTY FIRST/LAST' in str(w)
+                for w in warnings
+            ),
+            f"Expected ORDER BY .id warning for qualified path, got: {[str(w) for w in warnings]}",
+        )
+
+    async def test_edgeql_orderby_with_module_id_warns(self):
+        # Using WITH module default and qualified id
+        query = r"""
+            WITH MODULE default
+            SELECT User ORDER BY User.id LIMIT 1;
+        """
+        with self.con.capture_warnings() as warnings:
+            await self.con._fetchall_json(query)
+        self.assertTrue(
+            any(
+                'ORDER BY .id without EMPTY FIRST/LAST' in str(w)
+                for w in warnings
+            ),
+            f"Expected ORDER BY .id warning with WITH MODULE, got: {[str(w) for w in warnings]}",
+        )


### PR DESCRIPTION
Motivation: This has been a very common problem for us and today I realized it's also the culprit in https://github.com/geldata/gel/issues/8035 . I assume there is a bigbrain reason the `empty last` can't be assumed and silently injected and that this is hard to fix to not require `empty last` at all.

Obviously I did not write this, this is written by you-know-who (claude)

> [IR-first detection] in _is_sort_on_id()
> - Check direct pointer via ir_sortexpr.expr if it is an irast.Pointer.
> - Fallback to ir_sortexpr.path_id.rptr().
> 
> [Minimal syntactic fallback]
> - If IR checks don’t match, conservatively check if the qlast path’s terminal step is literally id.
> - Keeps logic robust without spelunking deeply into AST/IR structures.


Considered moving the code to a better place and probably splitting it up

- Create is_set_on_id(ir_set: irast.Set) -> bool in pathctx.py
- Small qlast helper to edb/edgeql/astutils.py

but not doing anything like that yet unless we want to