### PR TITLE
Pass `-I` in all the places we invoke `sys.executable` as subprocess

### DIFF
--- a/edb/testbase/cluster.py
+++ b/edb/testbase/cluster.py
@@ -71,7 +71,7 @@ class BaseCluster:
             edgedb_args.NetWorkerMode
         ] = None,
     ):
-        self._edgedb_cmd = [sys.executable, '-m', 'edb.server.main']
+        self._edgedb_cmd = [sys.executable, '-I', '-m', 'edb.server.main']
 
         if "EDGEDB_SERVER_MULTITENANT_CONFIG_FILE" not in os.environ:
             self._edgedb_cmd.append('--instance-name=localtest')

--- a/edb/testbase/server.py
+++ b/edb/testbase/server.py
@@ -2520,7 +2520,7 @@ class _EdgeDBServer:
         status_r, status_w = socket.socketpair()
 
         cmd = [
-            sys.executable, '-m', 'edb.server.main',
+            sys.executable, '-I', '-m', 'edb.server.main',
             '--port', 'auto',
             '--testmode',
             '--emit-server-status', f'fd://{status_w.fileno()}',

--- a/edb/tools/cli.py
+++ b/edb/tools/cli.py
@@ -55,6 +55,7 @@ def ui(args: tuple[str, ...]):
     subprocess.check_call(
         [
             sys.executable,
+            "-I",
             "-m",
             "edb.cli",
             "ui",
@@ -78,6 +79,7 @@ def _ensure_linked(args: tuple[str, ...]) -> list[str]:
     ):
         subprocess.check_call([
             sys.executable,
+            "-I",
             "-m",
             "edb.cli",
             "instance",

--- a/tests/common/test_signalctl.py
+++ b/tests/common/test_signalctl.py
@@ -35,6 +35,7 @@ class ChildProcess:
     def __init__(self, test_prog, global_prog=""):
         self._args = (
             sys.executable,
+            "-I",
             "-m",
             "edb.testbase.proc",
             textwrap.dedent(global_prog)

--- a/tests/test_backend_connect.py
+++ b/tests/test_backend_connect.py
@@ -768,7 +768,7 @@ class TestConnection(ClusterTestCase):
         """)
         try:
             subprocess.check_output(
-                [sys.executable, "-c", script],
+                [sys.executable, "-I", "-c", script],
                 stderr=subprocess.STDOUT,
                 text=True,
             )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -603,6 +603,7 @@ class TestDocSnippets(unittest.TestCase):
             proc = subprocess.run(
                 [
                     sys.executable,
+                    '-I',
                     '-m', 'sphinx',
                     '-n',
                     '-b', 'xml',

--- a/tests/test_server_compiler.py
+++ b/tests/test_server_compiler.py
@@ -248,6 +248,7 @@ class TestAmsg(tbs.TestCase):
             try:
                 proc = await asyncio.create_subprocess_exec(
                     sys.executable,
+                    "-I",
                     "-m", pool.WORKER_PKG + pool.BaseLocalPool._worker_mod,
                     "--sockname", sock_name,
                     "--numproc", str(num_proc),

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -155,7 +155,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         # * "--bootstrap-command"
 
         cmd = [
-            sys.executable, '-m', 'edb.server.main',
+            sys.executable, '-I', '-m', 'edb.server.main',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
@@ -226,7 +226,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         os.close(status_fd)
 
         cmd = [
-            sys.executable, '-m', 'edb.server.main',
+            sys.executable, '-I', '-m', 'edb.server.main',
             '--port', 'auto',
             '--testmode',
             '--temp-dir',
@@ -290,7 +290,7 @@ class TestServerOps(tb.TestCaseWithHttpClient, tb.CLITestCaseMixin):
         os.close(status_fd)
 
         cmd = [
-            sys.executable, '-m', 'edb.server.main',
+            sys.executable, '-I', '-m', 'edb.server.main',
             '--port', 'auto',
             '--testmode',
             '--log-level=debug',

--- a/tests/test_sourcecode.py
+++ b/tests/test_sourcecode.py
@@ -90,6 +90,7 @@ class TestCodeQuality(unittest.TestCase):
                 subprocess.run(
                     [
                         sys.executable,
+                        '-I',
                         '-m',
                         'mypy',
                         '--config-file',


### PR DESCRIPTION
I wasted a bunch of time today because I had installed some stuff in
`.local` and it was getting picked up in inittestdb's subprocess
invocation (via cluster.py), and the click version skew was breaking
stuff.

I shouldn't have done that, I guess, but we ought to pass `-I`
(isolated).