### PR TITLE
Fix creating branch when a schema has nested arrays

### DIFF
--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -2182,6 +2182,7 @@ def compile_sys_queries(
         FILTER
             NOT (.abstract ?? False)
             AND NOT (.transient ?? False)
+            AND NOT .element_type IS schema::Array
         SET {
             backend_id := sys::_get_pg_type_for_edgedb_type(
                 .id,

--- a/tests/schemas/dump_v7_default.esdl
+++ b/tests/schemas/dump_v7_default.esdl
@@ -33,3 +33,5 @@ function g() -> bool {
   using (global foo);
   required_permissions := bar;
 }
+
+alias Nested := [[1]];


### PR DESCRIPTION
We can't compute backend_ids for nested arrays, but we also don't need
to, since they don't actually get passed in as arguments.

Fixes #8910.